### PR TITLE
Only use Quickfix kind of CodeActions for Quickfixes

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -36,6 +37,7 @@ import org.eclipse.lsp4e.operations.diagnostics.LSPDiagnosticsToMarkers;
 import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
@@ -160,7 +162,13 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 					futures.add(codeAction);
 					codeAction.thenAcceptAsync(actions -> {
 						try {
-							marker.setAttribute(LSP_REMEDIATION, actions);
+							List<Either<Command, CodeAction>> quickFixActions = actions.stream().filter(a -> {
+								if (a.isRight()) {
+									return CodeActionKind.QuickFix.equals(a.getRight().getKind());
+								}
+								return true;
+							}).collect(Collectors.toList());
+							marker.setAttribute(LSP_REMEDIATION, quickFixActions);
 						} catch (CoreException e) {
 							LanguageServerPlugin.logError(e);
 						}


### PR DESCRIPTION
There are many various refactorings returned from the LS. However, CodeActions are fetched in the context of showing Quick Fixes (i.e. problem marker hover) then only QuickFix kind of CodeActions are applicable and the rest ignored.