### PR TITLE
Update quick fixes in the UI once computed

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016-2017 Red Hat Inc. and others.
+ * Copyright (c) 2016-2022 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -12,6 +12,8 @@
 package org.eclipse.lsp4e.operations.codeactions;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,6 +29,15 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.text.AbstractInformationControlManager;
+import org.eclipse.jface.text.ITextHover;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.ITextViewerExtension2;
+import org.eclipse.jface.text.TextViewer;
+import org.eclipse.jface.text.contentassist.ContentAssistant;
+import org.eclipse.jface.text.quickassist.IQuickAssistAssistant;
+import org.eclipse.jface.text.quickassist.QuickAssistAssistant;
+import org.eclipse.jface.text.source.ISourceViewerExtension3;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServersRegistry;
@@ -45,10 +56,13 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IMarkerResolution;
 import org.eclipse.ui.IMarkerResolution2;
 import org.eclipse.ui.IMarkerResolutionGenerator2;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.progress.ProgressInfoItem;
+import org.eclipse.ui.texteditor.ITextEditor;
 
 public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator2 {
 
@@ -63,7 +77,7 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 
 		@Override
 		public String getLabel() {
-			return Messages.computing;
+			return /*Messages.computing*/ "MARKER NOT YET..."; //$NON-NLS-1$
 		}
 
 		@Override
@@ -147,28 +161,71 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 							}));
 				}
 				List<CompletableFuture<?>> futures = new ArrayList<>();
-				for (CompletableFuture<LanguageServer> lsf : languageServerFutures) {
-					marker.setAttribute(LSP_REMEDIATION, COMPUTING);
-					Diagnostic diagnostic = (Diagnostic)marker.getAttribute(LSPDiagnosticsToMarkers.LSP_DIAGNOSTIC);
-					CodeActionContext context = new CodeActionContext(Collections.singletonList(diagnostic));
-					CodeActionParams params = new CodeActionParams();
-					params.setContext(context);
-					params.setTextDocument(new TextDocumentIdentifier(LSPEclipseUtils.toUri(marker.getResource()).toString()));
-					params.setRange(diagnostic.getRange());
-					CompletableFuture<List<Either<Command, CodeAction>>> codeAction = lsf
-							.thenComposeAsync(ls -> ls.getTextDocumentService().codeAction(params));
-					futures.add(codeAction);
-					codeAction.thenAcceptAsync(actions -> {
-						try {
-							marker.setAttribute(LSP_REMEDIATION, actions);
-						} catch (CoreException e) {
-							LanguageServerPlugin.logError(e);
+				final IEditorPart editor = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
+				if (editor instanceof ITextEditor) {
+					try {
+						Diagnostic diagnostic = (Diagnostic)marker.getAttribute(LSPDiagnosticsToMarkers.LSP_DIAGNOSTIC);
+						final ITextViewer textViewer = ((ITextEditor) editor).getAdapter(ITextViewer.class);
+						if (textViewer != null) {
+							for (CompletableFuture<LanguageServer> lsf : languageServerFutures) {
+								marker.setAttribute(LSP_REMEDIATION, COMPUTING);
+								CodeActionContext context = new CodeActionContext(Collections.singletonList(diagnostic));
+								CodeActionParams params = new CodeActionParams();
+								params.setContext(context);
+								params.setTextDocument(new TextDocumentIdentifier(LSPEclipseUtils.toUri(marker.getResource()).toString()));
+								params.setRange(diagnostic.getRange());
+								CompletableFuture<List<Either<Command, CodeAction>>> codeAction = lsf
+										.thenComposeAsync(ls -> ls.getTextDocumentService().codeAction(params));
+								futures.add(codeAction);
+								codeAction.thenAcceptAsync(actions -> {
+									try {
+										marker.setAttribute(LSP_REMEDIATION, actions);
+										PlatformUI.getWorkbench().getDisplay().asyncExec(() -> reinvokeQuickfixProposalsIfNecessary(textViewer));
+									} catch (CoreException e) {
+										LanguageServerPlugin.logError(e);
+									}
+								});
+							}
 						}
-					});
+					} catch (Exception e) {
+						LanguageServerPlugin.logError(e);
+					}
 				}
+
 				// wait a bit to avoid showing too much "Computing" without looking like a freeze
 				CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(300, TimeUnit.MILLISECONDS);
 			}
+		}
+	}
+
+	private void reinvokeQuickfixProposalsIfNecessary(ITextViewer textViewer) {
+		try {
+			// Quick assist proposals popup case
+			if (textViewer instanceof ISourceViewerExtension3) {
+				IQuickAssistAssistant quickAssistant = ((ISourceViewerExtension3)textViewer).getQuickAssistAssistant();
+					Field f = QuickAssistAssistant.class.getDeclaredField("fQuickAssistAssistantImpl"); //$NON-NLS-1$
+					f.setAccessible(true);
+					ContentAssistant ca = (ContentAssistant) f.get(quickAssistant);
+					Method m = ContentAssistant.class.getDeclaredMethod("isProposalPopupActive"); //$NON-NLS-1$
+					m.setAccessible(true);
+					boolean isProposalPopupActive = (Boolean) m.invoke(ca);
+					if (isProposalPopupActive) {
+						quickAssistant.showPossibleQuickAssists();
+					}
+			}
+			// Hover case
+			if (textViewer instanceof ITextViewerExtension2) {
+				ITextHover hover = ((ITextViewerExtension2) textViewer).getCurrentTextHover();
+				boolean hoverShowing = hover != null;
+				if (hoverShowing) {
+					Field f = TextViewer.class.getDeclaredField("fTextHoverManager"); //$NON-NLS-1$
+					f.setAccessible(true);
+					AbstractInformationControlManager manager = (AbstractInformationControlManager) f.get(textViewer);
+					manager.showInformation();
+				}
+			}
+		} catch (Exception e) {
+			LanguageServerPlugin.logError(e);
 		}
 	}
 


### PR DESCRIPTION
Adresses #123 

Draft of a possible solution. Reflection pieces can be substituted by the new API added to eclipse platform ui text. However, the first step is to check whether this is something we may use as starting point to carve the final solution.

cc: @martinlippert @mickaelistria 

**Note:** Changes to `LSPCodeActionQuickAssistProcessor` are unrelated to the issue but i feel they are common sense fix to the existing implementation.