### PR TITLE
concurrency: Bail out of changes if inconsistency detected

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -220,7 +220,11 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			LanguageServerPlugin.logError(e);
 			Thread.currentThread().interrupt();
 		}
-		LSPEclipseUtils.applyEdits(document, edits);
+		try {
+			LSPEclipseUtils.applyEdits(document, edits);
+		} catch (BadLocationException e) {
+			LanguageServerPlugin.logError(e);
+		}
 	}
 
 	public void documentSaved(long timestamp) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -41,7 +41,11 @@ import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
 public class LSPFormatter {
 
 	public void applyEdits(IDocument document, List<? extends TextEdit> edits) {
-		LSPEclipseUtils.applyEdits(document, edits);
+		try {
+			LSPEclipseUtils.applyEdits(document, edits);
+		} catch (BadLocationException e) {
+			LanguageServerPlugin.logError(e);
+		}
 	}
 
 	public CompletableFuture<List<? extends TextEdit>> requestFormatting(@NonNull IDocument document,


### PR DESCRIPTION
If the server sends back a bad location then it may be that the server's and the client's view of a document have
got out of sync. Abort set of changes rather than risk applying nonsensical changes and corrupting the document.
Split out of preceding commit following review.