### PR TITLE
minor code cleanup

### DIFF
--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPStackFrame.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPStackFrame.java
@@ -140,7 +140,7 @@ public class DSPStackFrame extends DSPDebugElement implements IStackFrame {
 			Scope[] scopes = complete(getDebugTarget().getDebugProtocolServer().scopes(arguments)).getScopes();
 			List<DSPVariable> vars = new ArrayList<>();
 			for (Scope scope : scopes) {
-				DSPVariable variable = new DSPVariable(getDebugTarget(), Integer.valueOf(-1), scope.getName(), "",
+				DSPVariable variable = new DSPVariable(getDebugTarget(), -1, scope.getName(), "",
 						scope.getVariablesReference());
 				vars.add(variable);
 			}
@@ -166,7 +166,7 @@ public class DSPStackFrame extends DSPDebugElement implements IStackFrame {
 
 	@Override
 	public int getLineNumber() throws DebugException {
-		return (int) stackFrame.getLine();
+		return stackFrame.getLine();
 	}
 
 	@Override
@@ -198,7 +198,7 @@ public class DSPStackFrame extends DSPDebugElement implements IStackFrame {
 	public BigInteger getFrameInstructionAddress() {
 		String addr = stackFrame.getInstructionPointerReference();
 		if (addr == null || addr.length() == 0) {
-			return new BigInteger("0");
+			return BigInteger.ZERO;
 		}
 		if (addr.startsWith("0x")) {
 			addr = addr.substring(2);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
@@ -296,7 +296,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 						try {
 							for (byte b : text
 									.getBytes(finalBuilder.launch.getAttribute(DebugPlugin.ATTR_CONSOLE_ENCODING))) {
-								bytes.add(Byte.valueOf(b));
+								bytes.add(b);
 							}
 						} catch (IOException e) {
 							DSPPlugin.logError(e);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPTabGroup.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPTabGroup.java
@@ -11,13 +11,12 @@ package org.eclipse.lsp4e.debug.launcher;
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.CommonTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
-import org.eclipse.debug.ui.ILaunchConfigurationTab;
 
 public class DSPTabGroup extends AbstractLaunchConfigurationTabGroup {
 
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-		setTabs(new ILaunchConfigurationTab[] { new DSPMainTab(), new CommonTab() });
+		setTabs(new DSPMainTab(), new CommonTab());
 	}
 
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -32,7 +32,7 @@ import org.eclipse.jface.text.IDocument;
  *
  */
 public class ConnectDocumentToLanguageServerSetupParticipant implements IDocumentSetupParticipant, IDocumentSetupParticipantExtension {
-	private final Map<IPath, Job> locationMap = new HashMap<IPath, Job>();
+	private final Map<IPath, Job> locationMap = new HashMap<>();
 
 	public ConnectDocumentToLanguageServerSetupParticipant() {
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -96,7 +96,7 @@ public class LanguageClientImpl implements LanguageClient {
 			} catch (InterruptedException e) {
 				LanguageServerPlugin.logError(e);
 				Thread.currentThread().interrupt();
-				return new ApplyWorkspaceEditResponse(Boolean.FALSE);
+				return new ApplyWorkspaceEditResponse(false);
 			}
 		});
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java
@@ -164,7 +164,7 @@ public class CommandExecutor {
 	}
 
 	private static Predicate<ServerCapabilities> handlesCommand(String id) {
-		return (serverCaps) -> {
+		return serverCaps -> {
 			ExecuteCommandOptions executeCommandProvider = serverCaps.getExecuteCommandProvider();
 			if (executeCommandProvider != null) {
 				return executeCommandProvider.getCommands().contains(id);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
@@ -291,14 +291,14 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 		}
 		Set<Character> triggers = new HashSet<>();
 		for (char c : initialArray) {
-			triggers.add(Character.valueOf(c));
+			triggers.add(c);
 		}
 		additionalTriggers.stream().filter(s -> !Strings.isNullOrEmpty(s))
-				.map(triggerChar -> Character.valueOf(triggerChar.charAt(0))).forEach(triggers::add);
+				.map(triggerChar -> triggerChar.charAt(0)).forEach(triggers::add);
 		char[] res = new char[triggers.size()];
 		int i = 0;
 		for (Character c : triggers) {
-			res[i] = c.charValue();
+			res[i] = c;
 			i++;
 		}
 		return res;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
@@ -255,7 +255,7 @@ public class HighlightReconcilingStrategy
 					annotationModel.addAnnotation(mapEntry.getKey(), mapEntry.getValue());
 				}
 			}
-			fOccurrenceAnnotations = annotationMap.keySet().toArray(new Annotation[annotationMap.keySet().size()]);
+			fOccurrenceAnnotations = annotationMap.keySet().toArray(new Annotation[annotationMap.size()]);
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
@@ -238,7 +238,7 @@ public class LSPLinkedEditingReconcilingStrategy extends LSPLinkedEditingBase im
 					annotationModel.addAnnotation(mapEntry.getKey(), mapEntry.getValue());
 				}
 			}
-			fLinkedEditingAnnotations = annotationMap.keySet().toArray(new Annotation[annotationMap.keySet().size()]);
+			fLinkedEditingAnnotations = annotationMap.keySet().toArray(new Annotation[annotationMap.size()]);
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
@@ -12,7 +12,6 @@
 package org.eclipse.lsp4e.operations.symbols;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.dialogs.PopupDialog;
 import org.eclipse.jface.text.BadLocationException;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsModel.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsModel.java
@@ -143,8 +143,7 @@ public class SymbolsModel {
 	}
 
 	public Object[] getElements() {
-		List<Object> res = new ArrayList<>();
-		res.addAll(Arrays.asList(getChildren(ROOT_SYMBOL_INFORMATION)));
+		List<Object> res = new ArrayList<>(Arrays.asList(getChildren(ROOT_SYMBOL_INFORMATION)));
 		final IFile current = this.file;
 		Function<DocumentSymbol, Object> mapper = current != null ?
 				symbol -> new DocumentSymbolWithFile(symbol, current) :

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
@@ -88,7 +88,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 		}
 	}
 
-	private final class BooleanMapLabelProvider extends ColumnLabelProvider {
+	private static final class BooleanMapLabelProvider extends ColumnLabelProvider {
 		private final Map<String, Boolean> map;
 
 		private BooleanMapLabelProvider(Map<String, Boolean> map) {
@@ -98,7 +98,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 
 		@Override
 		public String getText(Object element) {
-			return map.getOrDefault(((ContentTypeToLanguageServerDefinition) element).getValue().id, false).booleanValue()
+			return map.getOrDefault(((ContentTypeToLanguageServerDefinition) element).getValue().id, false)
 							? Messages.PreferencePage_enablementCondition_true
 							: Messages.PreferencePage_enablementCondition_false;
 		}


### PR DESCRIPTION
I ran the Eclipse Code Cleanup action with a few uncritical rules:
- Initialize collection at creation
- Make inner classes static where possible
- Primitive parsing
- Use boolean literals instead of Boolean.TRUE/FALSE when used as a primitive
- Operate on Maps directly
- Remove unused imports
- Simplify lambda expression and method reference syntax
- Use lambda where possible
- Use diamond operator
- Use Autoboxing / Unboxing
- valueOf() rather than instantiation