### PR TITLE
Fix adapter casting in CNFOutlinePage

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -62,6 +62,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.ITextOperationTarget;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.RewriteSessionEditProcessor;
 import org.eclipse.jface.text.TextSelection;
@@ -924,6 +925,17 @@ public class LSPEclipseUtils {
 				}
 			}
 		}
+		return null;
+	}
+
+	public static ITextViewer getTextViewer(@Nullable final IEditorPart editorPart) {
+		final ITextViewer textViewer = Adapters.adapt(editorPart, ITextViewer.class);
+		if (textViewer != null)
+			return textViewer;
+
+		final Object textOperationTarget = Adapters.adapt(editorPart, ITextOperationTarget.class);
+		if (textOperationTarget instanceof ITextViewer)
+			return (ITextViewer) textOperationTarget;
 		return null;
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -39,7 +39,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
@@ -85,7 +84,7 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 				LSPEclipseUtils.findOpenEditorsFor(LSPEclipseUtils.toUri(uri)).stream()
 					.map(reference -> reference.getEditor(true))
 					.filter(Objects::nonNull)
-					.map(editor -> editor.getAdapter(ITextViewer.class))
+					.map(LSPEclipseUtils::getTextViewer)
 					.filter(Objects::nonNull)
 					.filter(ISourceViewer.class::isInstance)
 					.map(ISourceViewer.class::cast)

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
@@ -24,7 +24,6 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.ITextOperationTarget;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.ITextViewerExtension5;
@@ -73,11 +72,7 @@ public class CNFOutlinePage implements IContentOutlinePage, ILabelProviderListen
 		preferences = InstanceScope.INSTANCE.getNode(LanguageServerPlugin.PLUGIN_ID);
 		preferences.addPreferenceChangeListener(this);
 		this.textEditor = textEditor;
-		if (textEditor != null) {
-			this.textEditorViewer = ((ITextViewer) textEditor.getAdapter(ITextOperationTarget.class));
-		} else {
-			this.textEditorViewer = null;
-		}
+		this.textEditorViewer = LSPEclipseUtils.getTextViewer(textEditor);
 		this.document = LSPEclipseUtils.getDocument(textEditor);
 		this.languageServer = languageServer;
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -33,7 +33,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
-import org.eclipse.jface.text.ITextOperationTarget;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.reconciler.AbstractReconciler;
@@ -246,8 +245,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 		if (refreshOnResourceChanged) {
 			return new ResourceChangeOutlineUpdater(outlineViewerInput.documentFile);
 		}
-		ITextViewer textViewer = outlineViewerInput.textEditor == null ? null
-				: ((ITextViewer) outlineViewerInput.textEditor.getAdapter(ITextOperationTarget.class));
+		final ITextViewer textViewer = LSPEclipseUtils.getTextViewer(outlineViewerInput.textEditor);
 		return textViewer == null ? new DocumentChangedOutlineUpdater(outlineViewerInput.document)
 				: new ReconcilerOutlineUpdater(textViewer);
 	}


### PR DESCRIPTION
Use `getAdapter(ITextViewer.class)` instead of `getAdapter(ITextOperationTarget.class)` to retrieve an `ITextViewer` instance.