### PR TITLE
Java editor LS Quick Assist

### DIFF
--- a/org.eclipse.lsp4e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JDT Integration for LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.jdt;singleton:=true
-Bundle-Version: 0.10.1.qualifier
+Bundle-Version: 0.10.2.qualifier
 Automatic-Module-Name: org.eclipse.lsp4e.jdt
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ClassPath: .

--- a/org.eclipse.lsp4e.jdt/plugin.xml
+++ b/org.eclipse.lsp4e.jdt/plugin.xml
@@ -32,5 +32,13 @@
             contentTypeId="org.eclipse.jdt.core.javaSource">
       </participant>
    </extension>
+   <extension
+         point="org.eclipse.jdt.ui.quickAssistProcessors">
+      <quickAssistProcessor
+            class="org.eclipse.lsp4e.jdt.LspJavaQuickAssistProcessor"
+            id="org.eclipse.lsp4e.jdt.quickAssistProcessor"
+            name="LS Java Quick Proposals">
+      </quickAssistProcessor>
+   </extension>
 
 </plugin>

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionProposalComputer.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionProposalComputer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Pivotal Inc. and others.
+ * Copyright (c) 2017, 2022 Pivotal Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -21,15 +21,11 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.ui.text.java.ContentAssistInvocationContext;
-import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposalComputer;
-import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Point;
 
 @SuppressWarnings({ "restriction" })
 public class LSJavaCompletionProposalComputer implements IJavaCompletionProposalComputer {
@@ -117,53 +113,6 @@ public class LSJavaCompletionProposalComputer implements IJavaCompletionProposal
 
 	@Override
 	public void sessionEnded() {
-	}
-	
-	class LSJavaProposal implements IJavaCompletionProposal {
-		
-		private ICompletionProposal delegate;
-		private int relevance;
-
-		public LSJavaProposal(ICompletionProposal delegate,  int relevance) {
-			this.delegate = delegate;
-			this.relevance = relevance;
-		}
-
-		@Override
-		public void apply(IDocument document) {
-			delegate.apply(document);	
-		}
-
-		@Override
-		public String getAdditionalProposalInfo() {
-			return delegate.getAdditionalProposalInfo();
-		}
-
-		@Override
-		public IContextInformation getContextInformation() {
-			return delegate.getContextInformation();
-		}
-
-		@Override
-		public String getDisplayString() {
-			return delegate.getDisplayString();
-		}
-
-		@Override
-		public Image getImage() {
-			return delegate.getImage();
-		}
-
-		@Override
-		public Point getSelection(IDocument document) {
-			return delegate.getSelection(document);
-		}
-
-		@Override
-		public int getRelevance() {
-			return relevance;
-		}
-		
 	}
 
 }

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaProposal.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaProposal.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2022 VMware Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  - Alex Boyko (VMware Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt;
+
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+
+class LSJavaProposal implements IJavaCompletionProposal {
+	
+	private ICompletionProposal delegate;
+	private int relevance;
+
+	public LSJavaProposal(ICompletionProposal delegate,  int relevance) {
+		this.delegate = delegate;
+		this.relevance = relevance;
+	}
+
+	@Override
+	public void apply(IDocument document) {
+		delegate.apply(document);	
+	}
+
+	@Override
+	public String getAdditionalProposalInfo() {
+		return delegate.getAdditionalProposalInfo();
+	}
+
+	@Override
+	public IContextInformation getContextInformation() {
+		return delegate.getContextInformation();
+	}
+
+	@Override
+	public String getDisplayString() {
+		return delegate.getDisplayString();
+	}
+
+	@Override
+	public Image getImage() {
+		return delegate.getImage();
+	}
+
+	@Override
+	public Point getSelection(IDocument document) {
+		return delegate.getSelection(document);
+	}
+
+	@Override
+	public int getRelevance() {
+		return relevance;
+	}
+	
+}

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LspJavaQuickAssistProcessor.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LspJavaQuickAssistProcessor.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2022 VMware Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  - Alex Boyko (VMware Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.ui.text.java.IInvocationContext;
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+import org.eclipse.jdt.ui.text.java.IQuickAssistProcessor;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.quickassist.IQuickAssistInvocationContext;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.TextInvocationContext;
+import org.eclipse.lsp4e.operations.codeactions.LSPCodeActionQuickAssistProcessor;
+
+public class LspJavaQuickAssistProcessor extends LSPCodeActionQuickAssistProcessor implements IQuickAssistProcessor {
+
+	private static final int RELEVANCE = 100;
+
+	private IQuickAssistInvocationContext getContext(IInvocationContext context) {
+		return new IQuickAssistInvocationContext() {
+			
+			@Override
+			public ISourceViewer getSourceViewer() {
+				// Should be of instance or a subclass of TextInvocationContext
+				return ((TextInvocationContext) context).getSourceViewer();
+			}
+			
+			@Override
+			public int getOffset() {
+				return context.getSelectionOffset();
+			}
+			
+			@Override
+			public int getLength() {
+				return context.getSelectionLength();
+			}
+		};
+	}
+
+	@Override
+	public boolean hasAssists(IInvocationContext context) throws CoreException {
+		return this.canAssist(getContext(context));
+	}
+	
+	@Override
+	public IJavaCompletionProposal[] getAssists(IInvocationContext context, IProblemLocation[] locations)
+			throws CoreException {
+		
+		ICompletionProposal[] proposals = computeQuickAssistProposals(getContext(context));
+		IJavaCompletionProposal[] javaProposals = new IJavaCompletionProposal[proposals.length];
+		for (int i = 0; i < proposals.length; i++) {
+			javaProposals[i] = new LSJavaProposal(proposals[i], RELEVANCE);
+		}
+		return javaProposals;
+	}
+
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Red Hat Inc. and others.
+ * Copyright (c) 2016, 2022 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -89,7 +89,7 @@ public class LanguageClientImpl implements LanguageClient {
 			Job job = new Job(Messages.serverEdit) {
 				@Override
 				public IStatus run(IProgressMonitor monitor) {
-					LSPEclipseUtils.applyWorkspaceEdit(params.getEdit());
+					LSPEclipseUtils.applyWorkspaceEdit(params.getEdit(), params.getLabel());
 					return Status.OK_STATUS;
 				}
 			};

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -70,6 +70,7 @@ import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionKindCapabilities;
 import org.eclipse.lsp4j.CodeActionLiteralSupportCapabilities;
 import org.eclipse.lsp4j.CodeActionOptions;
+import org.eclipse.lsp4j.CodeActionResolveSupportCapabilities;
 import org.eclipse.lsp4j.CodeLensCapabilities;
 import org.eclipse.lsp4j.ColorProviderCapabilities;
 import org.eclipse.lsp4j.CompletionCapabilities;
@@ -300,15 +301,16 @@ public class LanguageServerWrapper {
 				editCapabilities.setFailureHandling(FailureHandlingKind.Undo);
 				workspaceClientCapabilities.setWorkspaceEdit(editCapabilities);
 				TextDocumentClientCapabilities textDocumentClientCapabilities = new TextDocumentClientCapabilities();
-				textDocumentClientCapabilities
-						.setCodeAction(
-								new CodeActionCapabilities(
-										new CodeActionLiteralSupportCapabilities(
-												new CodeActionKindCapabilities(Arrays.asList(CodeActionKind.QuickFix,
-														CodeActionKind.Refactor, CodeActionKind.RefactorExtract,
-														CodeActionKind.RefactorInline, CodeActionKind.RefactorRewrite,
-														CodeActionKind.Source, CodeActionKind.SourceOrganizeImports))),
-										true));
+				CodeActionCapabilities codeAction = new CodeActionCapabilities(
+						new CodeActionLiteralSupportCapabilities(
+								new CodeActionKindCapabilities(Arrays.asList(CodeActionKind.QuickFix,
+										CodeActionKind.Refactor, CodeActionKind.RefactorExtract,
+										CodeActionKind.RefactorInline, CodeActionKind.RefactorRewrite,
+										CodeActionKind.Source, CodeActionKind.SourceOrganizeImports))),
+						true);
+				codeAction.setDataSupport(true);
+				codeAction.setResolveSupport(new CodeActionResolveSupportCapabilities(List.of("edit")));  //$NON-NLS-1$
+				textDocumentClientCapabilities.setCodeAction(codeAction);
 				textDocumentClientCapabilities.setCodeLens(new CodeLensCapabilities());
 				textDocumentClientCapabilities.setColorProvider(new ColorProviderCapabilities());
 				CompletionItemCapabilities completionItemCapabilities = new CompletionItemCapabilities(Boolean.TRUE);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Fraunhofer FOKUS and others.
+ * Copyright (c) 2019, 2022 Fraunhofer FOKUS and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -111,7 +111,7 @@ public class CommandExecutor {
 		// tentative fallback
 		if (command.getArguments() != null) {
 			WorkspaceEdit edit = createWorkspaceEdit(command.getArguments(), document);
-			LSPEclipseUtils.applyWorkspaceEdit(edit);
+			LSPEclipseUtils.applyWorkspaceEdit(edit, command.getTitle());
 			return CompletableFuture.completedFuture(null);
 		}
 		return null;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
@@ -76,7 +76,7 @@ public class CodeActionCompletionProposal implements ICompletionProposal {
 	private void apply(CodeAction codeaction) {
 		if (codeaction != null) {
 			if (codeaction.getEdit() != null) {
-				LSPEclipseUtils.applyWorkspaceEdit(codeaction.getEdit());
+				LSPEclipseUtils.applyWorkspaceEdit(codeaction.getEdit(), codeaction.getTitle());
 			}
 			if (codeaction.getCommand() != null) {
 				executeCommand(codeaction.getCommand());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat Inc. and others.
+ * Copyright (c) 2018, 2022 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -53,7 +53,7 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 	@Override
 	public void run(IMarker marker) {
 		if (codeAction.getEdit() != null) {
-			LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit());
+			LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit(), codeAction.getTitle());
 		}
 		if (codeAction.getCommand() != null) {
 			IResource resource = marker.getResource();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionQuickAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionQuickAssistProcessor.java
@@ -167,14 +167,6 @@ public class LSPCodeActionQuickAssistProcessor implements IQuickAssistProcessor 
 		return proposals.toArray(new ICompletionProposal[proposals.size()]);
 	}
 
-	private List<LSPDocumentInfo> getLSPDocumentInfos(IDocument document) {
-		if (document == null) {
-			return Collections.emptyList();
-		}
-		return LanguageServiceAccessor.getLSPDocumentInfosFor(document,
-				LSPCodeActionMarkerResolution::providesCodeActions);
-	}
-
 	/**
 	 * Reinvokes the quickAssist in order to refresh the list of completion
 	 * proposals
@@ -185,6 +177,14 @@ public class LSPCodeActionQuickAssistProcessor implements IQuickAssistProcessor 
 	private void refreshProposals(IQuickAssistInvocationContext invocationContext) {
 		invocationContext.getSourceViewer().getTextWidget().getDisplay().asyncExec(() -> invocationContext
 				.getSourceViewer().getTextOperationTarget().doOperation(ISourceViewer.QUICK_ASSIST));
+	}
+
+	private static List<LSPDocumentInfo> getLSPDocumentInfos(IDocument document) {
+		if (document == null) {
+			return Collections.emptyList();
+		}
+		return LanguageServiceAccessor.getLSPDocumentInfosFor(document,
+				LSPCodeActionMarkerResolution::providesCodeActions);
 	}
 
 	private static CodeActionParams prepareCodeActionParams(List<LSPDocumentInfo> infos, int offset, int length) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Red Hat Inc. and others.
+ * Copyright (c) 2016, 2022 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -130,7 +130,7 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 											@Override
 											public void widgetSelected(SelectionEvent e) {
 												if (codeAction.getEdit() != null) {
-													LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit());
+													LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit(), codeAction.getTitle());
 												}
 												if (codeAction.getCommand() != null) {
 													executeCommand(info, codeAction.getCommand());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2017-2021 Angelo ZERR.
+ *  Copyright (c) 2017-2022 Angelo ZERR.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -197,7 +197,7 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 			throw new CoreException(
 					new Status(IStatus.ERROR, LanguageServerPlugin.PLUGIN_ID, Messages.rename_processor_required));
 		}
-		return LSPEclipseUtils.toCompositeChange(rename);
+		return LSPEclipseUtils.toCompositeChange(rename, Messages.rename_title);
 	}
 
 	@Override


### PR DESCRIPTION
1. Support `codeAction/resolve` for edit property
2. LS based Quick Assist processor for Java editor
3. Single undo operation for WorkspaceEdit (UndoManager was missing from the apply operaion)
4. Bugs in `LSPCodeActionQuickAssistProcessor`
  - Can't cache range. Each subsequent invocation of QA in the same doc different location brings up the same cached proposals
  - Don't think caching proposals is a good idea. Computation method can be reentrant but not recursive. Problem is old proposals are never cleared. I might be misunderstanding this bit though...