### PR TITLE
Testing: use TestUtils.createTempFile

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -431,22 +430,18 @@ public class LanguageServiceAccessorTest {
 
 	@Test
 	public void testLSforExternalThenLocalFile() throws Exception {
-		File local = File.createTempFile("testLSforExternalThenLocalFile", ".lspt");
-		try {
-			ITextEditor editor = (ITextEditor) IDE.openEditorOnFileStore(
-					PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(local.toURI()));
-			Assert.assertEquals(1, LanguageServiceAccessor.getLanguageServers(
-					TestUtils.getTextViewer(editor).getDocument(), this::hasHoverCapabilities).get().size());
-			PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
-			// opening another file should either reuse the LS or spawn another one, but not
-			// both
-			Assert.assertEquals(1,
-					LanguageServiceAccessor.getLanguageServers(
-							TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "")).getDocument(),
-							this::hasHoverCapabilities).get().size());
-		} finally {
-			Files.deleteIfExists(local.toPath());
-		}
+		File local = TestUtils.createTempFile("testLSforExternalThenLocalFile", ".lspt");
+		ITextEditor editor = (ITextEditor) IDE.openEditorOnFileStore(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(local.toURI()));
+		Assert.assertEquals(1, LanguageServiceAccessor.getLanguageServers(
+				TestUtils.getTextViewer(editor).getDocument(), this::hasHoverCapabilities).get().size());
+		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
+		// opening another file should either reuse the LS or spawn another one, but not
+		// both
+		Assert.assertEquals(1,
+				LanguageServiceAccessor.getLanguageServers(
+						TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "")).getDocument(),
+						this::hasHoverCapabilities).get().size());
 	}
 
 	private boolean hasHoverCapabilities(ServerCapabilities capabilities) {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
@@ -13,7 +13,6 @@ package org.eclipse.lsp4e.test.color;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.nio.file.Files;
 import java.util.Collections;
 
 import org.eclipse.core.filesystem.EFS;
@@ -64,24 +63,20 @@ public class ColorTest {
 
 	@Test
 	public void testColorProviderExternalFile() throws Exception {
-		File file = File.createTempFile("testColorProviderExternalFile", ".lspt");
-		try {
-			try (
-				FileOutputStream out = new FileOutputStream(file);
-			) {
-				out.write("\u2588\u2588\u2588\u2588\u2588".getBytes());
-			}
-			ITextViewer viewer = TestUtils.getTextViewer(IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
-			StyledText widget = viewer.getTextWidget();
-			Assert.assertTrue(new DisplayHelper() {
-				@Override
-				protected boolean condition() {
-					return containsColor(widget, color, 10);
-				}
-			}.waitForCondition(widget.getDisplay(), 3000));
-		} finally {
-			Files.deleteIfExists(file.toPath());
+		File file = TestUtils.createTempFile("testColorProviderExternalFile", ".lspt");
+		try (
+			FileOutputStream out = new FileOutputStream(file);
+		) {
+			out.write("\u2588\u2588\u2588\u2588\u2588".getBytes());
 		}
+		ITextViewer viewer = TestUtils.getTextViewer(IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
+		StyledText widget = viewer.getTextWidget();
+		Assert.assertTrue(new DisplayHelper() {
+			@Override
+			protected boolean condition() {
+				return containsColor(widget, color, 10);
+			}
+		}.waitForCondition(widget.getDisplay(), 3000));
 	}
 
 	/**

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
@@ -525,18 +525,14 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		items.add(createCompletionItem("FirstClassExternal", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		File file = File.createTempFile("testCompletionExternalFile", ".lspt");
-		try {
-			ITextEditor editor = (ITextEditor) IDE.openEditorOnFileStore(
-					PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-			ITextViewer viewer = TestUtils.getTextViewer(editor);
-			ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
-			assertEquals(1, proposals.length);
-			proposals[0].apply(viewer.getDocument());
-			assertEquals("FirstClassExternal", viewer.getDocument().get());
-		} finally {
-			file.delete();
-		}
+		File file = TestUtils.createTempFile("testCompletionExternalFile", ".lspt");
+		ITextEditor editor = (ITextEditor) IDE.openEditorOnFileStore(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
+		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
+		assertEquals(1, proposals.length);
+		proposals[0].apply(viewer.getDocument());
+		assertEquals("FirstClassExternal", viewer.getDocument().get());
 	}
 
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -100,17 +99,13 @@ public class DefinitionTest {
 		Location location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(location));
 
-		File file = File.createTempFile("testDocumentLinkExternalFile", ".lspt");
-		try {
-			ITextEditor editor = (ITextEditor) IDE.openInternalEditorOnFileStore(
-					PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-			ITextViewer viewer = TestUtils.getTextViewer(editor);
+		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
+		ITextEditor editor = (ITextEditor) IDE.openInternalEditorOnFileStore(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
+		ITextViewer viewer = TestUtils.getTextViewer(editor);
 
-			IHyperlink[] hyperlinks = hyperlinkDetector.detectHyperlinks(viewer, new Region(0, 0), true);
-			assertEquals(1, hyperlinks.length);
-		} finally {
-			Files.deleteIfExists(file.toPath());
-		}
+		IHyperlink[] hyperlinks = hyperlinkDetector.detectHyperlinks(viewer, new Region(0, 0), true);
+		assertEquals(1, hyperlinks.length);
 	}
 	
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -193,7 +192,7 @@ public class DiagnosticsTest {
 	@Test
 	public void testDiagnosticsOnExternalFile() throws Exception {
 		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(new Diagnostic(new Range(new Position(0, 0), new Position(0, 1)), "This is a warning", DiagnosticSeverity.Warning, null)));
-		File file = File.createTempFile("testDiagnosticsOnExternalFile", ".lspt");
+		File file = TestUtils.createTempFile("testDiagnosticsOnExternalFile", ".lspt");
 		Font font = null;
 		try {
 			try (
@@ -218,7 +217,6 @@ public class DiagnosticsTest {
 				}
 			}.waitForCondition(widget.getDisplay(), 3000));
 		} finally {
-			Files.deleteIfExists(file.toPath());
 			if (font != null) {
 				font.dispose();
 			}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -81,18 +80,14 @@ public class DocumentLinkTest {
 		links.add(new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file://test0"));
 		MockLanguageServer.INSTANCE.setDocumentLinks(links);
 
-		File file = File.createTempFile("testDocumentLinkExternalFile", ".lspt");
-		try {
-			ITextEditor editor = (ITextEditor) IDE.openInternalEditorOnFileStore(
-					PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-			ITextViewer viewer = TestUtils.getTextViewer(editor);
-	
-			IHyperlink[] hyperlinks = documentLinkDetector.detectHyperlinks(viewer, new Region(13, 0), true);
-			assertEquals(1, hyperlinks.length);
-			assertEquals("file://test0", hyperlinks[0].getHyperlinkText());
-		} finally {
-			Files.deleteIfExists(file.toPath());
-		}
+		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
+		ITextEditor editor = (ITextEditor) IDE.openInternalEditorOnFileStore(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
+		ITextViewer viewer = TestUtils.getTextViewer(editor);
+
+		IHyperlink[] hyperlinks = documentLinkDetector.detectHyperlinks(viewer, new Region(13, 0), true);
+		assertEquals(1, hyperlinks.length);
+		assertEquals("file://test0", hyperlinks[0].getHyperlinkText());
 	}
 
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidCloseTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidCloseTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -59,24 +58,20 @@ public class DocumentDidCloseTest {
 
 	@Test
 	public void testCloseExternalFile() throws Exception {
-		File testFile = File.createTempFile("testCloseExternalFile", ".lspt");
-		try {
-			IEditorPart editor = IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(testFile.toURI()));
-	
-			// Force LS to initialize and open file
-			LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(editor.getEditorInput()), capabilites -> Boolean.TRUE);
-	
-			CompletableFuture<DidCloseTextDocumentParams> didCloseExpectation = new CompletableFuture<DidCloseTextDocumentParams>();
-			MockLanguageServer.INSTANCE.setDidCloseCallback(didCloseExpectation);
-	
-			TestUtils.closeEditor(editor, false);
-	
-			DidCloseTextDocumentParams lastChange = didCloseExpectation.get(1000, TimeUnit.MILLISECONDS);
-			assertNotNull(lastChange.getTextDocument());
-			assertEquals(LSPEclipseUtils.toUri(testFile).toString(), lastChange.getTextDocument().getUri());
-		} finally {
-			Files.deleteIfExists(testFile.toPath());
-		}
+		File testFile = TestUtils.createTempFile("testCloseExternalFile", ".lspt");
+		IEditorPart editor = IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(testFile.toURI()));
+
+		// Force LS to initialize and open file
+		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(editor.getEditorInput()), capabilites -> Boolean.TRUE);
+
+		CompletableFuture<DidCloseTextDocumentParams> didCloseExpectation = new CompletableFuture<DidCloseTextDocumentParams>();
+		MockLanguageServer.INSTANCE.setDidCloseCallback(didCloseExpectation);
+
+		TestUtils.closeEditor(editor, false);
+
+		DidCloseTextDocumentParams lastChange = didCloseExpectation.get(1000, TimeUnit.MILLISECONDS);
+		assertNotNull(lastChange.getTextDocument());
+		assertEquals(LSPEclipseUtils.toUri(testFile).toString(), lastChange.getTextDocument().getUri());
 	}
 
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidOpenTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidOpenTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -66,20 +65,16 @@ public class DocumentDidOpenTest {
 
 	@Test
 	public void testOpenExternalFile() throws Exception {
-		File file = File.createTempFile("testOpenExternalFile", ".lspt");
-		try {
-			CompletableFuture<DidOpenTextDocumentParams> didOpenExpectation = new CompletableFuture<DidOpenTextDocumentParams>();
-			MockLanguageServer.INSTANCE.setDidOpenCallback(didOpenExpectation);
-			IEditorPart editor = IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-			// Force LS to initialize and open file
-			LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(editor.getEditorInput()), capabilites -> Boolean.TRUE);
-	
-			DidOpenTextDocumentParams lastOpen = didOpenExpectation.get(1000, TimeUnit.MILLISECONDS);
-			assertNotNull(lastOpen.getTextDocument());
-			assertEquals("lspt", lastOpen.getTextDocument().getLanguageId());
-		} finally {
-			Files.deleteIfExists(file.toPath());
-		}
+		File file = TestUtils.createTempFile("testOpenExternalFile", ".lspt");
+		CompletableFuture<DidOpenTextDocumentParams> didOpenExpectation = new CompletableFuture<DidOpenTextDocumentParams>();
+		MockLanguageServer.INSTANCE.setDidOpenCallback(didOpenExpectation);
+		IEditorPart editor = IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
+		// Force LS to initialize and open file
+		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(editor.getEditorInput()), capabilites -> Boolean.TRUE);
+
+		DidOpenTextDocumentParams lastOpen = didOpenExpectation.get(1000, TimeUnit.MILLISECONDS);
+		assertNotNull(lastOpen.getTextDocument());
+		assertEquals("lspt", lastOpen.getTextDocument().getLanguageId());
 	}
 
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -395,7 +395,7 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testTextEditDoesntAutomaticallySaveOpenExternalFiles() throws Exception {
-		File file = File.createTempFile("testTextEditDoesntAutomaticallySaveOpenExternalFiles", ".whatever");
+		File file = TestUtils.createTempFile("testTextEditDoesntAutomaticallySaveOpenExternalFiles", ".whatever");
 		IEditorPart editor = IDE.openInternalEditorOnFileStore(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
 		TextEdit te = new TextEdit();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -31,7 +30,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.internal.text.html.BrowserInformationControl;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
-import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.lsp4e.operations.hover.LSPTextHover;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -49,6 +47,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -139,14 +138,10 @@ public class HoverTest {
 				new Range(new Position(0, 0), new Position(0, 0)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
-		File file = File.createTempFile("testHoverOnExternalfile", ".lspt");
-		try {
-			ITextViewer viewer = TestUtils.getTextViewer(IDE.openInternalEditorOnFileStore(
-					PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
-			Assert.assertTrue(hover.getHoverInfo(viewer, new Region(0, 0)).contains("blah"));
-		} finally {
-			Files.deleteIfExists(file.toPath());
-		}
+		File file = TestUtils.createTempFile("testHoverOnExternalfile", ".lspt");
+		ITextViewer viewer = TestUtils.getTextViewer(IDE.openInternalEditorOnFileStore(
+				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
+		Assert.assertTrue(hover.getHoverInfo(viewer, new Region(0, 0)).contains("blah"));
 	}
 
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
@@ -63,6 +63,8 @@ public class OutlineContentTest {
 				new Range(new Position(2, 0), new Position(2, 2)),
 				new Range(new Position(2, 0), new Position(2, 2)));
 
+		MockLanguageServer.INSTANCE.setDocumentSymbols(symbolCow, symbolFox, symbolCat);
+
 		// ensure outline sorting is disabled
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(LanguageServerPlugin.PLUGIN_ID);
 		prefs.putBoolean(CNFOutlinePage.SORT_OUTLINE_PREFERENCE, false);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
@@ -58,16 +58,12 @@ public class LSPTextChangeTest {
 
 	@Test
 	public void testPerformOperationExternalFile() throws Exception {
-		File file = File.createTempFile("testPerformOperationExternalFile", ".lspt");
-		try {
-			Files.write(file.toPath(), "old".getBytes());
-			TextEdit edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
-			PerformChangeOperation operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
-			operation.run(new NullProgressMonitor());
-			assertEquals(edit.getNewText(), new String(Files.readAllBytes(file.toPath())));
-		} finally {
-			Files.deleteIfExists(file.toPath());
-		}
+		File file = TestUtils.createTempFile("testPerformOperationExternalFile", ".lspt");
+		Files.write(file.toPath(), "old".getBytes());
+		TextEdit edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
+		PerformChangeOperation operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
+		operation.run(new NullProgressMonitor());
+		assertEquals(edit.getNewText(), new String(Files.readAllBytes(file.toPath())));
 	}
 
 }


### PR DESCRIPTION
in place of File.createTempFile, so we are sure the file gets cleared
and don't have to deal with cleanup as part of the test (done in the
AllClentRule)