### PR TITLE
concurrency: Ensure document changes are sent sequentially to the server

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
@@ -282,4 +282,8 @@ public class TestUtils {
 			latch.countDown();
 		}
 	}
+	
+	public static BooleanSupplier numberOfChangesIs(int changes) {
+		return () -> MockLanguageServer.INSTANCE.getDidChangeEvents().size() == changes;
+	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
@@ -12,12 +12,13 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.edit;
 
+import static org.eclipse.lsp4e.test.TestUtils.numberOfChangesIs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import java.nio.file.Files;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.eclipse.core.filesystem.EFS;
@@ -34,6 +35,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.swt.custom.StyledText;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
@@ -69,10 +71,9 @@ public class DocumentDidChangeTest {
 		});
 
 		// Test initial insert
-		CompletableFuture<DidChangeTextDocumentParams> didChangeExpectation = new CompletableFuture<DidChangeTextDocumentParams>();
-		MockLanguageServer.INSTANCE.setDidChangeCallback(didChangeExpectation);
 		viewer.getDocument().replace(0, 0, "Hello");
-		DidChangeTextDocumentParams lastChange = didChangeExpectation.get(1000, TimeUnit.MILLISECONDS);
+		TestUtils.waitForCondition(1000,  numberOfChangesIs(1));
+		DidChangeTextDocumentParams lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(0);
 		assertNotNull(lastChange.getContentChanges());
 		assertEquals(1, lastChange.getContentChanges().size());
 		TextDocumentContentChangeEvent change0 = lastChange.getContentChanges().get(0);
@@ -86,10 +87,9 @@ public class DocumentDidChangeTest {
 		assertEquals("Hello", change0.getText());
 
 		// Test additional insert
-		didChangeExpectation = new CompletableFuture<DidChangeTextDocumentParams>();
-		MockLanguageServer.INSTANCE.setDidChangeCallback(didChangeExpectation);
 		viewer.getDocument().replace(5, 0, " ");
-		lastChange = didChangeExpectation.get(1000, TimeUnit.MILLISECONDS);
+		TestUtils.waitForCondition(1000,  numberOfChangesIs(2));
+		lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(1);
 		assertNotNull(lastChange.getContentChanges());
 		assertEquals(1, lastChange.getContentChanges().size());
 		change0 = lastChange.getContentChanges().get(0);
@@ -103,10 +103,9 @@ public class DocumentDidChangeTest {
 		assertEquals(" ", change0.getText());
 
 		// test replace
-		didChangeExpectation = new CompletableFuture<DidChangeTextDocumentParams>();
-		MockLanguageServer.INSTANCE.setDidChangeCallback(didChangeExpectation);
 		viewer.getDocument().replace(0, 5, "Hallo");
-		lastChange = didChangeExpectation.get(1000, TimeUnit.MILLISECONDS);
+		TestUtils.waitForCondition(1000,  numberOfChangesIs(3));
+		lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(2);
 		assertNotNull(lastChange.getContentChanges());
 		assertEquals(1, lastChange.getContentChanges().size());
 		change0 = lastChange.getContentChanges().get(0);
@@ -138,10 +137,9 @@ public class DocumentDidChangeTest {
 		});
 
 		// Test initial insert
-		CompletableFuture<DidChangeTextDocumentParams> didChangeExpectation = new CompletableFuture<DidChangeTextDocumentParams>();
-		MockLanguageServer.INSTANCE.setDidChangeCallback(didChangeExpectation);
 		viewer.getDocument().replace("line1\nline2\n".length(), "line3\n".length(), "");
-		DidChangeTextDocumentParams lastChange = didChangeExpectation.get(1000, TimeUnit.MILLISECONDS);
+		TestUtils.waitForCondition(1000,  numberOfChangesIs(1));
+		DidChangeTextDocumentParams lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(0);
 		assertNotNull(lastChange.getContentChanges());
 		assertEquals(1, lastChange.getContentChanges().size());
 		TextDocumentContentChangeEvent change0 = lastChange.getContentChanges().get(0);
@@ -153,6 +151,26 @@ public class DocumentDidChangeTest {
 		assertEquals(0, range.getEnd().getCharacter());
 		assertEquals(Integer.valueOf(6), change0.getRangeLength());
 		assertEquals("", change0.getText());
+	}
+	
+	@Test
+	public void testIncrementalEditOrdering() throws Exception {
+		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
+		.setTextDocumentSync(TextDocumentSyncKind.Incremental);
+		IFile testFile = TestUtils.createUniqueTestFile(project, "");
+		IEditorPart editor = TestUtils.openEditor(testFile);
+		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		StyledText text = viewer.getTextWidget();
+		for (int i = 0; i < 500; i++) {
+			text.append(i + "\n");
+		}
+		TestUtils.waitForCondition(10000,  numberOfChangesIs(500));
+		List<DidChangeTextDocumentParams> changes = MockLanguageServer.INSTANCE.getDidChangeEvents();
+		for (int i = 0; i < 500; i++) {
+			String delta = changes.get(i).getContentChanges().get(0).getText();
+			assertEquals(i + "\n", delta);
+		}
+
 	}
 
 	@Test
@@ -171,21 +189,20 @@ public class DocumentDidChangeTest {
 			}
 		});
 		// Test initial insert
