### PR TITLE
Don't sort outline by default

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.13.8.qualifier
+Bundle-Version: 0.13.9.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -82,7 +82,7 @@
             id="org.eclipse.lsp4e.toggleSortOutline"
             name="Sort Outline">
          <state
-               class="org.eclipse.ui.handlers.RegistryToggleState:true"
+               class="org.eclipse.ui.handlers.RegistryToggleState:false"
                id="org.eclipse.ui.commands.toggleState" />
       </command>
    </extension>
@@ -342,8 +342,8 @@
                   value="org.eclipse.lsp4e.LanguageServiceAccessor$LSPDocumentInfo">
             </instanceof>
          </enablement>
-         <commonSorter 
-               id="org.eclipse.lsp4e.outline.OutlineSorter" 
+         <commonSorter
+               id="org.eclipse.lsp4e.outline.OutlineSorter"
                class="org.eclipse.lsp4e.outline.OutlineSorter" />
       </navigatorContent>
    </extension>

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -7,8 +7,8 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.13.8-SNAPSHOT</version>
-	
+	<version>0.13.9-SNAPSHOT</version>
+
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
While I did set it to false by default in code at https://github.com/eclipse/lsp4e/blob/5132a7f80eabe4474ae8369dcf8d9e3448f47d95/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineSorter.java#L67

I overlooked the declaration in the plugin.xml