### PR TITLE
WillSaveWaitUntil: Handle null for optional boolean server capability

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -215,7 +215,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			Either<TextDocumentSyncKind, TextDocumentSyncOptions> textDocumentSync = serverCapabilities.getTextDocumentSync();
 			if(textDocumentSync.isRight()) {
 				TextDocumentSyncOptions saveOptions = textDocumentSync.getRight();
-				return saveOptions != null && saveOptions.getWillSaveWaitUntil();
+				return saveOptions != null && Boolean.TRUE.equals(saveOptions.getWillSaveWaitUntil());
 			}
 		}
 		return false;


### PR DESCRIPTION
Ran into this one with the new support for DocumentWillSaveWaitUntil. Our language server doesn't support it yet and is not setting anything for the server capability rather than sending 'false'. I think this is legal as it's an optional property, so just need to handle the possible null.