-		CompletableFuture<DidChangeTextDocumentParams> didChangeExpectation = new CompletableFuture<DidChangeTextDocumentParams>();
-		MockLanguageServer.INSTANCE.setDidChangeCallback(didChangeExpectation);
 		String text = "Hello";
 		viewer.getDocument().replace(0, 0, text);
-		DidChangeTextDocumentParams lastChange = didChangeExpectation.get(1000, TimeUnit.MILLISECONDS);
+		TestUtils.waitForCondition(1000,  numberOfChangesIs(1));
+		DidChangeTextDocumentParams lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(0);
 		assertNotNull(lastChange.getContentChanges());
 		assertEquals(1, lastChange.getContentChanges().size());
 		TextDocumentContentChangeEvent change0 = lastChange.getContentChanges().get(0);
 		assertEquals(text, change0.getText());
 
 		// Test additional insert
-		didChangeExpectation = new CompletableFuture<DidChangeTextDocumentParams>();
-		MockLanguageServer.INSTANCE.setDidChangeCallback(didChangeExpectation);
+
 		viewer.getDocument().replace(5, 0, " World");
-		lastChange = didChangeExpectation.get(1000, TimeUnit.MILLISECONDS);
+		TestUtils.waitForCondition(1000,  numberOfChangesIs(2));
+		lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(1);
 		assertNotNull(lastChange.getContentChanges());
 		assertEquals(1, lastChange.getContentChanges().size());
 		change0 = lastChange.getContentChanges().get(0);
@@ -207,22 +224,20 @@ public class DocumentDidChangeTest {
 				return true;
 			}
 		});
-		// Test initial insert
-		CompletableFuture<DidChangeTextDocumentParams> didChangeExpectation = new CompletableFuture<DidChangeTextDocumentParams>();
-		MockLanguageServer.INSTANCE.setDidChangeCallback(didChangeExpectation);
-		String text = "Hello";
-		viewer.getDocument().replace(0, 0, text);
-		DidChangeTextDocumentParams lastChange = didChangeExpectation.get(1000, TimeUnit.MILLISECONDS);
+        // Test initial insert
+        String text = "Hello";
+        viewer.getDocument().replace(0, 0, text);
+        TestUtils.waitForCondition(1000,  numberOfChangesIs(1));
+        DidChangeTextDocumentParams lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(0);
 		assertNotNull(lastChange.getContentChanges());
 		assertEquals(1, lastChange.getContentChanges().size());
 		TextDocumentContentChangeEvent change0 = lastChange.getContentChanges().get(0);
 		assertEquals(text, change0.getText());
 
