### PR TITLE
Add a method to get an initializd LS for a given Language Server

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -396,6 +396,21 @@ public class LanguageServiceAccessor {
 	}
 
 	/**
+	 * Return existing {@link LanguageServerWrapper} for the given definition. If
+	 * not found, create a new one with the given definition.
+	 *
+	 * @param project
+	 * @param serverDefinition
+	 * @return
+	 * @throws IOException
+	 */
+	@Deprecated
+	public static LanguageServerWrapper getLSWrapperForDefinition(@NonNull IProject project,
+			@NonNull LanguageServerDefinition serverDefinition) throws IOException {
+		return 	getLSWrapperForConnection(project, serverDefinition, null);
+	}
+
+	/**
 	 * Return existing {@link LanguageServerWrapper} for the given connection. If
 	 * not found, create a new one with the given connection and register it for
 	 * this project/content-type.


### PR DESCRIPTION
This is needed to initialize server before the user open a file in the editor, as we need to start/connect to the LanguageServer before the first editor uses it.