### PR TITLE
Concurrency fixes

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
@@ -255,4 +255,8 @@ public class TestUtils {
 			latch.countDown();
 		}
 	}
+	
+	public static BooleanSupplier numberOfChangesIs(int changes) {
+		return () -> MockLanguageServer.INSTANCE.getDidChangeEvents().size() == changes;
+	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
@@ -55,8 +55,9 @@ public class FormatTest {
 	public void testFormattingInvalidDocument() throws InterruptedException, ExecutionException {
 		LSPFormatter formatter = new LSPFormatter();
 		ITextSelection selection = TextSelection.emptySelection();
+		Document document = new Document();
 
-		List<? extends TextEdit> edits = formatter.requestFormatting(new Document(), selection).get();
+		List<? extends TextEdit> edits = formatter.requestFormatting(document, selection, document.getModificationStamp()).get();
 		assertEquals(0, edits.size());
 	}
 
@@ -71,8 +72,9 @@ public class FormatTest {
 
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
+		Document document = (Document)viewer.getDocument();
 
-		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
+		List<? extends TextEdit> edits = formatter.requestFormatting(document, (ITextSelection) selection, document.getModificationStamp())
 				.get();
 		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), edits));
 
@@ -98,8 +100,9 @@ public class FormatTest {
 
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
+		Document document = (Document)viewer.getDocument();
 
-		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
+		List<? extends TextEdit> edits = formatter.requestFormatting(document, (ITextSelection) selection, document.getModificationStamp())
 				.get();
 		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), edits));
 

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -188,8 +188,8 @@ public final class MockLanguageServer implements LanguageServer {
 		this.textDocumentService.setDidOpenCallback(didOpenExpectation);
 	}
 
-	public void setDidChangeCallback(CompletableFuture<DidChangeTextDocumentParams> didChangeExpectation) {
-		this.textDocumentService.setDidChangeCallback(didChangeExpectation);
+	public List<DidChangeTextDocumentParams> getDidChangeEvents() {
+		return this.textDocumentService.getDidChangeEvents();
 	}
 
 	public void setDidSaveCallback(CompletableFuture<DidSaveTextDocumentParams> didSaveExpectation) {

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServerMultiRootFolders.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServerMultiRootFolders.java
@@ -169,8 +169,8 @@ public final class MockLanguageServerMultiRootFolders implements LanguageServer 
 		this.textDocumentService.setDidOpenCallback(didOpenExpectation);
 	}
 
-	public void setDidChangeCallback(CompletableFuture<DidChangeTextDocumentParams> didChangeExpectation) {
-		this.textDocumentService.setDidChangeCallback(didChangeExpectation);
+	public List<DidChangeTextDocumentParams> getDidChangeEvents() {
+		return this.textDocumentService.getDidChangeEvents();
 	}
 
 	public void setDidSaveCallback(CompletableFuture<DidSaveTextDocumentParams> didSaveExpectation) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -269,7 +269,11 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		}
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri.toString());
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(identifier, document.get());
-		languageServerWrapper.getInitializedServer().thenAcceptAsync(ls -> ls.getTextDocumentService().didSave(params));
+		++version;
+ 		lastChangeFuture = lastChangeFuture.thenApplyAsync(ls -> {
+ 			ls.getTextDocumentService().didSave(params);
+ 			return ls;
+ 		});
 	}
 
 	public void documentClosed() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -868,6 +868,19 @@ public class LanguageServerWrapper {
 		return -1;
 	}
 