-		// Test additional insert
-		didChangeExpectation = new CompletableFuture<DidChangeTextDocumentParams>();
-		MockLanguageServer.INSTANCE.setDidChangeCallback(didChangeExpectation);
-		viewer.getDocument().replace(5, 0, " World");
-		lastChange = didChangeExpectation.get(1000, TimeUnit.MILLISECONDS);
+        // Test additional insert
+        viewer.getDocument().replace(5, 0, " World");
+        TestUtils.waitForCondition(1000,  numberOfChangesIs(2));
+        lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(1);
 		assertNotNull(lastChange.getContentChanges());
 		assertEquals(1, lastChange.getContentChanges().size());
 		change0 = lastChange.getContentChanges().get(0);
@@ -239,4 +254,5 @@ public class DocumentDidChangeTest {
 		}
 		return syncKind;
 	}
+	
 }

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -188,8 +188,8 @@ public final class MockLanguageServer implements LanguageServer {
 		this.textDocumentService.setDidOpenCallback(didOpenExpectation);
 	}
 
-	public void setDidChangeCallback(CompletableFuture<DidChangeTextDocumentParams> didChangeExpectation) {
-		this.textDocumentService.setDidChangeCallback(didChangeExpectation);
+	public List<DidChangeTextDocumentParams> getDidChangeEvents() {
+		return this.textDocumentService.getDidChangeEvents();
 	}
 
 	public void setDidSaveCallback(CompletableFuture<DidSaveTextDocumentParams> didSaveExpectation) {

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServerMultiRootFolders.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServerMultiRootFolders.java
@@ -169,8 +169,8 @@ public final class MockLanguageServerMultiRootFolders implements LanguageServer 
 		this.textDocumentService.setDidOpenCallback(didOpenExpectation);
 	}
 
-	public void setDidChangeCallback(CompletableFuture<DidChangeTextDocumentParams> didChangeExpectation) {
-		this.textDocumentService.setDidChangeCallback(didChangeExpectation);
+	public List<DidChangeTextDocumentParams> getDidChangeEvents() {
+		return this.textDocumentService.getDidChangeEvents();
 	}
 
 	public void setDidSaveCallback(CompletableFuture<DidSaveTextDocumentParams> didSaveExpectation) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -19,13 +19,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -51,6 +54,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.services.LanguageServer;
 
 final class DocumentContentSynchronizer implements IDocumentListener {
 
@@ -62,23 +66,29 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private int version = 0;
 	private DidChangeTextDocumentParams changeParams;
 	private long modificationStamp;
-	final @NonNull CompletableFuture<Void> didOpenFuture;
+	private CompletableFuture<LanguageServer> lastChangeFuture;
+
+	/**
+ 	 * Synchronization guard to protect <code>lastChangeFuture</code> from race conditions
+ 	 */
+	private final Object syncGuard = new Object();
+	private LanguageServer languageServer;
 
 	public DocumentContentSynchronizer(@NonNull LanguageServerWrapper languageServerWrapper,
-			@NonNull IDocument document,
-			TextDocumentSyncKind syncKind) {
+			@NonNull IDocument document, TextDocumentSyncKind syncKind) {
 		this.languageServerWrapper = languageServerWrapper;
 		this.fileUri = LSPEclipseUtils.toUri(document);
-        try {
-            IFileStore store = EFS.getStore(fileUri);
-            this.modificationStamp = store.fetchInfo().getLastModified();
-        } catch (CoreException e) {
-            LanguageServerPlugin.logError(e);
-            this.modificationStamp =  new File(fileUri).lastModified();
-        }
-        this.syncKind = syncKind != null ? syncKind : TextDocumentSyncKind.Full;
+		try {
+			IFileStore store = EFS.getStore(fileUri);
+			this.modificationStamp = store.fetchInfo().getLastModified();
+		} catch (CoreException e) {
+			LanguageServerPlugin.logError(e);
+			this.modificationStamp = new File(fileUri).lastModified();
+		}
+		this.syncKind = syncKind != null ? syncKind : TextDocumentSyncKind.Full;
 
 		this.document = document;
+
 		// add a document buffer
 		TextDocumentItem textDocument = new TextDocumentItem();
 		textDocument.setUri(fileUri.toString());
@@ -98,8 +108,35 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 		textDocument.setLanguageId(languageId);
 		textDocument.setVersion(++version);
-		didOpenFuture = languageServerWrapper.getInitializedServer()
-				.thenAcceptAsync(ls -> ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument)));
+		lastChangeFuture = languageServerWrapper.getInitializedServer().thenApplyAsync(ls -> {
+			this.languageServer = ls;
+			ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument));
+			return ls;
+		});
+	}
+
+	/**
+ 	 * Submit an asynchronous call (i.e. to the language server) that be inserted into the current position w.r.t.
+ 	 * document change events
+ 	 *
+ 	 * @param <U> Computation return type
+ 	 * @param fn Asynchronous computation on the language server
+ 	 * @return Asynchronous result object.
+ 	 */
+	<U> @NonNull CompletableFuture<U> executeOnCurrentVersionAsync(
+			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
+		synchronized(syncGuard) {
+			CompletableFuture<U> valueFuture = lastChangeFuture.thenComposeAsync(fn);
+			// We ignore any exceptions that happen when executing the given future
+			lastChangeFuture = valueFuture.handle((value, error) -> {
+				return this.languageServer;
+			});
+			return valueFuture;
+		}
+	}
+
+	CompletableFuture<LanguageServer> lastChangeFuture() {
+		return lastChangeFuture;
 	}
 
 	@Override
