### PR TITLE
fix: avoid NPE in DocumentColorProvider#isColorProvider()

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/DocumentColorProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/DocumentColorProvider.java
@@ -102,7 +102,7 @@ public class DocumentColorProvider extends AbstractCodeMiningProvider {
 	}
 
 	private static boolean isColorProvider(ServerCapabilities capabilities) {
-		return capabilities.getColorProvider() != null
+		return capabilities != null && capabilities.getColorProvider() != null
 				&& ((capabilities.getColorProvider().getLeft() != null && capabilities.getColorProvider().getLeft())
 						|| capabilities.getColorProvider().getRight() != null);
 	}


### PR DESCRIPTION
Fix NPE reported in https://github.com/briandealwis/gore/issues/1:
```
java.util.concurrent.CompletionException: java.lang.NullPointerException: Cannot invoke "org.eclipse.lsp4j.ServerCapabilities.getColorProvider()" because "capabilities" is null
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1159)
	at java.base/java.util.concurrent.CompletableFuture$Completion.exec(CompletableFuture.java:483)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
Caused by: java.lang.NullPointerException: Cannot invoke "org.eclipse.lsp4j.ServerCapabilities.getColorProvider()" because "capabilities" is null
	at org.eclipse.lsp4e.operations.color.DocumentColorProvider.isColorProvider(DocumentColorProvider.java:105)
	at org.eclipse.lsp4e.LanguageServiceAccessor.lambda$15(LanguageServiceAccessor.java:590)
	at java.base/java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:1150)
	... 6 more
```