+	/**
+	 * Submit an asynchronous call (i.e. to the language server) that will only be executed if the
+	 * expected document version matches the stored one (which tracks change events).
+	 * Ensures that sequential actions on a document happen in order w.r.t. the language server's view
+	 *
+	 * @param <U> Return type of future
+	 * @param expectedDocumentStamp The current version of the document according to the calling code
+	 * @param file Document to synchronize on
+	 * @param fn Asynchronous computation on the language server
+	 * @return A future that will throw a <code>ConcurrentModificationException</code> on <code>get()</code>
+	 * if the document has changed in the meantime.
+	 * @return Null if the input file is null or does not exist within the workspace, returns null
+	 */
  	public <U> @Nullable CompletableFuture< U> executeOnCurrentVersionAsync(long expectedDocumentStamp, IFile file,
  			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
  		if (file != null && file.getLocation() != null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -157,7 +157,7 @@ public class LanguageServerWrapper {
 				return;
 			}
 			DocumentContentSynchronizer documentListener = connectedDocuments.get(LSPEclipseUtils.toUri(buffer));
-			if (documentListener != null && documentListener.getModificationStamp() < buffer.getModificationStamp()) {
+			if (documentListener != null) {
 				documentListener.documentSaved(buffer.getModificationStamp());
 			}
 		}
@@ -868,34 +868,12 @@ public class LanguageServerWrapper {
 		return -1;
 	}
 
-	public long getModificationStamp(@Nullable IFile file) {
- 		if (file != null && file.getLocation() != null) {
- 			DocumentContentSynchronizer documentContentSynchronizer = connectedDocuments.get(file.getLocationURI());
- 			if (documentContentSynchronizer != null) {
- 				return documentContentSynchronizer.getModificationStamp();
- 			}
- 		}
- 		return -1;
- 	}
-
-
- 	public long getDocumentModificationStamp(@Nullable IFile file) {
- 		if (file != null && file.getLocation() != null) {
- 			DocumentContentSynchronizer documentContentSynchronizer = connectedDocuments.get(file.getLocationURI());
- 			if (documentContentSynchronizer != null) {
- 				return documentContentSynchronizer.getDocumentModificationStamp();
- 			}
- 		}
- 		return -1;
- 	}
-
-
- 	public <U> @Nullable CompletableFuture< U> executeOnCurrentVersionAsync(IFile file,
+ 	public <U> @Nullable CompletableFuture< U> executeOnCurrentVersionAsync(long expectedDocumentStamp, IFile file,
  			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
  		if (file != null && file.getLocation() != null) {
  			DocumentContentSynchronizer documentContentSynchronizer = connectedDocuments.get(file.getLocationURI());
  			if (documentContentSynchronizer != null) {
- 				return documentContentSynchronizer.executeOnCurrentVersionAsync(fn);
+ 				return documentContentSynchronizer.executeOnCurrentVersionAsync(expectedDocumentStamp, fn);
  			}
  		}
  		return null;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -142,19 +142,11 @@ public class LanguageServiceAccessor {
 			return this.wrapper.isActive();
 		}
 
-		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(
+		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(long expectedDocumentStamp,
  				Function<LanguageServer, ? extends CompletionStage<U>> fn) {
- 			return this.wrapper.executeOnCurrentVersionAsync(LSPEclipseUtils.getFile(document), fn);
+ 			return this.wrapper.executeOnCurrentVersionAsync(expectedDocumentStamp, LSPEclipseUtils.getFile(document), fn);
  		}
 
-		public long getModificationStamp() {
- 			return wrapper.getModificationStamp(LSPEclipseUtils.getFile(document));
- 		}
-
- 		public long getDocumentModificationStamp() {
- 			return wrapper.getDocumentModificationStamp(LSPEclipseUtils.getFile(document));
-
- 		}
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -29,7 +29,9 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -139,6 +141,20 @@ public class LanguageServiceAccessor {
 		public boolean isActive() {
 			return this.wrapper.isActive();
 		}
+
+		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(
+ 				Function<LanguageServer, ? extends CompletionStage<U>> fn) {
+ 			return this.wrapper.executeOnCurrentVersionAsync(LSPEclipseUtils.getFile(document), fn);
+ 		}
+
+		public long getModificationStamp() {
+ 			return wrapper.getModificationStamp(LSPEclipseUtils.getFile(document));
+ 		}
+
+ 		public long getDocumentModificationStamp() {
+ 			return wrapper.getDocumentModificationStamp(LSPEclipseUtils.getFile(document));
+
+ 		}
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -142,6 +142,12 @@ public class LanguageServiceAccessor {
 			return this.wrapper.isActive();
 		}
 
+		/**
+		 * Submit an asynchronous call (i.e. to the language server) that will only be executed if the
+		 * expected document version matches the stored one (which tracks change events).
+		 *
+		 * @see org.eclipse.lsp4e.LanguageServerWrapper#executeOnCurrentVersionAsync
+		 */
 		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(long expectedDocumentStamp,
  				Function<LanguageServer, ? extends CompletionStage<U>> fn) {
  			return this.wrapper.executeOnCurrentVersionAsync(expectedDocumentStamp, LSPEclipseUtils.getFile(document), fn);


### PR DESCRIPTION
As discussed on the lsp4e-dev mailing list, these are some fixes we made internally to try and address some weird behaviour we used to get, particularly under load. The existing implementation submits document update events to a thread pool where they may get scheduled in any order. This can cause the client's and server's view of the state of a document to diverge, resulting in phantom error markers and so on.
