### PR TITLE
fix: avoid generating local-path file: URIs for workspaceFolders

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -810,7 +810,8 @@ public class LSPEclipseUtils {
 	@NonNull
 	public static WorkspaceFolder toWorkspaceFolder(@NonNull IProject project) {
 		WorkspaceFolder folder = new WorkspaceFolder();
-		folder.setUri(project.getLocationURI() != null ? project.getLocationURI().toString() : ""); //$NON-NLS-1$
+		URI uri = toUri(project);
+		folder.setUri(uri != null ? uri.toString() : ""); //$NON-NLS-1$
 		folder.setName(project.getName());
 		return folder;
 	}


### PR DESCRIPTION
The Go LSP `gopls` (https://github.com/golang/go/issues/49501) and Solargraph LSP (https://github.com/PyvesB/eclipse-solargraph/issues/17#issuecomment-991607202) are being confused by LSP4e using a local-path style URI when specifying `workspaceFolders`.  This PR updates `LSPEclipseUtils.toWorkspaceFolder()` to use `LSPEclipseUtils.toUri()` to compute  the workspace folder URI that is reported.


```
{
   "jsonrpc":"2.0",
   "id":"1",
   "method":"initialize",
   "params":{
      ...
      "workspaceFolders":[
         {
            "uri":"file:///Users/bsd/xxx/",
            "name":"xxx"
         },
      ]    
   }
}
...
{
   "jsonrpc":"2.0",
   "method":"workspace/didChangeWorkspaceFolders",
   "params":{
      "event":{
         "added":[
            {
               "uri":"file:///Users/bsd/xxx/",
               "name":"xxx"
            },
          "removed":[]
      }
   }
}