### PR TITLE
Fix for IllegalStateException: Duplicate RPC method runInTerminal.

### DIFF
--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
@@ -79,7 +79,6 @@ import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
-import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.validation.ReflectiveMessageValidator;
 
 public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDebugProtocolClient {
@@ -619,7 +618,7 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 	 * <p>
 	 * With this request a debug adapter can run a command in a terminal.
 	 */
-	@JsonRequest
+	@Override
 	public CompletableFuture<RunInTerminalResponse> runInTerminal(RunInTerminalRequestArguments args) {
 		if (RunInTerminalRequestArgumentsKind.EXTERNAL.equals(args.getKind())) {
 			// TODO handle external run in terminal in an external way?


### PR DESCRIPTION
There is a recent commit is LSP4J - Move runInTerminal #620 (eclipse/lsp4j@bdabc77) - that moves `runInTerminal` method
declaration from IDebugProtocolServer to IDebugProtocolClient in LSP4J.
So an according change is expected to be made in LSP4E's DSPDebugTarget as it implements IDebugProtocolClient, because until it's not,
we'll have runInTerminal to appear twice when finding for the RPC methods, which generates the mentioned `IllegalStateException:
Duplicate RPC method runInTerminal.` exception preventing a debug launch from being started.

Change-Id: I487f9f492c622601f3eb047c6016d63141877c55
Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>