### PR TITLE
Remove NPE in LanguageServiceAccessor.getLSWrapper(IProject,

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -547,7 +547,7 @@ public class LanguageServerWrapper {
 	 * @return whether this language server can operate on the given project
 	 * @since 0.5
 	 */
-	public boolean canOperate(IProject project) {
+	public boolean canOperate(@NonNull IProject project) {
 		return project.equals(this.initialProject) || serverDefinition.isSingleton || supportsWorkspaceFolderCapability();
 	}
 


### PR DESCRIPTION
LanguageServerDefinition, IPath) when the project is null and there are
started language server wrappers.