### PR TITLE
Improve performance by getting the document one for each resource

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -199,7 +199,7 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 	}
 
 	private IMarker getExistingMarkerFor(IDocument document, Diagnostic diagnostic, Set<IMarker> remainingMarkers) {
-		if (document != null) {
+		if (document == null) {
 			return null;
 		}
 


### PR DESCRIPTION
Improve performance by getting the document one for each resource
instead of several times: one for each new diagnostic (when calling
computeMarkerAttributes when creating the marker), once for each updated
diagnostic (when calling updateMarker for markers to update).