### PR TITLE
Add stopOnLastDisconnectedDocument configuration property

### DIFF
--- a/org.eclipse.lsp4e.test/fragment.xml
+++ b/org.eclipse.lsp4e.test/fragment.xml
@@ -28,6 +28,12 @@
             id="org.eclipse.lsp4e.test.server.disable"
             label="Test LS Enablement">
       </server>
+      <server
+            class="org.eclipse.lsp4e.test.MockConnectionProvider"
+            id="org.eclipse.lsp4e.test.server-with-stop-on-last-disconnected-document"
+            stopOnLastDisconnectedDocument="false"
+            label="Test LS with StopOnLastDisconnectedDocument set to false">
+      </server>
       <contentTypeMapping
             contentType="org.eclipse.lsp4e.test.content-type"
             id="org.eclipse.lsp4e.test.server">
@@ -60,6 +66,10 @@
       <contentTypeMapping
             contentType="org.eclipse.lsp4e.test.content-type-server-with-multi-root"
             id="org.eclipse.lsp4e.test.server-with-multi-root-support">
+      </contentTypeMapping>
+      <contentTypeMapping
+            contentType="org.eclipse.lsp4e.test.content-type-server-with-stop-on-last-disconnected-document"
+            id="org.eclipse.lsp4e.test.server-with-stop-on-last-disconnected-document">
       </contentTypeMapping>
       <contentTypeMapping
             contentType="org.eclipse.lsp4e.test.content-type-enabled"
@@ -125,6 +135,13 @@
             file-extensions="lsptWithMultiRoot"
             id="org.eclipse.lsp4e.test.content-type-server-with-multi-root"
             name="Test Content Type Server with Multi-Root Support"
+            priority="normal">
+      </content-type>
+      <content-type
+            base-type="org.eclipse.core.runtime.text"
+            file-extensions="lsptWithStopOnLastDisconnectedDocumentFalse"
+            id="org.eclipse.lsp4e.test.content-type-server-with-stop-on-last-disconnected-document"
+            name="Test Content Type Server with Stop On Last Disconnected Document set to false"
             priority="normal">
       </content-type>
       <content-type

--- a/org.eclipse.lsp4e.test/fragment.xml
+++ b/org.eclipse.lsp4e.test/fragment.xml
@@ -30,9 +30,9 @@
       </server>
       <server
             class="org.eclipse.lsp4e.test.MockConnectionProvider"
-            id="org.eclipse.lsp4e.test.server-with-stop-on-last-disconnected-document"
-            stopOnLastDisconnectedDocument="false"
-            label="Test LS with StopOnLastDisconnectedDocument set to false">
+            id="org.eclipse.lsp4e.test.server-with-last-document-disconnected-timeout"
+            lastDocumentDisconnectedTimeout="2"
+            label="Test LS with LastDocumentDisconnectedTimeout set to two seconds">
       </server>
       <contentTypeMapping
             contentType="org.eclipse.lsp4e.test.content-type"
@@ -68,8 +68,8 @@
             id="org.eclipse.lsp4e.test.server-with-multi-root-support">
       </contentTypeMapping>
       <contentTypeMapping
-            contentType="org.eclipse.lsp4e.test.content-type-server-with-stop-on-last-disconnected-document"
-            id="org.eclipse.lsp4e.test.server-with-stop-on-last-disconnected-document">
+            contentType="org.eclipse.lsp4e.test.content-type-server-with-last-document-disconnected-timeout"
+            id="org.eclipse.lsp4e.test.server-with-last-document-disconnected-timeout">
       </contentTypeMapping>
       <contentTypeMapping
             contentType="org.eclipse.lsp4e.test.content-type-enabled"
@@ -139,9 +139,9 @@
       </content-type>
       <content-type
             base-type="org.eclipse.core.runtime.text"
