### PR TITLE
Run updateMarker job with lock on specific resource only

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -27,8 +27,8 @@ import java.util.function.Consumer;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRunnable;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.annotation.NonNull;
@@ -167,7 +167,8 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 				}
 			}
 		};
-		ResourcesPlugin.getWorkspace().run(runnable, new NullProgressMonitor());
+		IWorkspace ws = resource.getWorkspace();
+		ws.run(runnable, ws.getRuleFactory().markerRule(resource), IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
 	}
 
 	protected void updateMarker(@NonNull Map<String, Object> targetAttributes, @NonNull IMarker marker) {


### PR DESCRIPTION
`ResourcesPlugin.getWorkspace().run(runnable, new NullProgressMonitor());` executes the job with a resource lock on the whole workspace which can result in interruption of auto build jobs of non-related projects at https://git.eclipse.org/c/platform/eclipse.platform.resources.git/tree/bundles/org.eclipse.core.resources/src/org/eclipse/core/internal/resources/Workspace.java#n2262