### PR TITLE
Lazy check for the existence of a resource

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -145,7 +145,7 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 			}
 		}
 		IWorkspaceRunnable runnable = monitor -> {
-			if (resource.exists()) {
+			try {
 				for (Diagnostic diagnostic : newDiagnostics) {
 					Map<String, Object> markerAttributes = computeMarkerAttributes(document, diagnostic, resource);
 					resource.createMarker(markerType, markerAttributes);
@@ -161,6 +161,10 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 						LanguageServerPlugin.logError(e);
 					}
 				});
+			} catch (CoreException e) {
+				if (resource.exists()) {
+					LanguageServerPlugin.logError(e);
+				}
 			}
 		};
 		ResourcesPlugin.getWorkspace().run(runnable, new NullProgressMonitor());


### PR DESCRIPTION
Lazy check for the existence of a resource, as we already checked that
the resource exist before calling updateMarkers.

Instead, if the resource has ceased to exist between the point we call
updateMarkers and the point where we create/update the markers, catch
the CoreException and ignore it.