-            file-extensions="lsptWithStopOnLastDisconnectedDocumentFalse"
-            id="org.eclipse.lsp4e.test.content-type-server-with-stop-on-last-disconnected-document"
-            name="Test Content Type Server with Stop On Last Disconnected Document set to false"
+            file-extensions="lsptWithLastDocumentDisconnectedTimeout"
+            id="org.eclipse.lsp4e.test.content-type-server-with-last-document-disconnected-timeout"
+            name="Test Content Type Server with LastDocumentDisconnectedTimeout set to two seconds"
             priority="normal">
       </content-type>
       <content-type

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -306,30 +306,30 @@ public class LanguageServiceAccessorTest {
 
 	@Test
 	public void testStopOnLastDisconnectedDocumentFalse() throws Exception {
-		IFile testFile1 = TestUtils.createUniqueTestFile(project, "lsptWithStopOnLastDisconnectedDocumentFalse", "");
+		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptWithStopOnLastDisconnectedDocumentFalse", "");
 
-		Collection<LanguageServerWrapper> wrappers1 = LanguageServiceAccessor.getLSWrappers(testFile1,
-				c -> Boolean.TRUE);
-		assertEquals(1, wrappers1.size());
-		LanguageServerWrapper wrapper1 = wrappers1.iterator().next();
-		assertTrue(wrapper1.isActive());
+		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);
+		assertEquals(1, wrappers.size());
+		LanguageServerWrapper wrapper = wrappers.iterator().next();
+		assertTrue(wrapper.isActive());
 		
-		wrapper1.disconnect(testFile1.getLocationURI());
-		assertTrue(wrapper1.isActive());
+		wrapper.disconnect(testFile.getLocationURI());
+		assertTrue(wrapper.isActive());
+		wrapper.stop();
+		assertFalse(wrapper.isActive());
 	}
 
 	@Test
 	public void testStopOnLastDisconnectedDocumentDefault() throws Exception {
-		IFile testFile1 = TestUtils.createUniqueTestFile(project, "");
+		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 
-		Collection<LanguageServerWrapper> wrappers1 = LanguageServiceAccessor.getLSWrappers(testFile1,
-				c -> Boolean.TRUE);
-		assertEquals(1, wrappers1.size());
-		LanguageServerWrapper wrapper1 = wrappers1.iterator().next();
-		assertTrue(wrapper1.isActive());
+		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);
+		assertEquals(1, wrappers.size());
+		LanguageServerWrapper wrapper = wrappers.iterator().next();
+		assertTrue(wrapper.isActive());
 		
-		wrapper1.disconnect(testFile1.getLocationURI());
-		assertFalse(wrapper1.isActive());
+		wrapper.disconnect(testFile.getLocationURI());
+		assertFalse(wrapper.isActive());
 	}
 
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -320,7 +320,7 @@ public class LanguageServiceAccessorTest {
 	}
 
 	@Test
