### PR TITLE
Add support for <commonSorter> in outline

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
@@ -8,9 +8,8 @@
  */
 package org.eclipse.lsp4e.test.outline;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.eclipse.lsp4e.test.TestUtils.waitForCondition;
+import static org.eclipse.lsp4e.test.TestUtils.*;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,6 +23,7 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextSelection;
+import org.eclipse.jface.text.tests.util.DisplayHelper;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.outline.CNFOutlinePage;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
@@ -123,6 +123,7 @@ public class OutlineContentTest {
 			outlinePage.createControl(shell);
 			shell.open();
 			Tree tree = (Tree) outlinePage.getControl();
+			DisplayHelper.sleep(tree.getDisplay(), 500);
 
 			editor.getSelectionProvider().setSelection(new TextSelection(4, 0));
 			assertTrue(waitForCondition(2_000, tree.getDisplay(), //
@@ -161,6 +162,7 @@ public class OutlineContentTest {
 			outlinePage.createControl(shell);
 			shell.open();
 			Tree tree = (Tree) outlinePage.getControl();
+			DisplayHelper.sleep(tree.getDisplay(), 500);
 
 			editor.getSelectionProvider().setSelection(new TextSelection(4, 0));
 			assertTrue(waitForCondition(2_000, tree.getDisplay(), //

--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -342,6 +342,9 @@
                   value="org.eclipse.lsp4e.LanguageServiceAccessor$LSPDocumentInfo">
             </instanceof>
          </enablement>
+         <commonSorter 
+               id="org.eclipse.lsp4e.outline.OutlineSorter" 
+               class="org.eclipse.lsp4e.outline.OutlineSorter" />
       </navigatorContent>
    </extension>
    <extension

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineSorter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineSorter.java
@@ -11,8 +11,11 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.outline;
 
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
+import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.SymbolInformation;
@@ -20,36 +23,47 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class OutlineSorter extends ViewerComparator {
 
-	public static final OutlineSorter INSTANCE = new OutlineSorter();
+	protected final IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(LanguageServerPlugin.PLUGIN_ID);
 
 	@Override
-	public int compare(final Viewer viewer, Object o1, Object o2) {
-
-		if (o1 instanceof Either && o2 instanceof Either) {
-			o1 = ((Either<?, ?>) o1).get();
-			o2 = ((Either<?, ?>) o2).get();
-		}
-
-		String name1 = null;
-		String name2 = null;
-
-		if (o1 instanceof DocumentSymbolWithFile) {
-			name1 = ((DocumentSymbolWithFile) o1).symbol.getName();
-		} else if (o1 instanceof DocumentSymbol) {
-			name1 = ((DocumentSymbol) o1).getName();
-		} else if (o1 instanceof SymbolInformation) {
-			name1 = ((SymbolInformation) o1).getName();
-		}
-		if (o2 instanceof DocumentSymbolWithFile) {
-			name2 = ((DocumentSymbolWithFile) o2).symbol.getName();
-		} else if (o2 instanceof DocumentSymbol) {
-			name2 = ((DocumentSymbol) o2).getName();
-		} else if (o2 instanceof SymbolInformation) {
-			name2 = ((SymbolInformation) o2).getName();
-		}
-
-		if (name1 == null || name2 == null)
+	public int compare(final Viewer viewer, final Object o1, final Object o2) {
+		if (!isSortingEnabled())
 			return 0;
+
+		final String name1 = getName(o1);
+		final String name2 = getName(o2);
+
+		if (name1 == null)
+			return name2 == null ? 0 : -1;
+
+		if (name2 == null)
+			return 1;
+
 		return name1.compareTo(name2);
+	}
+
+	private String getName(Object element) {
+		if (element instanceof Either) {
+			element = ((Either<?, ?>) element).get();
+		}
+		if (element instanceof DocumentSymbolWithFile) {
+			return ((DocumentSymbolWithFile) element).symbol.getName();
+		}
+		if (element instanceof DocumentSymbol) {
+			return ((DocumentSymbol) element).getName();
+		}
+		if (element instanceof SymbolInformation) {
+			return ((SymbolInformation) element).getName();
+		}
+		return null;
+	}
+
+	@Override
+	public boolean isSorterProperty(final Object element, final String property) {
+		return "name".equals(property); //$NON-NLS-1$
+	}
+
+	public boolean isSortingEnabled() {
+		return prefs.getBoolean(CNFOutlinePage.SORT_OUTLINE_PREFERENCE, false);
 	}
 }


### PR DESCRIPTION
- The outline and the quick outline now respect the `<commonSorter>` of the navigatorContent extension configuration.
- Additionally the quick outline doesn't use hard coded content/label providers anymore but the ones specified in the navigatorContent extension configuration.
- You will now actually see the `Computing...` message in the outline when it is initially loaded and not a blank view for 1 to 2 seconds.