@@ -114,8 +151,12 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			changeParams = null;
 
 			changeParamsToSend.getTextDocument().setVersion(++version);
-			languageServerWrapper.getInitializedServer()
-					.thenAcceptAsync(ls -> ls.getTextDocumentService().didChange(changeParamsToSend));
+			synchronized(syncGuard) {
+				lastChangeFuture = lastChangeFuture.thenApplyAsync(ls -> {
+					ls.getTextDocumentService().didChange(changeParamsToSend);
+					return ls;
+				});
+			}
 		}
 	}
 
@@ -130,15 +171,17 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	}
 
 	/**
-	 * Convert Eclipse {@link DocumentEvent} to LS according {@link TextDocumentSyncKind}.
-	 * {@link TextDocumentContentChangeEventImpl}.
+	 * Convert Eclipse {@link DocumentEvent} to LS according
+	 * {@link TextDocumentSyncKind}. {@link TextDocumentContentChangeEventImpl}.
 	 *
 	 * @param event
 	 *            Eclipse {@link DocumentEvent}
 	 * @return true if change event is ready to be sent
 	 */
 	private boolean createChangeEvent(DocumentEvent event) {
-		changeParams = new DidChangeTextDocumentParams(new VersionedTextDocumentIdentifier(), Collections.singletonList(new TextDocumentContentChangeEvent()));
+		Assert.isTrue(changeParams == null);
+		changeParams = new DidChangeTextDocumentParams(new VersionedTextDocumentIdentifier(),
+				Collections.singletonList(new TextDocumentContentChangeEvent()));
 		changeParams.getTextDocument().setUri(fileUri.toString());
 
 		IDocument document = event.getDocument();
@@ -203,8 +246,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		WillSaveTextDocumentParams params = new WillSaveTextDocumentParams(identifier, TextDocumentSaveReason.Manual);
 		List<TextEdit> edits = null;
 		try {
-			edits = languageServerWrapper.getInitializedServer()
-				.thenComposeAsync(ls -> ls.getTextDocumentService().willSaveWaitUntil(params))
+			edits = executeOnCurrentVersionAsync(ls -> ls.getTextDocumentService().willSaveWaitUntil(params))
 				.get(WILL_SAVE_WAIT_UNTIL_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
 		} catch (ExecutionException e) {
 			LanguageServerPlugin.logError(e);
@@ -226,32 +268,41 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	public void documentSaved(long timestamp) {
 		this.modificationStamp = timestamp;
 		ServerCapabilities serverCapabilities = languageServerWrapper.getServerCapabilities();
-		if(serverCapabilities != null ) {
-			Either<TextDocumentSyncKind, TextDocumentSyncOptions> textDocumentSync = serverCapabilities.getTextDocumentSync();
-			if(textDocumentSync.isRight() && textDocumentSync.getRight().getSave() == null) {
+		if (serverCapabilities != null) {
+			Either<TextDocumentSyncKind, TextDocumentSyncOptions> textDocumentSync = serverCapabilities
+					.getTextDocumentSync();
+			if (textDocumentSync.isRight() && textDocumentSync.getRight().getSave() == null) {
 				return;
 			}
 		}
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri.toString());
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(identifier, document.get());
-		languageServerWrapper.getInitializedServer().thenAcceptAsync(ls -> ls.getTextDocumentService().didSave(params));
+		synchronized(syncGuard) {
+			lastChangeFuture = lastChangeFuture.thenApplyAsync(ls -> {
+	  			ls.getTextDocumentService().didSave(params);
+	  			return ls;
+	  		});
+		}
 	}
 
 	public void documentClosed() {
 		String uri = fileUri.toString();
 		WILL_SAVE_WAIT_UNTIL_TIMEOUT_MAP.remove(uri);
-		// When LS is shut down all documents are being disconnected. No need to send "didClose" message to the LS that is being shut down or not yet started
+		// When LS is shut down all documents are being disconnected. No need to send
+		// "didClose" message to the LS that is being shut down or not yet started
 		if (languageServerWrapper.isActive()) {
 			TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
 			DidCloseTextDocumentParams params = new DidCloseTextDocumentParams(identifier);
-			languageServerWrapper.getInitializedServer().thenAcceptAsync(ls -> ls.getTextDocumentService().didClose(params));
+			lastChangeFuture.thenAcceptAsync(ls -> ls.getTextDocumentService().didClose(params));
 		}
 	}
 
 	/**
-	 * Returns the text document sync kind capabilities of the server and {@link TextDocumentSyncKind#Full} otherwise.
+	 * Returns the text document sync kind capabilities of the server and
+	 * {@link TextDocumentSyncKind#Full} otherwise.
 	 *
-	 * @return the text document sync kind capabilities of the server and {@link TextDocumentSyncKind#Full} otherwise.
+	 * @return the text document sync kind capabilities of the server and
+	 *         {@link TextDocumentSyncKind#Full} otherwise.
 	 */
 	private TextDocumentSyncKind getTextDocumentSyncKind() {
 		return syncKind;
@@ -271,7 +322,8 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 	private void checkEvent(DocumentEvent event) {
 		if (this.document != event.getDocument()) {
-			throw new IllegalStateException("Synchronizer should apply to only a single document, which is the one it was instantiated for"); //$NON-NLS-1$
+			throw new IllegalStateException(
+					"Synchronizer should apply to only a single document, which is the one it was instantiated for"); //$NON-NLS-1$
 		}
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -262,7 +262,11 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			LanguageServerPlugin.logError(e);
 			Thread.currentThread().interrupt();
 		}
-		LSPEclipseUtils.applyEdits(document, edits);
+		try {
+			LSPEclipseUtils.applyEdits(document, edits);
+		} catch (BadLocationException e) {
+			LanguageServerPlugin.logError(e);
+		}
 	}
 
 	public void documentSaved(long timestamp) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -869,24 +869,22 @@ public class LanguageServerWrapper {
 	}
 
 	/**
- 	 * Submit an asynchronous call (i.e. to the language server) that be inserted into the current position w.r.t.
- 	 * document change events
- 	 *
- 	 * @param <U> Computation return type
- 	 * @param file Document to serialise on
- 	 * @param fn Asynchronous computation on the language server
- 	 * @return Asynchronous result object.
- 	 */
- 	public <U> @Nullable CompletableFuture< U> executeOnCurrentVersionAsync(IFile file,
- 			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
- 		if (file != null && file.getLocation() != null) {
- 			DocumentContentSynchronizer documentContentSynchronizer = connectedDocuments.get(file.getLocationURI());
- 			if (documentContentSynchronizer != null) {
- 				return documentContentSynchronizer.executeOnCurrentVersionAsync(fn);
- 			}
- 		}
- 		return null;
- 	}
+	 * Submit an asynchronous call (i.e. to the language server) that be inserted into the current position w.r.t.
+	 * document change events
+	 *
+	 * @param <U> Computation return type
+	 * @param file Document to serialise on
+	 * @param fn Asynchronous computation on the language server
+	 * @return Asynchronous result object.
+	 */
+	<U> @Nullable CompletableFuture< U> executeOnCurrentVersionAsync(URI uri,
+			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
+		DocumentContentSynchronizer documentContentSynchronizer = connectedDocuments.get(uri);
+		if (documentContentSynchronizer != null) {
+			return documentContentSynchronizer.executeOnCurrentVersionAsync(fn);
+		}
+		return null;
+	}
 
 
 	public boolean canOperate(@NonNull IDocument document) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -29,7 +29,9 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -139,6 +141,17 @@ public class LanguageServiceAccessor {
 		public boolean isActive() {
 			return this.wrapper.isActive();
 		}
+
+		/**
+ 		 * Submit an asynchronous call (i.e. to the language server) that will be inserted into the current
+ 		 * stream of document change events
+ 		 *
+ 		 * @see org.eclipse.lsp4e.LanguageServerWrapper#executeOnCurrentVersionAsync
+ 		 */
+		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(
+ 				Function<LanguageServer, ? extends CompletionStage<U>> fn) {
+ 			return this.wrapper.executeOnCurrentVersionAsync(LSPEclipseUtils.getFile(document), fn);
+ 		}
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -150,7 +150,7 @@ public class LanguageServiceAccessor {
  		 */
 		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(
  				Function<LanguageServer, ? extends CompletionStage<U>> fn) {
- 			return this.wrapper.executeOnCurrentVersionAsync(LSPEclipseUtils.getFile(document), fn);
+ 			return this.wrapper.executeOnCurrentVersionAsync(this.fileUri, fn);
  		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -41,7 +41,11 @@ import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
 public class LSPFormatter {
 
 	public void applyEdits(IDocument document, List<? extends TextEdit> edits) {
-		LSPEclipseUtils.applyEdits(document, edits);
+		try {
+			LSPEclipseUtils.applyEdits(document, edits);
+		} catch (BadLocationException e) {
+			LanguageServerPlugin.logError(e);
+		}
 	}
 
 	public CompletableFuture<List<? extends TextEdit>> requestFormatting(@NonNull IDocument document,


### PR DESCRIPTION
As discussed on the lsp4e-dev mailing list, these are some fixes we made internally to try and address some weird behaviour we used to get, particularly under load. The existing implementation submits document update events to a thread pool where they may get scheduled in any order. This can cause the client's and server's view of the state of a document to diverge, resulting in phantom error markers and so on.

This work was originally submitted in https://github.com/eclipse/lsp4e/pull/121 but with more extensive changes that have proved contentious. As agreed, I have cut this down to a minimal fix for serialising document updates and providing a mechanism for other code that wants/needs to be inserted into that stream of events.
