### PR TITLE
formatting: ensure formatting requests are sequenced wrt updates

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -119,7 +119,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
  	 * @param fn Asynchronous computation on the language server
  	 * @return Asynchronous result object.
  	 */
-	private <U> @NonNull CompletableFuture<U> executeOnCurrentVersionAsync(
+	<U> @NonNull CompletableFuture<U> executeOnCurrentVersionAsync(
 			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
 		AtomicReference<CompletableFuture<U>> resValueFuture = new AtomicReference<>();
 		lastChangeFuture.updateAndGet(f -> {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -31,12 +31,14 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -516,6 +518,24 @@ public class LanguageServerWrapper {
 			if (uri != null) {
 				return connect(LSPEclipseUtils.toUri(document), document);
 			}
+		}
+		return null;
+	}
+
+	/**
+	 * Submit an asynchronous call (i.e. to the language server) that be inserted into the current position w.r.t.
+	 * document change events
+	 *
+	 * @param <U> Computation return type
+	 * @param file Document to serialise on
+	 * @param fn Asynchronous computation on the language server
+	 * @return Asynchronous result object.
+	 */
+	<U> @Nullable CompletableFuture< U> executeOnCurrentVersionAsync(URI uri,
+			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
+		DocumentContentSynchronizer documentContentSynchronizer = connectedDocuments.get(uri);
+		if (documentContentSynchronizer != null) {
+			return documentContentSynchronizer.executeOnCurrentVersionAsync(fn);
 		}
 		return null;
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -29,7 +29,9 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -139,6 +141,17 @@ public class LanguageServiceAccessor {
 		public boolean isActive() {
 			return this.wrapper.isActive();
 		}
+
+		/**
+  		 * Submit an asynchronous call (i.e. to the language server) that will be inserted into the current
+  		 * stream of document change events
+  		 *
+  		 * @see org.eclipse.lsp4e.LanguageServerWrapper#executeOnCurrentVersionAsync
+  		 */
+ 		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(
+  				Function<LanguageServer, ? extends CompletionStage<U>> fn) {
+  			return this.wrapper.executeOnCurrentVersionAsync(this.fileUri, fn);
+  		}
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -86,8 +86,7 @@ public class LSPFormatter {
 					fullFormat ? info.getDocument().getLength() : textSelection.getOffset() + textSelection.getLength(),
 					info.getDocument());
 			params.setRange(new Range(start, end));
-			return info.getInitializedLanguageClient()
-					.thenComposeAsync(server -> server.getTextDocumentService().rangeFormatting(params));
+			return info.executeOnCurrentVersionAsync(server -> server.getTextDocumentService().rangeFormatting(params));
 		}
 
 		DocumentFormattingParams params = new DocumentFormattingParams();


### PR DESCRIPTION
This was originally part of the concurrency fixes we submitted: I lost track of what eventually made it into the reduced PR and forgot to resubmit this change independently.

We needed to make a fix along these lines as without it it's possible for formatting requests to become interleaved with in-flight document change notifications and the document to become garbled.
