### PR TITLE
Export org.eclipse.lsp4e.operations.codeactions

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -45,6 +45,7 @@ Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.lsp4e.LanguageServerPlugin
 Export-Package: org.eclipse.lsp4e;x-internal:=true,
+ org.eclipse.lsp4e.operations.codeactions;x-internal:=true,
  org.eclipse.lsp4e.command;x-internal:=true,
  org.eclipse.lsp4e.operations.completion;x-internal:=true,
  org.eclipse.lsp4e.operations.hover;x-internal:=true,


### PR DESCRIPTION
As a continuation of https://github.com/eclipse/lsp4e/pull/83, we need to export org.eclipse.lsp4e.operations.codeactions so that it is possible to register org.eclipse.lsp4e.operations.codeactions.LSPCodeActionMarkerResolution as marker resolution generator for the marker type with the extended attributes.

Otherwise, the new marker will not generate any marker resolution.