-	public void testLastDocumentDisconnectedTimeoutManualTimerStop() throws Exception {
+	public void testLastDocumentDisconnectedTimeoutTimerStop() throws Exception {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptWithLastDocumentDisconnectedTimeout", "");
 
 		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -305,14 +305,14 @@ public class LanguageServiceAccessorTest {
 	}
 
 	@Test
-	public void testStopOnLastDisconnectedDocumentFalse() throws Exception {
-		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptWithStopOnLastDisconnectedDocumentFalse", "");
+	public void testLastDocumentDisconnectedTimeoutManualStop() throws Exception {
+		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptWithLastDocumentDisconnectedTimeout", "");
 
 		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);
 		assertEquals(1, wrappers.size());
 		LanguageServerWrapper wrapper = wrappers.iterator().next();
 		assertTrue(wrapper.isActive());
-		
+
 		wrapper.disconnect(testFile.getLocationURI());
 		assertTrue(wrapper.isActive());
 		wrapper.stop();
@@ -320,14 +320,29 @@ public class LanguageServiceAccessorTest {
 	}
 
 	@Test
-	public void testStopOnLastDisconnectedDocumentDefault() throws Exception {
+	public void testLastDocumentDisconnectedTimeoutManualTimerStop() throws Exception {
+		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptWithLastDocumentDisconnectedTimeout", "");
+
+		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);
+		assertEquals(1, wrappers.size());
+		LanguageServerWrapper wrapper = wrappers.iterator().next();
+		assertTrue(wrapper.isActive());
+
+		wrapper.disconnect(testFile.getLocationURI());
+		assertTrue(wrapper.isActive());
+		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+		assertFalse(wrapper.isActive());
+	}
+	
+	@Test
+	public void testLastDocumentDisconnectedTimeoutZero() throws Exception {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 
 		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);
 		assertEquals(1, wrappers.size());
 		LanguageServerWrapper wrapper = wrappers.iterator().next();
 		assertTrue(wrapper.isActive());
-		
+
 		wrapper.disconnect(testFile.getLocationURI());
 		assertFalse(wrapper.isActive());
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -305,6 +305,34 @@ public class LanguageServiceAccessorTest {
 	}
 
 	@Test
+	public void testStopOnLastDisconnectedDocumentFalse() throws Exception {
+		IFile testFile1 = TestUtils.createUniqueTestFile(project, "lsptWithStopOnLastDisconnectedDocumentFalse", "");
+
+		Collection<LanguageServerWrapper> wrappers1 = LanguageServiceAccessor.getLSWrappers(testFile1,
+				c -> Boolean.TRUE);
+		assertEquals(1, wrappers1.size());
+		LanguageServerWrapper wrapper1 = wrappers1.iterator().next();
+		assertTrue(wrapper1.isActive());
+		
+		wrapper1.disconnect(testFile1.getLocationURI());
+		assertTrue(wrapper1.isActive());
+	}
+
+	@Test
+	public void testStopOnLastDisconnectedDocumentDefault() throws Exception {
+		IFile testFile1 = TestUtils.createUniqueTestFile(project, "");
+
+		Collection<LanguageServerWrapper> wrappers1 = LanguageServiceAccessor.getLSWrappers(testFile1,
+				c -> Boolean.TRUE);
+		assertEquals(1, wrappers1.size());
+		LanguageServerWrapper wrapper1 = wrappers1.iterator().next();
+		assertTrue(wrapper1.isActive());
+		
+		wrapper1.disconnect(testFile1.getLocationURI());
+		assertFalse(wrapper1.isActive());
+	}
+
+	@Test
 	public void testLanguageServerHierarchy_moreSpecializedFirst() throws Exception {
 		// file with a content-type and a parent, each associated to one LS
 		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptchild", "");

--- a/org.eclipse.lsp4e/schema/languageServer.exsd
+++ b/org.eclipse.lsp4e/schema/languageServer.exsd
@@ -146,6 +146,8 @@ As an example:
             <annotation>
                <documentation>
                   Wether the server should be stopped when the last buffer connected to the server is disconnected. It defaults to true.
+
+If set to false, the server will run until LanguageServerWrapper#close is called programatically or the IDE is closed.
                </documentation>
             </annotation>
          </attribute>

--- a/org.eclipse.lsp4e/schema/languageServer.exsd
+++ b/org.eclipse.lsp4e/schema/languageServer.exsd
@@ -142,12 +142,12 @@ As an example:
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="stopOnLastDisconnectedDocument" type="boolean">
+         <attribute name="lastDocumentDisconnectedTimeout" type="string">
             <annotation>
                <documentation>
-                  Wether the server should be stopped when the last buffer connected to the server is disconnected. It defaults to true.
+                  Timeout in seconds after which the server should be stopped when the last buffer connected to the server is disconnected. It defaults to zero, that is, the server is stop right after the last connected document is disconected.
 
-If set to false, the server will run until LanguageServerWrapper#close is called programatically or the IDE is closed.
+If set to a number bigger than zero, the server will run until the timeout is reached or until LanguageServerWrapper#close is called programatically or the IDE is closed.
                </documentation>
             </annotation>
          </attribute>

--- a/org.eclipse.lsp4e/schema/languageServer.exsd
+++ b/org.eclipse.lsp4e/schema/languageServer.exsd
@@ -142,6 +142,13 @@ As an example:
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="stopOnLastDisconnectedDocument" type="boolean">
+            <annotation>
+               <documentation>
+                  Wether the server should be stopped when the last buffer connected to the server is disconnected. It defaults to true.
+               </documentation>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -610,7 +610,7 @@ public class LanguageServerWrapper {
 			documentListener.getDocument().removeDocumentListener(documentListener);
 			documentListener.documentClosed();
 		}
-		if (this.connectedDocuments.isEmpty()) {
+		if (this.serverDefinition.stopOnLastDisconnectedDocument && this.connectedDocuments.isEmpty()) {
 			stop();
 		}
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -408,11 +408,26 @@ public class LanguageServerWrapper {
 		return this.launcherFuture != null && !this.launcherFuture.isDone() && !this.launcherFuture.isCancelled();
 	}
 
-	public synchronized void stop() {
+	private void removeStopTimer() {
 		if (timer != null) {
 			timer.cancel();
 			timer = null;
 		}
+	}
+
+	private void startStopTimer() {
+		timer = new Timer("Stop Language Server Timer"); //$NON-NLS-1$
+
+		timer.schedule(new TimerTask() {
+			@Override
+			public void run() {
+				stop();
+			}
+		}, TimeUnit.SECONDS.toMillis(this.serverDefinition.lastDocumentDisconnectedTimeout));
+	}
+
+	public synchronized void stop() {
+		removeStopTimer();
 		if (this.initializeFuture != null) {
 			this.initializeFuture.cancel(true);
 			this.initializeFuture = null;
@@ -572,10 +587,7 @@ public class LanguageServerWrapper {
 	 * @noreference internal so far
 	 */
 	private CompletableFuture<LanguageServer> connect(@NonNull URI uri, IDocument document) throws IOException {
-		if (timer != null) {
-			timer.cancel();
-			timer = null;
-		}
+		removeStopTimer();
 		if (this.connectedDocuments.containsKey(uri)) {
 			return CompletableFuture.completedFuture(languageServer);
 		}
@@ -621,20 +633,12 @@ public class LanguageServerWrapper {
 			documentListener.documentClosed();
 		}
 		if (this.connectedDocuments.isEmpty()) {
-			if (timer != null) {
-				timer.cancel();
-			}
-			if (this.serverDefinition.lastDocumentDisconnectedTimeout == 0) {
+			if (this.serverDefinition.lastDocumentDisconnectedTimeout != 0) {
+				removeStopTimer();
+				startStopTimer();
+			} else {
 				stop();
 			}
-			timer = new Timer("Stop Language Server Timer"); //$NON-NLS-1$
-
-			timer.schedule(new TimerTask() {
-				@Override
-				public void run() {
-					stop();
-				}
-			}, TimeUnit.SECONDS.toMillis(this.serverDefinition.lastDocumentDisconnectedTimeout));
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -409,6 +409,10 @@ public class LanguageServerWrapper {
 	}
 
 	public synchronized void stop() {
+		if (timer != null) {
+			timer.cancel();
+			timer = null;
+		}
 		if (this.initializeFuture != null) {
 			this.initializeFuture.cancel(true);
 			this.initializeFuture = null;
@@ -570,6 +574,7 @@ public class LanguageServerWrapper {
 	private CompletableFuture<LanguageServer> connect(@NonNull URI uri, IDocument document) throws IOException {
 		if (timer != null) {
 			timer.cancel();
+			timer = null;
 		}
 		if (this.connectedDocuments.containsKey(uri)) {
 			return CompletableFuture.completedFuture(languageServer);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -405,7 +405,7 @@ public class LanguageServerWrapper {
 		return this.launcherFuture != null && !this.launcherFuture.isDone() && !this.launcherFuture.isCancelled();
 	}
 
-	synchronized void stop() {
+	public synchronized void stop() {
 		if (this.initializeFuture != null) {
 			this.initializeFuture.cancel(true);
 			this.initializeFuture = null;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
@@ -74,8 +74,8 @@ public class LanguageServersRegistry {
 	private static final String ID_ATTRIBUTE = "id"; //$NON-NLS-1$
 	private static final String SINGLETON_ATTRIBUTE = "singleton"; //$NON-NLS-1$
 	private static final boolean DEFAULT_SINGLETON = false;
-	private static final String STOP_ON_LAST_DISCONNECTED_DOCUMENT = "stopOnLastDisconnectedDocument"; //$NON-NLS-1$
-	private static final boolean DEFAULT_STOP_ON_LAST_DISCONNECTED_DOCUMENT = true;
+	private static final String LAST_DOCUMENT_DISCONNECTED_TIMEOUT = "lastDocumentDisconnectedTimeout"; //$NON-NLS-1$
+	private static final int DEFAULT_LAST_DOCUMENTED_DISCONNECTED_TIEMOUT = 0;
 	private static final String CONTENT_TYPE_ATTRIBUTE = "contentType"; //$NON-NLS-1$
 	private static final String LANGUAGE_ID_ATTRIBUTE = "languageId"; //$NON-NLS-1$
 	private static final String CLASS_ATTRIBUTE = "class"; //$NON-NLS-1$
@@ -92,14 +92,14 @@ public class LanguageServersRegistry {
 		public final @NonNull String id;
 		public final @NonNull String label;
 		public final boolean isSingleton;
-		public final boolean stopOnLastDisconnectedDocument;
+		public final int lastDocumentDisconnectedTimeout;
 		public final @NonNull Map<IContentType, String> languageIdMappings;
 
-		LanguageServerDefinition(@NonNull String id, @NonNull String label, boolean isSingleton, boolean stopOnLastDisconnectedDocument) {
+		LanguageServerDefinition(@NonNull String id, @NonNull String label, boolean isSingleton, int lastDocumentDisconnectedTimeout) {
 			this.id = id;
 			this.label = label;
 			this.isSingleton = isSingleton;
-			this.stopOnLastDisconnectedDocument = stopOnLastDisconnectedDocument;
+			this.lastDocumentDisconnectedTimeout = lastDocumentDisconnectedTimeout;
 			this.languageIdMappings = new ConcurrentHashMap<>();
 		}
 
@@ -145,13 +145,13 @@ public class LanguageServersRegistry {
 			return Boolean.parseBoolean(element.getAttribute(SINGLETON_ATTRIBUTE));
 		}
 
-		private static boolean getStopOnLastDisconnectedDocument(IConfigurationElement element) {
-			String stopOnLastDisconnectedDocumentAttribute = element.getAttribute(STOP_ON_LAST_DISCONNECTED_DOCUMENT);
-			return stopOnLastDisconnectedDocumentAttribute == null ? DEFAULT_STOP_ON_LAST_DISCONNECTED_DOCUMENT : Boolean.parseBoolean(stopOnLastDisconnectedDocumentAttribute);
+		private static int getLastDocumentDisconnectedTimeout(IConfigurationElement element) {
+			String lastDocumentisconnectedTiemoutAttribute = element.getAttribute(LAST_DOCUMENT_DISCONNECTED_TIMEOUT);
+			return lastDocumentisconnectedTiemoutAttribute == null ? DEFAULT_LAST_DOCUMENTED_DISCONNECTED_TIEMOUT : Integer.parseInt(lastDocumentisconnectedTiemoutAttribute);
 		}
 
 		public ExtensionLanguageServerDefinition(@NonNull IConfigurationElement element) {
-			super(element.getAttribute(ID_ATTRIBUTE), element.getAttribute(LABEL_ATTRIBUTE), getIsSingleton(element), getStopOnLastDisconnectedDocument(element));
+			super(element.getAttribute(ID_ATTRIBUTE), element.getAttribute(LABEL_ATTRIBUTE), getIsSingleton(element), getLastDocumentDisconnectedTimeout(element));
 			this.extension = element;
 		}
 
@@ -224,7 +224,7 @@ public class LanguageServersRegistry {
 
 		public LaunchConfigurationLanguageServerDefinition(ILaunchConfiguration launchConfiguration,
 				Set<String> launchModes) {
-			super(launchConfiguration.getName(), launchConfiguration.getName(), DEFAULT_SINGLETON, DEFAULT_STOP_ON_LAST_DISCONNECTED_DOCUMENT);
+			super(launchConfiguration.getName(), launchConfiguration.getName(), DEFAULT_SINGLETON, DEFAULT_LAST_DOCUMENTED_DISCONNECTED_TIEMOUT);
 			this.launchConfiguration = launchConfiguration;
 			this.launchModes = launchModes;
 		}


### PR DESCRIPTION
In https://github.com/eclipse/lsp4e/pull/92 we introduced the possibility of initializing server before the user open a file in the editor, as a related functionality, we introduce the possibility of keeping the server running even if the last connected document is disconnected.
The reasoning is similar as in that PR: our language server will setup some state and do an initial build (The initial build in our case just loads the precomputed state and will publish the markers of this state to the user, that is different to the eclipse target) on initialization, and this is time consuming. In addition to start the LS upfront, we also want to keep it running even if editors are closed.