### PR TITLE
Linked editing doesn't exit on whitespaces and other non-word chars #94

### DIFF
--- a/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mock Language Server to test LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.tests.mock
-Bundle-Version: 0.14.2.qualifier
+Bundle-Version: 0.14.3.qualifier
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.lsp4j;bundle-version="[0.12.0,0.13.0)",

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -231,7 +231,10 @@ public class MockTextDocumentService implements TextDocumentService {
 		}
 
 		if (this.diagnostics != null && !this.diagnostics.isEmpty()) {
-			this.remoteProxies.stream().forEach(p -> p.publishDiagnostics(new PublishDiagnosticsParams(params.getTextDocument().getUri(), this.diagnostics)));
+			// 'collect(Collectors.toSet()` is added here in order to prevent a
+			// ConcurrentModificationException appearance
+			this.remoteProxies.stream().collect(Collectors.toSet()).forEach(p -> p.publishDiagnostics(
+					new PublishDiagnosticsParams(params.getTextDocument().getUri(), this.diagnostics)));
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingBase.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingBase.java
@@ -32,7 +32,6 @@ import org.eclipse.lsp4j.TextDocumentPositionParams;
 public class LSPLinkedEditingBase implements IPreferenceChangeListener {
 	public static final String LINKED_EDITING_PREFERENCE = "org.eclipse.ui.genericeditor.linkedediting"; //$NON-NLS-1$
 
-	protected LinkedEditingRanges fLinkedEditingRanges;
 	private CompletableFuture<Void> request;
 	protected boolean fEnabled;
 
@@ -49,7 +48,6 @@ public class LSPLinkedEditingBase implements IPreferenceChangeListener {
 	}
 
 	protected CompletableFuture<LinkedEditingRanges> collectLinkedEditingRanges(IDocument document, int offset) {
-		fLinkedEditingRanges = null;
 		cancel();
 
 		if (document == null) {


### PR DESCRIPTION
LinkedRditingRange's wordPattern value is used to control the linked editing. The value of the wordPattern is to be provided
by the active LS, otherwize a common Unicode Indentifier  pattern is used to validate the input.

Change-Id: I6291f7136fbdb8f4ee3f067d8b17c74400067676
Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>