### PR TITLE
handlers: Scope lsp4e handlers to language server-enabled editors

### DIFF
--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -91,7 +91,7 @@
       <handler
             class="org.eclipse.lsp4e.operations.references.LSFindReferences"
             commandId="org.eclipse.ui.genericeditor.findReferences">
-         <enabledWhen>
+         <activeWhen>
             <and>
                <with
                      variable="selection">
@@ -99,8 +99,14 @@
                         value="org.eclipse.jface.text.ITextSelection">
                   </instanceof>
                </with>
+               <with
+                     variable="activeEditorInput">
+                  <test
+                        property="org.eclipse.lsp4e.hasLanguageServer">
+                  </test>
+               </with>
             </and>
-         </enabledWhen>
+         </activeWhen>
       </handler>
       <handler
             class="org.eclipse.lsp4e.operations.rename.LSPRenameHandler"
@@ -113,13 +119,19 @@
                         value="org.eclipse.jface.text.ITextSelection">
                   </instanceof>
                </with>
+               <with
+                     variable="activeEditorInput">
+                  <test
+                        property="org.eclipse.lsp4e.hasLanguageServer">
+                  </test>
+               </with>
             </and>
          </activeWhen>
       </handler>
       <handler
             class="org.eclipse.lsp4e.operations.format.LSPFormatHandler"
             commandId="org.eclipse.lsp4e.format">
-         <enabledWhen>
+         <activeWhen>
             <and>
                <with
                      variable="selection">
@@ -127,8 +139,14 @@
                         value="org.eclipse.jface.text.ITextSelection">
                   </instanceof>
                </with>
+               <with
+                     variable="activeEditorInput">
+                  <test
+                        property="org.eclipse.lsp4e.hasLanguageServer">
+                  </test>
+               </with>
             </and>
-         </enabledWhen>
+         </activeWhen>
       </handler>
       <handler
             class="org.eclipse.lsp4e.operations.symbols.LSPSymbolInFileHandler"


### PR DESCRIPTION
I think the command handlers for lsp4e are scoped too widely - whenever text is generally selected in an editor. Restricting this to editors that actually have the language server enabled for them, and also using `activeWhen` rather than `enabledWhen` more consistently: I think the former is intended for controlling whether plugins have any interest at all in the current view/editor, and the latter for deciding whether a command makes sense or not for the detailed selection.
