### PR TITLE
Refactoring: add support for the platform's preview UI

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.refactoring.LSPTextChange;
 import org.eclipse.lsp4e.test.AllCleanRule;
@@ -27,6 +28,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.TextChange;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -42,6 +44,16 @@ public class LSPTextChangeTest {
 		PerformChangeOperation operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
 		operation.run(new NullProgressMonitor());
 		assertEquals(edit.getNewText(), LSPEclipseUtils.getDocument(file).get());
+	}
+	
+	@Test
+	public void testRefactoringPreview() throws Exception {
+		IProject project = TestUtils.createProject("blah");
+		IFile file = TestUtils.createUniqueTestFile(project, "old");
+		TextEdit edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
+		TextChange change = new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit);
+		IDocument preview = change.getPreviewDocument(new NullProgressMonitor());
+		assertEquals(preview.get(), "new");
 	}
 
 	@Test

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/LSPTextChange.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/LSPTextChange.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.ltk.core.refactoring.Change;
@@ -91,7 +92,20 @@ public class LSPTextChange extends TextChange {
 				this.fBuffer = manager.getFileStoreTextFileBuffer(this.file.getRight());
 			}
 		}
-		return fBuffer.getDocument();
+		final IDocument document  = fBuffer.getDocument();
+		int offset = 0;
+		int length = document.getLength();
+		if (this.textEdit.getRange() != null) {
+			try {
+				offset = LSPEclipseUtils.toOffset(this.textEdit.getRange().getStart(), document);
+				length = LSPEclipseUtils.toOffset(this.textEdit.getRange().getEnd(), document) - offset;
+				this.setEdit(new ReplaceEdit(offset, length, this.textEdit.getNewText()));
+			} catch (BadLocationException e) {
+				// Should not happen
+				LanguageServerPlugin.logError(e);
+			}
+		}
+		return document;
 	}
 
 	@Override


### PR DESCRIPTION
After wading through the eclipse code we found that this change allowed the diffs to display properly in the refactoring preview dialog:

![image](https://user-images.githubusercontent.com/6334768/170035727-65f73f51-4d09-4693-8d39-a62999a2c405.png)

