### PR TITLE
Avoid potential NPE

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
-Bundle-Version: 0.13.1.qualifier
+Bundle-Version: 0.13.2.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
@@ -252,7 +252,7 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 					return q;
 				});
 		if (ILaunchManager.DEBUG_MODE.equals(launch.getLaunchMode())) {
-			future = CompletableFuture.allOf(future, initialized.thenRun(() -> {
+			future = CompletableFuture.allOf(future, initialized).thenRun(() -> {
 				monitor.worked(10);
 			}).thenCompose(v -> {
 				monitor.worked(10);
@@ -267,7 +267,7 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 					return getDebugProtocolServer().configurationDone(new ConfigurationDoneArguments());
 				}
 				return CompletableFuture.completedFuture(null);
-			}));
+			});
 		}
 		return future;
 	}


### PR DESCRIPTION
fix #51

The parenthesis were nto placed at the right place. Only the
"initialized" future which corresponds to the server which has sent the
initialized answer has been received. The "capabilities" attribute might
not have been provided a value after the "initialized".

Signed-off-by: Aurélien Pupier <apupier@redhat.com>