### PR TITLE
LanguageServiceAccessor: Rework thread-safe access to startedServers to prevent dead locks

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
@@ -337,7 +337,7 @@ public class LanguageServersRegistry {
 	 * @return the {@link LanguageServerDefinition}s <strong>directly</strong> associated to the given content-type.
 	 * This does <strong>not</strong> include the one that match transitively as per content-type hierarchy
 	 */
-	List<ContentTypeToLanguageServerDefinition> findProviderFor(final @NonNull IContentType contentType) {
+	List<@NonNull ContentTypeToLanguageServerDefinition> findProviderFor(final @NonNull IContentType contentType) {
 		return connections.stream()
 			.filter(entry -> entry.getKey().equals(contentType))
 			.sorted((mapping1, mapping2) -> {


### PR DESCRIPTION
This is my proposal to address the dead lock issues reported via #161 and #22.

The deadlock occurs when `LSPFoldingReconciler` or `CodeMiningReconciler` are triggered in background threads at the same time when text is modified in the UI thread.

Both executions end up in acquiring a lock on the `SynchronizableDocument` as well as on the `LanguageServiceAccessor.startedServers` field. Unfortunately in case of the Reconcilers first the lock on the `startedServers` field is acquired and then some underlying internal Eclipse platform code tries to get a lock on the document, whereas in case of text modifications in the UI thread first the document gets locked and then it is attempted to acquire the `startedServers` field. Because of race conditions this can lead to deadlocks.

Here is an example:
```python
"main":
        at org.eclipse.lsp4e.LanguageServiceAccessor.getLSWrappers(LanguageServiceAccessor.java:350)
        - waiting to lock <0x000000070ab59c48> (a java.util.HashSet) # <-- SECOND: locking the serversStarted field is attempted
        at org.eclipse.lsp4e.LanguageServiceAccessor.getLanguageServers(LanguageServiceAccessor.java:601)
        at org.eclipse.lsp4e.operations.linkedediting.LSPLinkedEditingBase.collectLinkedEditingRanges(LSPLinkedEditingBase.java:71)
        at org.eclipse.lsp4e.operations.linkedediting.LSPLinkedEditingReconcilingStrategy.updateLinkedEditing(LSPLinkedEditingReconcilingStrategy.java:179)
        at org.eclipse.lsp4e.operations.linkedediting.LSPLinkedEditingReconcilingStrategy.documentChanged(LSPLinkedEditingReconcilingStrategy.java:168)
        at org.eclipse.jface.text.AbstractDocument.doFireDocumentChanged2(AbstractDocument.java:748)
        at org.eclipse.jface.text.AbstractDocument.fireDocumentChanged(AbstractDocument.java:775)
        at org.eclipse.core.internal.filebuffers.SynchronizableDocument.replace(SynchronizableDocument.java:164)
        - locked <0x000000070222b270> (a java.lang.Object) # <-- FIRST: document is locked
        at org.eclipse.jface.text.projection.ProjectionTextStore.replace(ProjectionTextStore.java:106)
        at org.eclipse.jface.text.AbstractDocument.replace(AbstractDocument.java:1093)
        at org.eclipse.jface.text.DefaultDocumentAdapter.replaceTextRange(DefaultDocumentAdapter.java:223)
        at org.eclipse.swt.custom.StyledText.modifyContent(StyledText.java:7639)
        at org.eclipse.swt.custom.StyledText.sendKeyEvent(StyledText.java:8539)
        at org.eclipse.swt.custom.StyledText.paste(StyledText.java:7713)

"org.eclipse.lsp4e.operations.folding.LSPFoldingReconciler":
        at org.eclipse.core.internal.filebuffers.SynchronizableDocument.getChar(SynchronizableDocument.java:140)
        - waiting to lock <0x000000070222b270> (a java.lang.Object)# <-- SECOND: locking the serversStarted field is attempted
        at org.eclipse.core.internal.filebuffers.DocumentReader$DocumentCharSequence.charAt(DocumentReader.java:66)
        at org.eclipse.core.internal.filebuffers.DocumentReader.read(DocumentReader.java:171)
        at org.eclipse.wst.xml.core.internal.contenttype.XMLResourceEncodingDetector.parseInput(XMLResourceEncodingDetector.java:79)
        at org.eclipse.wst.xml.core.internal.contenttype.ContentDescriberForXML.determineValidity(ContentDescriberForXML.java:119)
        at org.eclipse.wst.xml.core.internal.contenttype.ContentDescriberForXML.describe(ContentDescriberForXML.java:77)
        at org.eclipse.core.internal.content.ContentTypeCatalog.collectMatchingByContents(ContentTypeCatalog.java:226)
        at org.eclipse.core.internal.content.ContentTypeMatcher.getDescriptionFor(ContentTypeMatcher.java:87)
        at org.eclipse.core.internal.filebuffers.ResourceTextFileBuffer.getContentType(ResourceTextFileBuffer.java:196)
        at org.eclipse.lsp4e.LSPEclipseUtils.getDocumentContentTypes(LSPEclipseUtils.java:934)
        at org.eclipse.lsp4e.LanguageServersRegistry.matches(LanguageServersRegistry.java:433)
        at org.eclipse.lsp4e.LanguageServiceAccessor.lambda$5(LanguageServiceAccessor.java:355)
        at org.eclipse.lsp4e.LanguageServiceAccessor.getLSWrappers(LanguageServiceAccessor.java:362)
        - locked <0x000000070ab59c48> (a java.util.HashSet) # <-- FIRST: document is locked
        at org.eclipse.lsp4e.LanguageServiceAccessor.getLanguageServers(LanguageServiceAccessor.java:601)
        at org.eclipse.lsp4e.operations.folding.LSPFoldingReconcilingStrategy.reconcile(LSPFoldingReconcilingStrategy.java:126)
```

My attempt to solve it or to make a deadlock situation much less likely is by reducing the need for acquiring a lock on the `startedServers` field only to situations where a matching Language Server is not yet running. Currently for any lookup the field lock is acquired.

To achieve this I first use a thread-safe collection type for `startedServers` to prevent any potential ConcurrentModificationExceptions during read access. And second I only guard code blocks that may modify the `startedServers` field in a double-check-locking style.

For code review I suggest to only check this commit with the ignore white space changes option turned on: [1f3b5565fcdb1d51464139d99e884fa498b34a37?w=1](https://github.com/eclipse/lsp4e/pull/167/commits/1f3b5565fcdb1d51464139d99e884fa498b34a37?w=1)