### PR TITLE
Use destroyForcibly for debug process

### DIFF
--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
@@ -373,11 +373,11 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 				&& "launch".equals(dspParameters.getOrDefault("request", "launch"));
 		if (shouldSendTerminateRequest) {
 			fSentTerminateRequest = true;
-			getDebugProtocolServer().terminate(new TerminateArguments());
+			getDebugProtocolServer().terminate(new TerminateArguments()).thenRunAsync(this::terminated);
 		} else {
 			DisconnectArguments arguments = new DisconnectArguments();
 			arguments.setTerminateDebuggee(true);
-			getDebugProtocolServer().disconnect(arguments).thenRun(this::terminated);
+			getDebugProtocolServer().disconnect(arguments).thenRunAsync(this::terminated);
 		}
 	}
 

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
@@ -319,7 +319,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 				} else {
 					inputStream = debugAdapterProcess.getInputStream();
 					outputStream = debugAdapterProcess.getOutputStream();
-					cleanup = debugAdapterProcess::destroy;
+					cleanup = debugAdapterProcess::destroyForcibly;
 				}
 			} else {
 


### PR DESCRIPTION
Some process (eg node-debug2) are not responding well to a gentle
"destroy" and often remain as zombies. Let's "destroyForcibly" instead.