### PR TITLE
Improve tests

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.13.12.qualifier
+Bundle-Version: 0.13.13.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.13.12-SNAPSHOT</version>
+	<version>0.13.13-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -13,14 +13,10 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -76,7 +72,7 @@ public class LanguageServiceAccessorTest {
 	}
 
 	@Test
-	public void testGetLSWrapper() throws IOException, CoreException {
+	public void testGetLSWrapper() throws IOException {
 		LanguageServerDefinition serverDefinition = LanguageServersRegistry.getInstance().getDefinition("org.eclipse.lsp4e.test.server");
 		assertNotNull(serverDefinition);
 		LanguageServerWrapper lsWrapper = LanguageServiceAccessor.getLSWrapper(project, serverDefinition);
@@ -90,13 +86,13 @@ public class LanguageServiceAccessorTest {
 	}
 
 	@Test
-	public void testGetLSPDocumentInfoForInvalidTextEditor() throws CoreException, InvocationTargetException {
+	public void testGetLSPDocumentInfoForInvalidTextEditor() throws CoreException {
 		IFile testFile = TestUtils.createFile(project, "not_associated_with_ls.abc", "");
 		ITextViewer textViewer = TestUtils.openTextViewer(testFile);
 		Collection<LSPDocumentInfo> infos = LanguageServiceAccessor.getLSPDocumentInfosFor(textViewer.getDocument(), capabilities -> Boolean.TRUE);
 		assertTrue(infos.isEmpty());
 	}
-	
+
 	@Test
 	public void testGetLanguageServerInvalidFile() throws Exception {
 		IFile testFile = TestUtils.createFile(project, "not_associated_with_ls.abc", "");
@@ -124,17 +120,17 @@ public class LanguageServiceAccessorTest {
 				.get(1, TimeUnit.SECONDS);
 		assertNotNull(info);
 	}
-	
+
 	@Test
 	public void testLSAsExtensionForDifferentLanguageId() throws Exception {
 		IFile testFile = TestUtils.createFile(project, "shouldUseExtension.lspt-different", "");		@NonNull
 		Collection<LanguageServerWrapper> lsWrappers = LanguageServiceAccessor.getLSWrappers(testFile,
 				capabilites -> Boolean.TRUE);
-		
+
 		assertEquals(1, lsWrappers.size());
 		LanguageServerWrapper wrapper = lsWrappers.iterator().next();
 		assertNotNull(wrapper);
-		
+
 		IContentType contentType = Platform.getContentTypeManager().getContentType("org.eclipse.lsp4e.test.content-type-different");
 		assertEquals("differentLanguageId", wrapper.getLanguageId(new IContentType[] {contentType}));
 	}
@@ -189,7 +185,7 @@ public class LanguageServiceAccessorTest {
 
 		((AbstractTextEditor) editor1).close(false);
 		((AbstractTextEditor) editor2).close(false);
-		
+
 		new LSDisplayHelper(() -> LanguageServiceAccessor.getActiveLanguageServers(capabilities -> Boolean.TRUE).size() == 0)
 				.waitForCondition(display, 5000);
 		assertEquals(0, LanguageServiceAccessor.getActiveLanguageServers(capabilities -> Boolean.TRUE).size());
@@ -287,16 +283,16 @@ public class LanguageServiceAccessorTest {
 		assertEquals(1, wrappers1.size());
 		LanguageServerWrapper wrapper1 = wrappers1.iterator().next();
 		assertTrue(wrapper1.isActive());
-		
+
 		wrapper1.disconnect(testFile1.getLocationURI());
 		assertFalse(wrapper1.isActive());
-		
+
 		Collection<LanguageServerWrapper> wrappers2 = LanguageServiceAccessor.getLSWrappers(testFile2,
 				c -> Boolean.TRUE);
 		assertEquals(1, wrappers2.size());
 		LanguageServerWrapper wrapper2 = wrappers2.iterator().next();
 		assertTrue(wrapper2.isActive());
-		
+
 		// make sure the language server for testFile1 (which is unrelated to testFile2 is not started again)
 		assertFalse(wrapper1.isActive());
 
@@ -332,7 +328,7 @@ public class LanguageServiceAccessorTest {
 		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
 		assertFalse(wrapper.isActive());
 	}
-	
+
 	@Test
 	public void testLastDocumentDisconnectedTimeoutZero() throws Exception {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
@@ -356,7 +352,7 @@ public class LanguageServiceAccessorTest {
 		assertEquals("org.eclipse.lsp4e.test.server2", iterator.next().serverDefinition.id);
 		assertEquals("org.eclipse.lsp4e.test.server", iterator.next().serverDefinition.id);
 	}
-		
+
 	@Test
 	public void testLanguageServerHierarchy_parentContentTypeUsed() throws Exception {
 		// file with a content-type whose parent (only) is associated to one LS
@@ -398,7 +394,7 @@ public class LanguageServiceAccessorTest {
 		IFile file = TestUtils.createUniqueTestFile(project, "lspt-tester", "");
 		assertTrue(LanguageServiceAccessor.getLSWrappers(file, capabilities -> true).isEmpty());
 		MappingEnablementTester.enabled = true;
-		
+
 		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(file, capabilities -> true);
 		assertEquals(1, wrappers.size());
 		assertEquals("org.eclipse.lsp4e.test.server.disable", wrappers.iterator().next().serverDefinition.id);
@@ -434,7 +430,7 @@ public class LanguageServiceAccessorTest {
 		ITextEditor editor = (ITextEditor) IDE.openEditorOnFileStore(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(local.toURI()));
 		Assert.assertEquals(1, LanguageServiceAccessor.getLanguageServers(
-				TestUtils.getTextViewer(editor).getDocument(), this::hasHoverCapabilities).get().size());
+				LSPEclipseUtils.getTextViewer(editor).getDocument(), this::hasHoverCapabilities).get().size());
 		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
 		// opening another file should either reuse the LS or spawn another one, but not
 		// both

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -13,19 +13,19 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test;
 
+import static org.eclipse.lsp4e.LSPEclipseUtils.*;
+import static org.eclipse.lsp4e.LanguageServiceAccessor.*;
+import static org.eclipse.lsp4e.test.TestUtils.*;
 import static org.junit.Assert.*;
 
-import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import org.eclipse.core.filesystem.EFS;
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -34,203 +34,171 @@ import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.internal.core.IInternalDebugCoreConstants;
 import org.eclipse.debug.internal.core.Preferences;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.text.Document;
-import org.eclipse.jface.text.ITextViewer;
-import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
-import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServersRegistry;
-import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.LanguageServiceAccessor.LSPDocumentInfo;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServerMultiRootFolders;
-import org.eclipse.lsp4j.HoverOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.services.LanguageServer;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.eclipse.ui.texteditor.ITextEditor;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class LanguageServiceAccessorTest {
 
-	@Rule public AllCleanRule clear = new AllCleanRule();
+	private static final Predicate<ServerCapabilities> MATCH_ALL = capabilities -> true;
+
+	@Rule
+	public AllCleanRule clear = new AllCleanRule();
 	private IProject project;
 
 	@Before
 	public void setUp() throws CoreException {
-		project = TestUtils.createProject("LanguageServiceAccessorTest" + System.currentTimeMillis());
+		project = createProject("LanguageServiceAccessorTest" + System.currentTimeMillis());
 	}
 
 	@Test
 	public void testGetLSWrapper() throws IOException {
-		LanguageServerDefinition serverDefinition = LanguageServersRegistry.getInstance().getDefinition("org.eclipse.lsp4e.test.server");
+		var serverDefinition = LanguageServersRegistry.getInstance().getDefinition("org.eclipse.lsp4e.test.server");
 		assertNotNull(serverDefinition);
-		LanguageServerWrapper lsWrapper = LanguageServiceAccessor.getLSWrapper(project, serverDefinition);
+
+		var lsWrapper = getLSWrapper(project, serverDefinition);
 		assertNotNull(lsWrapper);
 	}
 
 	@Test
 	public void testGetLSPDocumentInfoForInvalidDocument() {
-		Collection<LSPDocumentInfo> infos = LanguageServiceAccessor.getLSPDocumentInfosFor(new Document(), null);
+		var infos = getLSPDocumentInfosFor(new Document(), MATCH_ALL);
 		assertTrue(infos.isEmpty());
 	}
 
 	@Test
 	public void testGetLSPDocumentInfoForInvalidTextEditor() throws CoreException {
-		IFile testFile = TestUtils.createFile(project, "not_associated_with_ls.abc", "");
-		ITextViewer textViewer = TestUtils.openTextViewer(testFile);
-		Collection<LSPDocumentInfo> infos = LanguageServiceAccessor.getLSPDocumentInfosFor(textViewer.getDocument(), capabilities -> Boolean.TRUE);
+		var testFile = createFile(project, "not_associated_with_ls.abc", "");
+		var textViewer = openTextViewer(testFile);
+		var infos = getLSPDocumentInfosFor(textViewer.getDocument(), MATCH_ALL);
 		assertTrue(infos.isEmpty());
 	}
 
 	@Test
 	public void testGetLanguageServerInvalidFile() throws Exception {
-		IFile testFile = TestUtils.createFile(project, "not_associated_with_ls.abc", "");
-		Collection<LanguageServer> servers = new ArrayList<>();
-		for (CompletableFuture<LanguageServer> future :LanguageServiceAccessor.getInitializedLanguageServers(testFile, capabilites -> Boolean.TRUE)){
-			servers.add(future.get(1, TimeUnit.SECONDS));
-		}
-		assertTrue(servers.isEmpty());
+		var testFile = createFile(project, "not_associated_with_ls.abc", "");
+		assertEmpty(getInitializedLanguageServers(testFile, MATCH_ALL));
 	}
 
 	@Test
 	public void testLSAsExtension() throws Exception {
-		IFile testFile = TestUtils.createFile(project, "shouldUseExtension.lspt", "");
-		LanguageServer info = LanguageServiceAccessor
-				.getInitializedLanguageServers(testFile, capabilites -> Boolean.TRUE).iterator().next()
-				.get(1, TimeUnit.SECONDS);
-		assertNotNull(info);
+		var testFile = createFile(project, "shouldUseExtension.lspt", "");
+		var ls = getInitializedLanguageServers(testFile, MATCH_ALL).get(0).get(2, TimeUnit.SECONDS);
+		assertNotNull(ls);
 	}
 
 	@Test
 	public void testLSAsRunConfiguration() throws Exception {
-		IFile testFile = TestUtils.createFile(project, "shouldUseRunConfiguration.lspt2", "");
-		LanguageServer info = LanguageServiceAccessor
-				.getInitializedLanguageServers(testFile, capabilites -> Boolean.TRUE).iterator().next()
-				.get(1, TimeUnit.SECONDS);
-		assertNotNull(info);
+		var testFile = createFile(project, "shouldUseRunConfiguration.lspt2", "");
+		var ls = getInitializedLanguageServers(testFile, MATCH_ALL).get(0).get(2, TimeUnit.SECONDS);
+		assertNotNull(ls);
 	}
 
 	@Test
 	public void testLSAsExtensionForDifferentLanguageId() throws Exception {
-		IFile testFile = TestUtils.createFile(project, "shouldUseExtension.lspt-different", "");		@NonNull
-		Collection<LanguageServerWrapper> lsWrappers = LanguageServiceAccessor.getLSWrappers(testFile,
-				capabilites -> Boolean.TRUE);
-
+		var testFile = createFile(project, "shouldUseExtension.lspt-different", "");
+		var lsWrappers = getLSWrappers(testFile, MATCH_ALL);
 		assertEquals(1, lsWrappers.size());
-		LanguageServerWrapper wrapper = lsWrappers.iterator().next();
+
+		var wrapper = lsWrappers.iterator().next();
 		assertNotNull(wrapper);
 
-		IContentType contentType = Platform.getContentTypeManager().getContentType("org.eclipse.lsp4e.test.content-type-different");
-		assertEquals("differentLanguageId", wrapper.getLanguageId(new IContentType[] {contentType}));
+		var contentType = Platform.getContentTypeManager()
+				.getContentType("org.eclipse.lsp4e.test.content-type-different");
+		assertEquals("differentLanguageId", wrapper.getLanguageId(new IContentType[] { contentType }));
 	}
 
 	@Test
 	public void testGetLSWrappersInitializationFailed() throws Exception {
-		IFile testFile = TestUtils.createFile(project, "fileWithFailedServer.lsptWithException", "");
-		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile,
-				capabilites -> Boolean.TRUE);
+		var testFile = createFile(project, "fileWithFailedServer.lsptWithException", "");
+		var wrappers = getLSWrappers(testFile, MATCH_ALL);
 		assertEquals(1, wrappers.size());
 	}
 
 	@Test
 	public void testReuseSameLSforMultiContentType() throws Exception {
-		IFile testFile1 = TestUtils.createUniqueTestFile(project, "");
-		IFile testFile2 = TestUtils.createUniqueTestFileMultiLS(project, "");
-		// wrap in HashSet as a workaround of https://github.com/eclipse/lsp4j/issues/106
-		Collection<LanguageServer> file1LanguageServers = new ArrayList<>();
-		for (CompletableFuture<LanguageServer> future : LanguageServiceAccessor.getInitializedLanguageServers(testFile1,
-				capabilites -> Boolean.TRUE)) {
-			file1LanguageServers.add(future.get(1, TimeUnit.SECONDS));
-		}
+		var testFile1 = createUniqueTestFile(project, "");
+		var testFile2 = createUniqueTestFileMultiLS(project, "");
+
+		var file1LanguageServers = getInitializedLanguageServers(testFile1, MATCH_ALL);
 		assertEquals(1, file1LanguageServers.size());
-		LanguageServer file1LS = file1LanguageServers.iterator().next();
-		Collection<LanguageServer> file2LanguageServers = new ArrayList<>();
-		for (CompletableFuture<LanguageServer> future : LanguageServiceAccessor.getInitializedLanguageServers(testFile2,
-				capabilites -> Boolean.TRUE)) {
-			file2LanguageServers.add(future.get(1, TimeUnit.SECONDS));
+
+		var file2LanguageServers = new ArrayList<>();
+		for (var future : getInitializedLanguageServers(testFile2, MATCH_ALL)) {
+			file2LanguageServers.add(future.get(2, TimeUnit.SECONDS));
 		}
 		assertEquals(2, file2LanguageServers.size());
+
+		var file1LS = file1LanguageServers.get(0).get(2, TimeUnit.SECONDS);
 		assertTrue(file2LanguageServers.contains(file1LS)); // LS from file1 is reused
-		assertEquals("Not right amount of language servers bound to project", 2, LanguageServiceAccessor.getLanguageServers(project, c -> Boolean.TRUE).size());
+
+		assertEquals("Not right amount of language servers bound to project", 2,
+				getLanguageServers(project, MATCH_ALL).size());
 	}
 
 	@Test
 	public void testGetOnlyRunningLanguageServers() throws Exception {
-		Display display = Display.getCurrent();
+		var testFile1 = createUniqueTestFile(project, "");
+		var testFile2 = createUniqueTestFile(project, "lspt-different", "");
 
-		IFile testFile1 = TestUtils.createUniqueTestFile(project, "");
-		IFile testFile2 = TestUtils.createUniqueTestFile(project, "lspt-different", "");
+		var editor1 = openEditor(testFile1);
+		var editor2 = openEditor(testFile2);
 
-		IEditorPart editor1 = TestUtils.openEditor(testFile1);
-		IEditorPart editor2 = TestUtils.openEditor(testFile2);
+		assertNotEmpty(getInitializedLanguageServers(testFile1, MATCH_ALL));
+		assertNotEmpty(getInitializedLanguageServers(testFile2, MATCH_ALL));
 
-		LanguageServiceAccessor.getInitializedLanguageServers(testFile1, capabilities -> Boolean.TRUE).iterator()
-				.next();
-		LanguageServiceAccessor.getInitializedLanguageServers(testFile2, capabilities -> Boolean.TRUE).iterator()
-				.next();
-
-		List<LanguageServer> runningServers = LanguageServiceAccessor.getActiveLanguageServers(capabilities -> Boolean.TRUE);
+		var runningServers = getActiveLanguageServers(MATCH_ALL);
 		assertEquals(2, runningServers.size());
 
 		((AbstractTextEditor) editor1).close(false);
 		((AbstractTextEditor) editor2).close(false);
 
-		new LSDisplayHelper(() -> LanguageServiceAccessor.getActiveLanguageServers(capabilities -> Boolean.TRUE).size() == 0)
-				.waitForCondition(display, 5000);
-		assertEquals(0, LanguageServiceAccessor.getActiveLanguageServers(capabilities -> Boolean.TRUE).size());
+		waitForCondition(5_000, () -> getActiveLanguageServers(MATCH_ALL).isEmpty());
+		assertEquals(0, getActiveLanguageServers(MATCH_ALL).size());
 
-		editor1 = TestUtils.openEditor(testFile1);
-		LanguageServiceAccessor.getInitializedLanguageServers(testFile1, capabilities -> Boolean.TRUE).iterator()
-				.next();
+		editor1 = openEditor(testFile1);
+		assertNotEmpty(getInitializedLanguageServers(testFile1, MATCH_ALL));
 
-		new LSDisplayHelper(() -> LanguageServiceAccessor.getActiveLanguageServers(capabilities -> Boolean.TRUE).size() == 1)
-				.waitForCondition(display, 5000);
-		assertEquals(1, LanguageServiceAccessor.getActiveLanguageServers(capabilities -> Boolean.TRUE).size());
+		waitForCondition(5_000, () -> getActiveLanguageServers(MATCH_ALL).size() == 1);
+		assertEquals(1, getActiveLanguageServers(MATCH_ALL).size());
 	}
 
 	@Test
 	public void testCreateNewLSAfterInitialProjectGotDeleted() throws Exception {
-		IFile testFile1 = TestUtils.createUniqueTestFile(project, "");
+		var testFile1 = createUniqueTestFile(project, "");
 
-		TestUtils.openEditor(testFile1);
-		LanguageServiceAccessor.getInitializedLanguageServers(testFile1, capabilities -> Boolean.TRUE).iterator()
-				.next();
-		new LSDisplayHelper(() -> MockLanguageServer.INSTANCE.isRunning()).waitForCondition(Display.getCurrent(), 5000,
-				300);
+		openEditor(testFile1);
+		assertNotEmpty(getInitializedLanguageServers(testFile1, MATCH_ALL));
+		waitForCondition(5_000, () -> MockLanguageServer.INSTANCE.isRunning());
 
-		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile1,
-				c -> Boolean.TRUE);
-		LanguageServerWrapper wrapper1 = wrappers.iterator().next();
+		var wrappers = getLSWrappers(testFile1, MATCH_ALL);
+		var wrapper1 = wrappers.iterator().next();
 		assertTrue(wrapper1.isActive());
 
 		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
-		new LSDisplayHelper(() -> !MockLanguageServer.INSTANCE.isRunning()).waitForCondition(Display.getCurrent(), 5000,
-				300);
+		waitForCondition(5_000, () -> !MockLanguageServer.INSTANCE.isRunning());
 
 		project.delete(true, true, new NullProgressMonitor());
 
-		project = TestUtils.createProject("LanguageServiceAccessorTest2" + System.currentTimeMillis());
-		IFile testFile2 = TestUtils.createUniqueTestFile(project, "");
+		project = createProject("LanguageServiceAccessorTest2" + System.currentTimeMillis());
+		var testFile2 = createUniqueTestFile(project, "");
 
-		TestUtils.openEditor(testFile2);
-		LanguageServiceAccessor.getInitializedLanguageServers(testFile2, capabilities -> Boolean.TRUE).iterator()
-				.next();
-		new LSDisplayHelper(() -> MockLanguageServer.INSTANCE.isRunning()).waitForCondition(Display.getCurrent(), 5000,
-				300);
+		openEditor(testFile2);
+		assertNotEmpty(getInitializedLanguageServers(testFile2, MATCH_ALL));
+		waitForCondition(5_000, () -> MockLanguageServer.INSTANCE.isRunning());
 
-		wrappers = LanguageServiceAccessor.getLSWrappers(testFile2, c -> Boolean.TRUE);
-		LanguageServerWrapper wrapper2 = wrappers.iterator().next();
+		wrappers = getLSWrappers(testFile2, MATCH_ALL);
+		var wrapper2 = wrappers.iterator().next();
 		assertTrue(wrapper2.isActive());
 
 		assertTrue(wrapper1 != wrapper2);
@@ -238,36 +206,30 @@ public class LanguageServiceAccessorTest {
 
 	@Test
 	public void testReuseMultirootFolderLSAfterInitialProjectGotDeleted() throws Exception {
-		IFile testFile1 = TestUtils.createUniqueTestFile(project, "lsptWithMultiRoot", "");
+		var testFile1 = createUniqueTestFile(project, "lsptWithMultiRoot", "");
 
-		TestUtils.openEditor(testFile1);
-		LanguageServiceAccessor.getInitializedLanguageServers(testFile1, capabilities -> Boolean.TRUE).iterator()
-				.next();
-		new LSDisplayHelper(() -> MockLanguageServerMultiRootFolders.INSTANCE.isRunning())
-				.waitForCondition(Display.getCurrent(), 5000, 300);
+		openEditor(testFile1);
+		assertNotEmpty(getInitializedLanguageServers(testFile1, MATCH_ALL));
+		waitForCondition(5_000, () -> MockLanguageServerMultiRootFolders.INSTANCE.isRunning());
 
-		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile1,
-				c -> Boolean.TRUE);
-		LanguageServerWrapper wrapper1 = wrappers.iterator().next();
+		var wrappers = getLSWrappers(testFile1, MATCH_ALL);
+		var wrapper1 = wrappers.iterator().next();
 		assertTrue(wrapper1.isActive());
 
 		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
-		new LSDisplayHelper(() -> !MockLanguageServerMultiRootFolders.INSTANCE.isRunning())
-				.waitForCondition(Display.getCurrent(), 5000, 300);
+		waitForCondition(5_000, () -> !MockLanguageServerMultiRootFolders.INSTANCE.isRunning());
 
 		project.delete(true, true, new NullProgressMonitor());
 
-		project = TestUtils.createProject("LanguageServiceAccessorTest2" + System.currentTimeMillis());
-		IFile testFile2 = TestUtils.createUniqueTestFile(project, "lsptWithMultiRoot", "");
+		project = createProject("LanguageServiceAccessorTest2" + System.currentTimeMillis());
+		var testFile2 = createUniqueTestFile(project, "lsptWithMultiRoot", "");
 
-		TestUtils.openEditor(testFile2);
-		LanguageServiceAccessor.getInitializedLanguageServers(testFile2, capabilities -> Boolean.TRUE).iterator()
-				.next();
-		new LSDisplayHelper(() -> MockLanguageServerMultiRootFolders.INSTANCE.isRunning())
-				.waitForCondition(Display.getCurrent(), 5000, 300);
+		openEditor(testFile2);
+		assertNotEmpty(getInitializedLanguageServers(testFile2, MATCH_ALL));
+		waitForCondition(5_000, () -> MockLanguageServerMultiRootFolders.INSTANCE.isRunning());
 
-		wrappers = LanguageServiceAccessor.getLSWrappers(testFile2, c -> Boolean.TRUE);
-		LanguageServerWrapper wrapper2 = wrappers.iterator().next();
+		wrappers = getLSWrappers(testFile2, MATCH_ALL);
+		var wrapper2 = wrappers.iterator().next();
 		assertTrue(wrapper2.isActive());
 
 		assertTrue(wrapper1 == wrapper2);
@@ -275,22 +237,22 @@ public class LanguageServiceAccessorTest {
 
 	@Test
 	public void testDontRestartUnrelatedLSForFileFromSameProject() throws Exception {
-		IFile testFile1 = TestUtils.createUniqueTestFile(project, "");
-		IFile testFile2 = TestUtils.createUniqueTestFile(project, "lspt-different", "");
+		var testFile1 = createUniqueTestFile(project, "");
+		var testFile2 = createUniqueTestFile(project, "lspt-different", "");
 
-		Collection<LanguageServerWrapper> wrappers1 = LanguageServiceAccessor.getLSWrappers(testFile1,
-				c -> Boolean.TRUE);
+		var wrappers1 = getLSWrappers(testFile1, MATCH_ALL);
 		assertEquals(1, wrappers1.size());
-		LanguageServerWrapper wrapper1 = wrappers1.iterator().next();
+
+		var wrapper1 = wrappers1.iterator().next();
 		assertTrue(wrapper1.isActive());
 
 		wrapper1.disconnect(testFile1.getLocationURI());
 		assertFalse(wrapper1.isActive());
 
-		Collection<LanguageServerWrapper> wrappers2 = LanguageServiceAccessor.getLSWrappers(testFile2,
-				c -> Boolean.TRUE);
+		var wrappers2 = getLSWrappers(testFile2, MATCH_ALL);
 		assertEquals(1, wrappers2.size());
-		LanguageServerWrapper wrapper2 = wrappers2.iterator().next();
+
+		var wrapper2 = wrappers2.iterator().next();
 		assertTrue(wrapper2.isActive());
 
 		// make sure the language server for testFile1 (which is unrelated to testFile2 is not started again)
@@ -301,41 +263,46 @@ public class LanguageServiceAccessorTest {
 
 	@Test
 	public void testLastDocumentDisconnectedTimeoutManualStop() throws Exception {
-		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptWithLastDocumentDisconnectedTimeout", "");
+		var testFile = createUniqueTestFile(project, "lsptWithLastDocumentDisconnectedTimeout", "");
 
-		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);
+		var wrappers = getLSWrappers(testFile, MATCH_ALL);
 		assertEquals(1, wrappers.size());
-		LanguageServerWrapper wrapper = wrappers.iterator().next();
+
+		var wrapper = wrappers.iterator().next();
 		assertTrue(wrapper.isActive());
 
 		wrapper.disconnect(testFile.getLocationURI());
 		assertTrue(wrapper.isActive());
+
 		wrapper.stop();
 		assertFalse(wrapper.isActive());
 	}
 
 	@Test
 	public void testLastDocumentDisconnectedTimeoutTimerStop() throws Exception {
-		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptWithLastDocumentDisconnectedTimeout", "");
+		var testFile = createUniqueTestFile(project, "lsptWithLastDocumentDisconnectedTimeout", "");
 
-		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);
+		var wrappers = getLSWrappers(testFile, MATCH_ALL);
 		assertEquals(1, wrappers.size());
-		LanguageServerWrapper wrapper = wrappers.iterator().next();
+
+		var wrapper = wrappers.iterator().next();
 		assertTrue(wrapper.isActive());
 
 		wrapper.disconnect(testFile.getLocationURI());
 		assertTrue(wrapper.isActive());
+
 		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
 		assertFalse(wrapper.isActive());
 	}
 
 	@Test
 	public void testLastDocumentDisconnectedTimeoutZero() throws Exception {
-		IFile testFile = TestUtils.createUniqueTestFile(project, "");
+		var testFile = createUniqueTestFile(project, "");
 
-		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile, c -> Boolean.TRUE);
+		var wrappers = getLSWrappers(testFile, MATCH_ALL);
 		assertEquals(1, wrappers.size());
-		LanguageServerWrapper wrapper = wrappers.iterator().next();
+
+		var wrapper = wrappers.iterator().next();
 		assertTrue(wrapper.isActive());
 
 		wrapper.disconnect(testFile.getLocationURI());
@@ -345,10 +312,9 @@ public class LanguageServiceAccessorTest {
 	@Test
 	public void testLanguageServerHierarchy_moreSpecializedFirst() throws Exception {
 		// file with a content-type and a parent, each associated to one LS
-		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptchild", "");
-		@NonNull Collection<LanguageServerWrapper> servers = LanguageServiceAccessor.getLSWrappers(testFile,
-				c -> Boolean.TRUE);
-		Iterator<LanguageServerWrapper> iterator = servers.iterator();
+		var testFile = createUniqueTestFile(project, "lsptchild", "");
+		var servers = getLSWrappers(testFile, MATCH_ALL);
+		var iterator = servers.iterator();
 		assertEquals("org.eclipse.lsp4e.test.server2", iterator.next().serverDefinition.id);
 		assertEquals("org.eclipse.lsp4e.test.server", iterator.next().serverDefinition.id);
 	}
@@ -356,111 +322,102 @@ public class LanguageServiceAccessorTest {
 	@Test
 	public void testLanguageServerHierarchy_parentContentTypeUsed() throws Exception {
 		// file with a content-type whose parent (only) is associated to one LS
-		IFile testFile = TestUtils.createUniqueTestFile(project, "lsptchildNoLS", "");
-		@NonNull Collection<LanguageServerWrapper> servers = LanguageServiceAccessor.getLSWrappers(testFile,
-				c -> Boolean.TRUE);
-		Iterator<LanguageServerWrapper> iterator = servers.iterator();
+		var testFile = createUniqueTestFile(project, "lsptchildNoLS", "");
+		var servers = getLSWrappers(testFile, MATCH_ALL);
+		var iterator = servers.iterator();
 		assertEquals("org.eclipse.lsp4e.test.server", iterator.next().serverDefinition.id);
 		assertFalse("Should only be a single LS", iterator.hasNext());
 	}
 
 	@Test
 	public void testLanguageServerEnablement() throws Exception {
-		LanguageServerPlugin.getDefault().getPreferenceStore().setValue(
-				"org.eclipse.lsp4e.test.server.disable" + "/" + "org.eclipse.lsp4e.test.content-type-disabled",
-				"false");
-		IFile disabledFile = TestUtils.createUniqueTestFile(project, "lspt-disabled", "");
-		IFile enabledFile = TestUtils.createUniqueTestFile(project, "lspt-enabled", "");
+		final var serverId = ContentTypeToLanguageServerDefinitionTest.SERVER_TO_DISABLE;
+		final var prefKey = serverId + "/" + "org.eclipse.lsp4e.test.content-type-disabled";
+		LanguageServerPlugin.getDefault().getPreferenceStore().setValue(prefKey, Boolean.FALSE.toString());
 
-		LanguageServiceAccessor.getLSWrappers(disabledFile, capabilities -> true).stream().forEach(
-				wrapper -> assertFalse(wrapper.serverDefinition.id.equals("org.eclipse.lsp4e.test.server.disable")));
-		assertTrue(LanguageServiceAccessor.getLSWrappers(enabledFile, capabilities -> true).stream()
-				.filter(wrapper -> wrapper.serverDefinition.id.equals("org.eclipse.lsp4e.test.server.disable"))
-				.findFirst().isPresent());
+		var disabledFile = createUniqueTestFile(project, "lspt-disabled", "");
+		assertFalse(getLSWrappers(disabledFile, MATCH_ALL).stream().filter(w -> w.serverDefinition.id.equals(serverId))
+				.findAny().isPresent());
 
-		LanguageServerPlugin.getDefault().getPreferenceStore().setValue(
-				"org.eclipse.lsp4e.test.server.disable" + "/" + "org.eclipse.lsp4e.test.content-type-disabled",
-				"true");
-		assertTrue(LanguageServiceAccessor.getLSWrappers(disabledFile, capabilities -> true).stream()
-				.filter(wrapper -> wrapper.serverDefinition.id.equals("org.eclipse.lsp4e.test.server.disable"))
-				.findFirst().isPresent());
-		assertTrue(LanguageServiceAccessor.getLSWrappers(enabledFile, capabilities -> true).stream()
-				.filter(wrapper -> wrapper.serverDefinition.id.equals("org.eclipse.lsp4e.test.server.disable"))
-				.findFirst().isPresent());
+		var enabledFile = createUniqueTestFile(project, "lspt-enabled", "");
+		assertTrue(getLSWrappers(enabledFile, MATCH_ALL).stream().filter(w -> w.serverDefinition.id.equals(serverId))
+				.findAny().isPresent());
+
+		LanguageServerPlugin.getDefault().getPreferenceStore().setValue(prefKey, Boolean.TRUE.toString());
+
+		assertTrue(getLSWrappers(disabledFile, MATCH_ALL).stream().filter(w -> w.serverDefinition.id.equals(serverId))
+				.findAny().isPresent());
+		assertTrue(getLSWrappers(enabledFile, MATCH_ALL).stream().filter(w -> w.serverDefinition.id.equals(serverId))
+				.findAny().isPresent());
 	}
 
 	@Test
 	public void testLanguageServerEnablementTester() throws Exception {
-		IFile file = TestUtils.createUniqueTestFile(project, "lspt-tester", "");
-		assertTrue(LanguageServiceAccessor.getLSWrappers(file, capabilities -> true).isEmpty());
+		final var serverId = ContentTypeToLanguageServerDefinitionTest.SERVER_TO_DISABLE;
+
+		var file = createUniqueTestFile(project, "lspt-tester", "");
+		assertTrue(getLSWrappers(file, MATCH_ALL).isEmpty());
 		MappingEnablementTester.enabled = true;
 
-		Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(file, capabilities -> true);
+		var wrappers = getLSWrappers(file, MATCH_ALL);
 		assertEquals(1, wrappers.size());
-		assertEquals("org.eclipse.lsp4e.test.server.disable", wrappers.iterator().next().serverDefinition.id);
+		assertEquals(serverId, wrappers.iterator().next().serverDefinition.id);
 	}
 
 	@Test
 	public void testStatusHandlerLSAsRunConfiguration() throws Exception {
-		// test which checks that status handler preferences is kept after the launch is
-		// done.
-		IFile testFile = TestUtils.createFile(project, "shouldUseRunConfiguration.lspt2", "");
+		// test which checks that status handler preferences is kept after the launch is done.
+		var testFile = createFile(project, "shouldUseRunConfiguration.lspt2", "");
 
 		// Test with default status handler (see DebugPlugin#getStatusHandler)
-		boolean oldStatusHandler = getStatusHandler();
-		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(testFile), null).get(1, TimeUnit.SECONDS);
-		assertEquals(getStatusHandler(), oldStatusHandler);
+		var oldStatusHandler = isStatusHandlersEnabled();
+		getLanguageServers(getDocument(testFile), null).get(2, TimeUnit.SECONDS);
+		assertEquals(isStatusHandlersEnabled(), oldStatusHandler);
 
 		// Test with status handler set to false
-		setStatusHandler(false);
-		oldStatusHandler = getStatusHandler();
-		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(testFile), null).get(1, TimeUnit.SECONDS);
-		assertEquals(getStatusHandler(), false);
+		setStatusHandlersEnabled(false);
+		oldStatusHandler = isStatusHandlersEnabled();
+		getLanguageServers(getDocument(testFile), null).get(2, TimeUnit.SECONDS);
+		assertEquals(isStatusHandlersEnabled(), false);
 
 		// Test with status handler set to true
-		setStatusHandler(true);
-		oldStatusHandler = getStatusHandler();
-		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(testFile), null).get(1, TimeUnit.SECONDS);
-		assertEquals(getStatusHandler(), true);
+		setStatusHandlersEnabled(true);
+		oldStatusHandler = isStatusHandlersEnabled();
+		getLanguageServers(getDocument(testFile), null).get(2, TimeUnit.SECONDS);
+		assertEquals(isStatusHandlersEnabled(), true);
 	}
 
 	@Test
 	public void testLSforExternalThenLocalFile() throws Exception {
-		File local = TestUtils.createTempFile("testLSforExternalThenLocalFile", ".lspt");
-		ITextEditor editor = (ITextEditor) IDE.openEditorOnFileStore(
-				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(local.toURI()));
-		Assert.assertEquals(1, LanguageServiceAccessor.getLanguageServers(
-				LSPEclipseUtils.getTextViewer(editor).getDocument(), this::hasHoverCapabilities).get().size());
-		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().closeAllEditors(false);
-		// opening another file should either reuse the LS or spawn another one, but not
-		// both
-		Assert.assertEquals(1,
-				LanguageServiceAccessor.getLanguageServers(
-						TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "")).getDocument(),
-						this::hasHoverCapabilities).get().size());
-	}
+		var wb = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		var local = createTempFile("testLSforExternalThenLocalFile", ".lspt");
+		var editor = (ITextEditor) IDE.openEditorOnFileStore(wb.getActivePage(), EFS.getStore(local.toURI()));
 
-	private boolean hasHoverCapabilities(ServerCapabilities capabilities) {
-		Either<Boolean, HoverOptions> hoverProvider = capabilities.getHoverProvider();
-		if(hoverProvider.isLeft()) {
-			return hoverProvider.getLeft();
-		} else {
-			return hoverProvider.getRight() != null;
-		}
+		Predicate<ServerCapabilities> hasHoverCapabilities = capabilities -> {
+			var hoverProvider = capabilities.getHoverProvider();
+			return hoverProvider.isLeft() ? hoverProvider.getLeft() : hoverProvider.getRight() != null;
+		};
+
+		assertEquals(1, getLanguageServers(getTextViewer(editor).getDocument(), hasHoverCapabilities).get().size());
+		wb.getActivePage().closeAllEditors(false);
+		// opening another file should either reuse the LS or spawn another one, but not both
+		assertEquals(1, getLanguageServers( //
+				openTextViewer(createUniqueTestFile(project, "")).getDocument(), hasHoverCapabilities).get().size());
 	}
 
 	@Test
 	public void testSingletonLS() throws Exception {
-		IFile testFile1 = TestUtils.createFile(project, "shouldUseSingletonLS.lsp-singletonLS", "");
-		IProject project2 = TestUtils.createProject("project2");
-		IFile testFile2 = TestUtils.createFile(project2, "shouldUseSingletonLS2.lsp-singletonLS", "");
-		@NonNull CompletableFuture<List<@NonNull LanguageServer>> languageServers = LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(testFile1), cap -> true);
-		@NonNull CompletableFuture<List<@NonNull LanguageServer>> languageServers2 = LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(testFile2), cap -> true);
-		Assert.assertEquals(1, languageServers.get().size());
-		Assert.assertEquals(languageServers.get(), languageServers2.get());
+		var testFile1 = createFile(project, "shouldUseSingletonLS.lsp-singletonLS", "");
+		var languageServers = getLanguageServers(getDocument(testFile1), MATCH_ALL);
+
+		var project2 = createProject("project2");
+		var testFile2 = createFile(project2, "shouldUseSingletonLS2.lsp-singletonLS", "");
+		var languageServers2 = getLanguageServers(getDocument(testFile2), MATCH_ALL);
+		assertEquals(1, languageServers.get().size());
+		assertEquals(languageServers.get(), languageServers2.get());
 	}
 
-	private static boolean getStatusHandler() {
+	private static boolean isStatusHandlersEnabled() {
 		return Platform.getPreferencesService().getBoolean(DebugPlugin.getUniqueIdentifier(),
 				IInternalDebugCoreConstants.PREF_ENABLE_STATUS_HANDLERS, true, null);
 	}
@@ -471,8 +428,16 @@ public class LanguageServiceAccessorTest {
 	 * @param enabled
 	 *            the status handler preferences
 	 */
-	private static void setStatusHandler(boolean enabled) {
+	private static void setStatusHandlersEnabled(boolean enabled) {
 		Preferences.setBoolean(DebugPlugin.getUniqueIdentifier(),
 				IInternalDebugCoreConstants.PREF_ENABLE_STATUS_HANDLERS, enabled, null);
+	}
+
+	private static <T> void assertEmpty(Collection<T> coll) {
+		assertTrue("Given collection is expected to be empty! " + coll, coll.isEmpty());
+	}
+
+	private static <T> void assertNotEmpty(Collection<T> coll) {
+		assertFalse("Given collection must not be empty!", coll.isEmpty());
 	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/RunningLanguageServerTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/RunningLanguageServerTest.java
@@ -11,11 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -93,7 +90,7 @@ public class RunningLanguageServerTest {
 	}
 
 	@Test
-	public void testBug535887DisabledWithMultipleOpenFiles() throws CoreException, InvocationTargetException {
+	public void testBug535887DisabledWithMultipleOpenFiles() throws CoreException {
 		ContentTypeToLanguageServerDefinition lsDefinition = TestUtils.getDisabledLS();
 		lsDefinition.setUserEnabled(true);
 		LanguageServiceAccessor.enableLanguageServerContentType(lsDefinition, TestUtils.getEditors());

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -48,7 +49,7 @@ public class ColorTest {
 		color = new RGB(56, 78, 90); // a color that's not likely used anywhere else
 		MockLanguageServer.INSTANCE.getTextDocumentService().setDocumentColors(Collections.singletonList(new ColorInformation(new Range(new Position(0, 0), new Position(0, 1)), new Color(color.red / 255., color.green / 255., color.blue / 255., 255))));
 	}
-	
+
 	@Test
 	public void testColorProvider() throws Exception {
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(TestUtils.createProject("testColorProvider"), "\u2588\u2588\u2588\u2588\u2588"));
@@ -69,7 +70,7 @@ public class ColorTest {
 		) {
 			out.write("\u2588\u2588\u2588\u2588\u2588".getBytes());
 		}
-		ITextViewer viewer = TestUtils.getTextViewer(IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
 		StyledText widget = viewer.getTextWidget();
 		Assert.assertTrue(new DisplayHelper() {
 			@Override
@@ -110,12 +111,12 @@ public class ColorTest {
 		System.err.println("Smallest dRGB was " + bestYet);
 		return false;
 	}
-	
+
 	private static int distance(RGB from, RGB to) {
 		final int dR = from.red - to.red;
 		final int dG = from.green - to.green;
 		final int dB = from.blue - to.blue;
-		
+
 		return (int) Math.sqrt((dR * dR + dG * dG + dB * dB) / 3);
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/AbstractCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/AbstractCompletionTest.java
@@ -11,9 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.completion;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,7 +37,7 @@ import org.junit.Before;
 import org.junit.Rule;
 
 public abstract class AbstractCompletionTest {
-	
+
 	@Rule public AllCleanRule clear = new AllCleanRule();
 	protected IProject project;
 	protected LSContentAssistProcessor contentAssistProcessor;
@@ -60,7 +59,7 @@ public abstract class AbstractCompletionTest {
 		item.setTextEdit(Either.forLeft(new TextEdit(range, label)));
 		return item;
 	}
-	
+
 	protected CompletionItem createCompletionItemWithInsertReplace(String label, CompletionItemKind kind, Range insertRange, Range replaceRange) {
 		CompletionItem item = new CompletionItem();
 		item.setLabel(label);
@@ -74,7 +73,7 @@ public abstract class AbstractCompletionTest {
 	}
 
 	protected void confirmCompletionResults(String[] completions, String content, Integer cursorIndexInContent,
-			String[] expectedOrder) throws PartInitException, InvocationTargetException, CoreException {
+			String[] expectedOrder) throws PartInitException, CoreException {
 		Range range = new Range(new Position(0, 0), new Position(0, cursorIndexInContent));
 		List<CompletionItem> items = new ArrayList<>();
 		for (String string : completions) {
@@ -84,8 +83,7 @@ public abstract class AbstractCompletionTest {
 	}
 
 	protected void confirmCompletionResults(List<CompletionItem> completions, String content,
-			Integer cursorIndexInContent, String[] expectedOrder)
-			throws PartInitException, InvocationTargetException, CoreException {
+			Integer cursorIndexInContent, String[] expectedOrder) throws PartInitException, CoreException {
 
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, completions));
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -12,15 +12,9 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.completion;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,7 +73,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	 * file-specific LS already associated is something we want to support.
 	 */
 	@Test
-	public void testAssistForUnknownButConnectedType() throws CoreException, InvocationTargetException, IOException, InterruptedException {
+	public void testAssistForUnknownButConnectedType() throws CoreException, IOException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
@@ -111,7 +105,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testNoPrefix() throws CoreException, InvocationTargetException {
+	public void testNoPrefix() throws CoreException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
@@ -128,7 +122,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testPrefix() throws CoreException, InvocationTargetException {
+	public void testPrefix() throws CoreException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		items.add(createCompletionItem("SecondClass", CompletionItemKind.Class));
@@ -150,16 +144,16 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	 * The test will use a Command that shall be handled by the langauge server.
 	 */
 	@Test
-	public void testCommandExecution() throws CoreException, InvocationTargetException, InterruptedException, ExecutionException, TimeoutException {
+	public void testCommandExecution() throws CoreException, InterruptedException, ExecutionException, TimeoutException {
 		CompletionItem completionItem = createCompletionItem("Bla", CompletionItemKind.Class);
 		String expectedParameter = "command execution parameter";
 		List<Object> commandArguments = Arrays.asList(expectedParameter);
 		completionItem.setCommand(new Command("TestCommand", MockLanguageServer.SUPPORTED_COMMAND_ID, commandArguments));
 
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Arrays.asList(completionItem)));
-		
+
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, ""));
-		
+
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(1, proposals.length);
 
@@ -175,7 +169,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testPrefixCaseSensitivity() throws CoreException, InvocationTargetException {
+	public void testPrefixCaseSensitivity() throws CoreException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
@@ -192,7 +186,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testCompleteOnFileEnd() throws CoreException, InvocationTargetException { // bug 508842
+	public void testCompleteOnFileEnd() throws CoreException { // bug 508842
 		CompletionItem item = new CompletionItem();
 		item.setLabel("1024M");
 		item.setKind(CompletionItemKind.Value);
@@ -213,7 +207,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testTriggerCharsWithoutPreliminaryCompletion() throws CoreException, InvocationTargetException { // bug 508463
+	public void testTriggerCharsWithoutPreliminaryCompletion() throws CoreException { // bug 508463
 		Set<String> triggers = new HashSet<>();
 		triggers.add("a");
 		triggers.add("b");
@@ -231,7 +225,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testTriggerCharsNullList() throws CoreException, InvocationTargetException {
+	public void testTriggerCharsNullList() throws CoreException {
 		MockLanguageServer.INSTANCE.setCompletionTriggerChars(null);
 
 		TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "First"));
@@ -240,7 +234,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testApplyCompletionWithPrefix() throws CoreException, InvocationTargetException {
+	public void testApplyCompletionWithPrefix() throws CoreException {
 		Range range = new Range(new Position(0, 0), new Position(0, 5));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
@@ -257,7 +251,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testApplyCompletionReplace() throws CoreException, InvocationTargetException {
+	public void testApplyCompletionReplace() throws CoreException {
 		Range range = new Range(new Position(0, 0), new Position(0, 20));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
@@ -273,7 +267,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testApplyCompletionReplaceAndTypingWithTextEdit() throws CoreException, InvocationTargetException, BadLocationException {
+	public void testApplyCompletionReplaceAndTypingWithTextEdit() throws CoreException, BadLocationException {
 		Range range = new Range(new Position(0, 0), new Position(0, 20));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
@@ -295,8 +289,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testApplyCompletionReplaceAndTyping()
-			throws CoreException, InvocationTargetException, BadLocationException {
+	public void testApplyCompletionReplaceAndTyping() throws CoreException, BadLocationException {
 		CompletionItem item = new CompletionItem("strncasecmp");
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("strncasecmp()");
@@ -320,7 +313,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testCompletionReplace() throws CoreException, InvocationTargetException {
+	public void testCompletionReplace() throws CoreException {
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(
@@ -364,7 +357,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testBasicSnippet() throws PartInitException, InvocationTargetException, CoreException {
+	public void testBasicSnippet() throws PartInitException, CoreException {
 		CompletionItem completionItem = createCompletionItem("$1 and ${2:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
@@ -378,7 +371,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testChoiceSnippet() throws PartInitException, InvocationTargetException, CoreException {
+	public void testChoiceSnippet() throws PartInitException, CoreException {
 		CompletionItem completionItem = createCompletionItem("1${1|a,b|}2", CompletionItemKind.Class);
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
@@ -398,7 +391,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testDuplicateVariable() throws PartInitException, InvocationTargetException, CoreException {
+	public void testDuplicateVariable() throws PartInitException, CoreException {
 		CompletionItem completionItem = createCompletionItem("${1:foo} and ${1:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
@@ -412,7 +405,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testSnippetTabStops() throws PartInitException, InvocationTargetException, CoreException {
+	public void testSnippetTabStops() throws PartInitException, CoreException {
 		CompletionItem completionItem = createCompletionItem("sum(${1:x}, ${2:y})", CompletionItemKind.Method,
 				new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
@@ -452,7 +445,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testReopeningFileAndReusingContentAssist() throws CoreException, InvocationTargetException {
+	public void testReopeningFileAndReusingContentAssist() throws CoreException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
@@ -512,5 +505,4 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		assertTrue(completionProposal.isValidFor(document, 6));
 		assertFalse(completionProposal.isValidFor(document, 7));
 	}
-
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
@@ -11,10 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.completion;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -48,7 +46,7 @@ public class ContextInformationTest {
 	}
 
 	@Test
-	public void testNoContextInformation() throws CoreException, InvocationTargetException {
+	public void testNoContextInformation() throws CoreException {
 		MockLanguageServer.INSTANCE.setSignatureHelp(new SignatureHelp());
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
@@ -59,7 +57,7 @@ public class ContextInformationTest {
 	}
 
 	@Test
-	public void testContextInformationNoParameters() throws CoreException, InvocationTargetException {
+	public void testContextInformationNoParameters() throws CoreException {
 		SignatureHelp signatureHelp = new SignatureHelp();
 		SignatureInformation information = new SignatureInformation("label", "documentation", Collections.emptyList());
 		signatureHelp.setSignatures(Collections.singletonList(information));
@@ -78,7 +76,7 @@ public class ContextInformationTest {
 	}
 
 	@Test
-	public void testTriggerChars() throws CoreException, InvocationTargetException {
+	public void testTriggerChars() throws CoreException {
 		Set<String> triggers = new HashSet<>();
 		triggers.add("a");
 		triggers.add("b");
@@ -92,7 +90,7 @@ public class ContextInformationTest {
 	}
 
 	@Test
-	public void testTriggerCharsNullList() throws CoreException, InvocationTargetException {
+	public void testTriggerCharsNullList() throws CoreException {
 		MockLanguageServer.INSTANCE.setContextInformationTriggerChars(null);
 
 		TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "First"));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
@@ -12,14 +12,10 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.completion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +32,7 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.BoldStylerProvider;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServersRegistry;
 import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
@@ -69,7 +66,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	 * file-specific LS already associated is something we want to support.
 	 */
 	@Test
-	public void testAssistForUnknownButConnectedType() throws CoreException, InvocationTargetException, IOException, InterruptedException {
+	public void testAssistForUnknownButConnectedType() throws CoreException, IOException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
@@ -101,7 +98,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testNoPrefix() throws CoreException, InvocationTargetException {
+	public void testNoPrefix() throws CoreException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
@@ -157,7 +154,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testPrefix() throws CoreException, InvocationTargetException {
+	public void testPrefix() throws CoreException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		items.add(createCompletionItem("SecondClass", CompletionItemKind.Class));
@@ -176,7 +173,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testPrefixCaseSensitivity() throws CoreException, InvocationTargetException {
+	public void testPrefixCaseSensitivity() throws CoreException {
 		List<CompletionItem> items = new ArrayList<>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
@@ -194,7 +191,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testCompleteOnFileEnd() throws CoreException, InvocationTargetException { // bug 508842
+	public void testCompleteOnFileEnd() throws CoreException { // bug 508842
 		CompletionItem item = new CompletionItem();
 		item.setLabel("1024M");
 		item.setKind(CompletionItemKind.Value);
@@ -216,7 +213,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testCompletionWithAdditionalEdits() throws CoreException, InvocationTargetException {
+	public void testCompletionWithAdditionalEdits() throws CoreException {
 		List<CompletionItem> items = new ArrayList<>();
 		CompletionItem item = new CompletionItem("additionaEditsCompletion");
 		item.setKind(CompletionItemKind.Function);
@@ -249,7 +246,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testSnippetCompletionWithAdditionalEdits()
-			throws PartInitException, InvocationTargetException, CoreException {
+			throws PartInitException, CoreException {
 		CompletionItem item = new CompletionItem("snippet item");
 		item.setInsertText("$1 and ${2:foo}");
 		item.setKind(CompletionItemKind.Class);
@@ -278,7 +275,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testApplyCompletionWithPrefix() throws CoreException, InvocationTargetException {
+	public void testApplyCompletionWithPrefix() throws CoreException {
 		Range range = new Range(new Position(0, 0), new Position(0, 5));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
@@ -296,7 +293,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testApplyCompletionReplace() throws CoreException, InvocationTargetException {
+	public void testApplyCompletionReplace() throws CoreException {
 		Range range = new Range(new Position(0, 0), new Position(0, 20));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
@@ -313,7 +310,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testApplyCompletionReplaceAndTypingWithTextEdit() throws CoreException, InvocationTargetException, BadLocationException {
+	public void testApplyCompletionReplaceAndTypingWithTextEdit() throws CoreException, BadLocationException {
 		Range range = new Range(new Position(0, 0), new Position(0, 22));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
@@ -336,8 +333,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testApplyCompletionReplaceAndTyping()
-			throws CoreException, InvocationTargetException, BadLocationException {
+	public void testApplyCompletionReplaceAndTyping() throws CoreException, BadLocationException {
 		CompletionItem item = new CompletionItem("strncasecmp");
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("strncasecmp()");
@@ -362,7 +358,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testCompletionReplace() throws CoreException, InvocationTargetException {
+	public void testCompletionReplace() throws CoreException {
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, Collections.singletonList(
@@ -407,7 +403,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testBasicSnippet() throws PartInitException, InvocationTargetException, CoreException {
+	public void testBasicSnippet() throws PartInitException, CoreException {
 		CompletionItem completionItem = createCompletionItem("$1 and ${2:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
@@ -422,7 +418,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testDuplicateVariable() throws PartInitException, InvocationTargetException, CoreException {
+	public void testDuplicateVariable() throws PartInitException, CoreException {
 		CompletionItem completionItem = createCompletionItem("${1:foo} and ${1:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
@@ -437,7 +433,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testVariableReplacement() throws PartInitException, InvocationTargetException, CoreException {
+	public void testVariableReplacement() throws PartInitException, CoreException {
 		CompletionItem completionItem = createCompletionItem(
 				"${1:$TM_FILENAME_BASE} ${2:$TM_FILENAME} ${3:$TM_FILEPATH} ${4:$TM_DIRECTORY} ${5:$TM_LINE_INDEX} ${6:$TM_LINE_NUMBER} ${7:$TM_CURRENT_LINE} ${8:$TM_SELECTED_TEXT}",
 				CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
@@ -479,25 +475,25 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		IFile file = TestUtils.createUniqueTestFile(project, "Some Text Before\n<tag>tagText</tag>\nSome Text After");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 		// Create item
-		CompletionItem item = createCompletionItem("tagText", 
-				CompletionItemKind.Text, 
+		CompletionItem item = createCompletionItem("tagText",
+				CompletionItemKind.Text,
 				new Range(
-						new Position(1, "<tag>".length()), 
+						new Position(1, "<tag>".length()),
 						new Position(1,  "<tag>".length() + "tag".length())));
 		// Set additional TExtEdits on the item
 		List<TextEdit> additionalEdits = new ArrayList<>(2);
 		// Prefix to be inserted to the end of line that precedes the line to be "completed"
 		additionalEdits.add(new TextEdit(new Range(
-				new Position(1, 0), 
-				new Position(1, 0)), 
+				new Position(1, 0),
+				new Position(1, 0)),
 				"<prefix>prefixText</prefix>\n"));
 		// Postfix to be inserted to the end of line to be "completed"
 		additionalEdits.add(new TextEdit(new Range(
-				new Position(1, "<tag>tag</tag>".length()), 
-				new Position(1, "<tag>tag</tag>".length())), 
+				new Position(1, "<tag>tag</tag>".length()),
+				new Position(1, "<tag>tag</tag>".length())),
 				"\n<postfix>postfixText</postfix>"));
 		item.setAdditionalTextEdits(additionalEdits);
-		
+
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, Collections.singletonList(item)));
 
 		String text = viewer.getDocument().get();
@@ -528,7 +524,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		File file = TestUtils.createTempFile("testCompletionExternalFile", ".lspt");
 		ITextEditor editor = (ITextEditor) IDE.openEditorOnFileStore(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(1, proposals.length);
 		proposals[0].apply(viewer.getDocument());
@@ -576,7 +572,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		String addInfo = completionProposal.getAdditionalProposalInfo(new NullProgressMonitor()); // check no expection is sent
 		assertTrue(addInfo.indexOf("<p>detail</p>") >= 0);
 	}
-	
+
 	@Test
 	public void testAdditionalInformationWithEmptyDocumentation() throws Exception {
 		IDocument document = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "")).getDocument();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
@@ -11,8 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.definition;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -29,6 +28,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.declaration.LSBasedHyperlink;
 import org.eclipse.lsp4e.operations.declaration.OpenDeclarationHyperlinkDetector;
 import org.eclipse.lsp4e.test.AllCleanRule;
@@ -67,7 +67,7 @@ public class DefinitionTest {
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 
 		IHyperlink[] hyperlinks = hyperlinkDetector.detectHyperlinks(viewer, new Region(1, 0), true);
-		assertEquals(1, hyperlinks.length);		
+		assertEquals(1, hyperlinks.length);
 		// TODO add location check
 	}
 
@@ -102,12 +102,12 @@ public class DefinitionTest {
 		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
 		ITextEditor editor = (ITextEditor) IDE.openInternalEditorOnFileStore(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		IHyperlink[] hyperlinks = hyperlinkDetector.detectHyperlinks(viewer, new Region(0, 0), true);
 		assertEquals(1, hyperlinks.length);
 	}
-	
+
 	@Test
 	public void testDefinitionManyLocation() throws Exception {
 		List<Location> locations = new ArrayList<>();
@@ -134,7 +134,7 @@ public class DefinitionTest {
 		IHyperlink[] hyperlinks = hyperlinkDetector.detectHyperlinks(viewer, new Region(1, 0), true);
 		assertEquals(true, hyperlinks == null);
 	}
-	
+
 	@Test
 	public void testDefinitionEmptyLocations() throws Exception {
 		MockLanguageServer.INSTANCE.setDefinition(Collections.emptyList());

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.diagnostics;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -105,7 +104,7 @@ public class DiagnosticsTest {
 		markers = file.findMarkers(LSPDiagnosticsToMarkers.LS_DIAGNOSTIC_MARKER_TYPE, false, IResource.DEPTH_INFINITE);
 		assertEquals(0, markers.length);
 	}
-	
+
 	@Test
 	public void testFileBuffersNotLeaked() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "Diagnostic Other Text");
@@ -115,11 +114,11 @@ public class DiagnosticsTest {
 		diagnostics.add(createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1"));
 
 		IDocument existingDocument = LSPEclipseUtils.getExistingDocument(file);
-		
+
 		assertNull(existingDocument);
-		
+
 		diagnosticsToMarkers.accept(new PublishDiagnosticsParams(file.getLocationURI().toString(), diagnostics));
-		
+
 		IDocument shouldHaveBeenClosed = LSPEclipseUtils.getExistingDocument(file);
 		assertNull(shouldHaveBeenClosed);
 
@@ -200,7 +199,7 @@ public class DiagnosticsTest {
 			) {
 				out.write('a');
 			}
-			ITextViewer viewer = TestUtils.getTextViewer(IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
+			ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
 			StyledText widget = viewer.getTextWidget();
 			FontData biggerFont = new FontData(); // bigger font to keep color intact in some pixe (not altered by anti-aliasing)
 			biggerFont.setHeight(40);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
@@ -11,8 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.documentLink;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -25,6 +24,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.documentLink.DocumentLinkDetector;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -83,7 +83,7 @@ public class DocumentLinkTest {
 		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
 		ITextEditor editor = (ITextEditor) IDE.openInternalEditorOnFileStore(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		IHyperlink[] hyperlinks = documentLinkDetector.detectHyperlinks(viewer, new Region(13, 0), true);
 		assertEquals(1, hyperlinks.length);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
@@ -12,12 +12,10 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.edit;
 
-import static org.eclipse.lsp4e.test.TestUtils.numberOfChangesIs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.eclipse.lsp4e.test.TestUtils.*;
+import static org.junit.Assert.*;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -26,6 +24,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -60,7 +59,7 @@ public class DocumentDidChangeTest {
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		LanguageServiceAccessor.getLanguageServers(viewer.getDocument(), new Predicate<ServerCapabilities>() {
 			@Override
 			public boolean test(ServerCapabilities t) {
@@ -127,7 +126,7 @@ public class DocumentDidChangeTest {
 		String multiLineText = "line1\nline2\nline3\n";
 		IFile testFile = TestUtils.createUniqueTestFile(project, multiLineText);
 		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		LanguageServiceAccessor.getLanguageServers(viewer.getDocument(), new Predicate<ServerCapabilities>() {
 			@Override
 			public boolean test(ServerCapabilities t) {
@@ -152,14 +151,14 @@ public class DocumentDidChangeTest {
 		assertEquals(Integer.valueOf(6), change0.getRangeLength());
 		assertEquals("", change0.getText());
 	}
-	
+
 	@Test
 	public void testIncrementalEditOrdering() throws Exception {
 		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
 		.setTextDocumentSync(TextDocumentSyncKind.Incremental);
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		StyledText text = viewer.getTextWidget();
 		for (int i = 0; i < 500; i++) {
 			text.append(i + "\n");
@@ -180,7 +179,7 @@ public class DocumentDidChangeTest {
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		LanguageServiceAccessor.getLanguageServers(viewer.getDocument(), new Predicate<ServerCapabilities>() {
 			@Override
 			public boolean test(ServerCapabilities t) {
@@ -216,7 +215,7 @@ public class DocumentDidChangeTest {
 
 		File file = TestUtils.createTempFile("testFullSyncExternalFile", ".lspt");
 		IEditorPart editor = IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		LanguageServiceAccessor.getLanguageServers(viewer.getDocument(), new Predicate<ServerCapabilities>() {
 			@Override
 			public boolean test(ServerCapabilities t) {
@@ -254,5 +253,5 @@ public class DocumentDidChangeTest {
 		}
 		return syncKind;
 	}
-	
+
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidSaveTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidSaveTest.java
@@ -12,8 +12,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.edit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.concurrent.CompletableFuture;
@@ -56,7 +55,7 @@ public class DocumentDidSaveTest {
 	public void testSave() throws Exception {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		// make sure that timestamp after save will differ from creation time (no better idea at the moment)
 		testFile.setLocalTimeStamp(0);
@@ -86,7 +85,7 @@ public class DocumentDidSaveTest {
 	public void testSaveExternalFile() throws Exception {
 		File file = TestUtils.createTempFile("testSaveExternalFile", ".lspt");
 		IEditorPart editor = IDE.openEditorOnFileStore(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI()));
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		// make sure that timestamp after save will differ from creation time (no better idea at the moment)
 //			testFile.setLocalTimeStamp(0);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentRevertAndCloseTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentRevertAndCloseTest.java
@@ -11,13 +11,12 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.edit;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
-import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.test.AllCleanRule;
@@ -26,6 +25,7 @@ import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.junit.Before;
 import org.junit.Rule;
@@ -45,25 +45,25 @@ public class DocumentRevertAndCloseTest {
 	public void testShutdownLsp() throws Exception {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "Hello!");
 		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		// make sure that timestamp after save will differ from creation time (no better idea at the moment)
 		testFile.setLocalTimeStamp(0);
 
 		// Force LS to initialize and open file
 		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(testFile), capabilites -> Boolean.TRUE);
-		
+
 		viewer.getDocument().replace(0, 0, "Bye!");
 		((AbstractTextEditor)editor).doRevertToSaved();
 		((AbstractTextEditor)editor).getSite().getPage().closeEditor(editor, false);
-		
+
 		Display display = PlatformUI.getWorkbench().getDisplay();
 		assertTrue(new DisplayHelper() {
 			@Override
 			protected boolean condition() {
 				return !MockLanguageServer.INSTANCE.isRunning();
 			}
-			
+
 		}.waitForCondition(display, 3000));
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
@@ -63,7 +63,7 @@ public class DocumentWillSaveWaitUntilTest {
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		// Force LS to initialize and open file
 		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(testFile), capabilites -> Boolean.TRUE);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -13,9 +13,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.edit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -235,7 +233,7 @@ public class LSPEclipseUtilsTest {
 	@Test
 	public void testCustomResourceToURIMapping() throws CoreException { // bug 576425
 		IProject project = null;
-	
+
 		URI uri = URI.create("other://res.txt");
 		project = TestUtils.createProject(getClass().getSimpleName() + uri.getScheme());
 		IFile file = project.getFile("res.txt");
@@ -251,7 +249,7 @@ public class LSPEclipseUtilsTest {
 		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
 		editor = TestUtils.openEditor(file);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		TextEdit textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "InsertHere".length())), "Inserted");
 		IDocument document = viewer.getDocument();
 		LSPEclipseUtils.applyEdit(textEdit, document);
@@ -265,7 +263,7 @@ public class LSPEclipseUtilsTest {
 		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineHERE");
 		editor = TestUtils.openEditor(file);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		TextEdit textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "HERE".length())), "Inserted");
 		IDocument document = viewer.getDocument();
 		LSPEclipseUtils.applyEdit(textEdit, document);
@@ -279,7 +277,7 @@ public class LSPEclipseUtilsTest {
 		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "");
 		editor = TestUtils.openEditor(file);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		TextEdit[] edits = new TextEdit[] {
 				new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), " throws "),
 				new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), "Exception") };

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
@@ -11,9 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.format;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -28,6 +27,7 @@ import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.format.LSPFormatter;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -62,12 +62,12 @@ public class FormatTest {
 
 	@Test
 	public void testFormattingNoChanges()
-			throws CoreException, InvocationTargetException, InterruptedException, ExecutionException {
+			throws CoreException, InterruptedException, ExecutionException {
 		MockLanguageServer.INSTANCE.setFormattingTextEdits(Collections.emptyList());
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Formatting Other Text");
 		IEditorPart editor = TestUtils.openEditor(file);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
@@ -85,7 +85,7 @@ public class FormatTest {
 
 	@Test
 	public void testFormatting()
-			throws CoreException, InvocationTargetException, InterruptedException, ExecutionException {
+			throws CoreException, InterruptedException, ExecutionException {
 		List<TextEdit> formattingTextEdits = new ArrayList<>();
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 0), new Position(0, 1)), "MyF"));
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
@@ -94,7 +94,7 @@ public class FormatTest {
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Formatting Other Text");
 		IEditorPart editor = TestUtils.openEditor(file);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
@@ -111,8 +111,7 @@ public class FormatTest {
 	}
 
 	@Test
-	public void testNullFormatting()
-			throws CoreException, InvocationTargetException, InterruptedException, ExecutionException {
+	public void testNullFormatting() {
 		IDocument document = new Document("Formatting Other Text");
 		LSPFormatter formatter = new LSPFormatter();
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/highlight/HighlightTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/highlight/HighlightTest.java
@@ -11,9 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.highlight;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,7 +28,6 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.lsp4e.operations.highlight.HighlightReconcilingStrategy;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -39,6 +37,7 @@ import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -58,7 +57,7 @@ public class HighlightTest {
 	}
 
 	@Test
-	public void testHighlight() throws CoreException, InvocationTargetException {
+	public void testHighlight() throws CoreException {
 		checkGenericEditorVersion();
 
 		List<DocumentHighlight> highlights = new ArrayList<>();
@@ -113,7 +112,7 @@ public class HighlightTest {
 	}
 
 	@Test
-	public void testCheckIfOtherAnnotationsRemains() throws CoreException, InvocationTargetException {
+	public void testCheckIfOtherAnnotationsRemains() throws CoreException {
 		checkGenericEditorVersion();
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "  READ WRITE TEXT");

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
@@ -11,15 +11,11 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.hover;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -30,6 +26,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.internal.text.html.BrowserInformationControl;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.hover.LSPTextHover;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -59,7 +56,7 @@ public class HoverTest {
 	@Rule public AllCleanRule clear = new AllCleanRule();
 	private IProject project;
 	private LSPTextHover hover;
-	
+
 	@Before
 	public void setUp() throws CoreException {
 		project = TestUtils.createProject("HoverTest" + System.currentTimeMillis());
@@ -67,7 +64,7 @@ public class HoverTest {
 	}
 
 	@Test
-	public void testHoverRegion() throws CoreException, InvocationTargetException {
+	public void testHoverRegion() throws CoreException {
 		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
@@ -76,9 +73,9 @@ public class HoverTest {
 
 		assertEquals(new Region(0, 10), hover.getHoverRegion(viewer, 5));
 	}
-	
+
 	@Test
-	public void testHoverRegionInvalidOffset() throws CoreException, InvocationTargetException {
+	public void testHoverRegionInvalidOffset() throws CoreException {
 		MockLanguageServer.INSTANCE.setHover(null);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -86,9 +83,9 @@ public class HoverTest {
 
 		assertEquals(new Region(15, 0), hover.getHoverRegion(viewer, 15));
 	}
-	
+
 	@Test
-	public void testHoverInfo() throws CoreException, InvocationTargetException {
+	public void testHoverInfo() throws CoreException {
 		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
@@ -98,9 +95,9 @@ public class HoverTest {
 		// TODO update test when MARKDOWN to HTML will be finished
 		assertTrue(hover.getHoverInfo(viewer, new Region(0, 10)).contains("HoverContent"));
 	}
-	
+
 	@Test
-	public void testHoverInfoEmptyContentList() throws CoreException, InvocationTargetException {
+	public void testHoverInfoEmptyContentList() throws CoreException {
 		Hover hoverResponse = new Hover(Collections.emptyList(), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
@@ -109,9 +106,9 @@ public class HoverTest {
 
 		assertEquals(null, hover.getHoverInfo(viewer, new Region(0, 10)));
 	}
-	
+
 	@Test
-	public void testHoverInfoInvalidOffset() throws CoreException, InvocationTargetException {
+	public void testHoverInfoInvalidOffset() throws CoreException {
 		MockLanguageServer.INSTANCE.setHover(null);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -119,9 +116,9 @@ public class HoverTest {
 
 		assertEquals(null, hover.getHoverInfo(viewer, new Region(0, 10)));
 	}
-	
+
 	@Test
-	public void testHoverEmptyContentItem() throws CoreException, InvocationTargetException {
+	public void testHoverEmptyContentItem() throws CoreException {
 		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
@@ -132,14 +129,13 @@ public class HoverTest {
 	}
 
 	@Test
-	public void testHoverOnExternalFile()
-			throws CoreException, InvocationTargetException, IOException, InterruptedException {
+	public void testHoverOnExternalFile() throws CoreException, IOException {
 		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("blah")),
 				new Range(new Position(0, 0), new Position(0, 0)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		File file = TestUtils.createTempFile("testHoverOnExternalfile", ".lspt");
-		ITextViewer viewer = TestUtils.getTextViewer(IDE.openInternalEditorOnFileStore(
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openInternalEditorOnFileStore(
 				PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), EFS.getStore(file.toURI())));
 		Assert.assertTrue(hover.getHoverInfo(viewer, new Region(0, 0)).contains("blah"));
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/linkedediting/LinkedEditingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/linkedediting/LinkedEditingTest.java
@@ -11,12 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.linkedediting;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -56,18 +52,18 @@ public class LinkedEditingTest {
 	}
 
 	@Test
-	public void testLinkedEditing() throws CoreException, InvocationTargetException {
+	public void testLinkedEditing() throws CoreException {
 		List<Range> ranges = new ArrayList<>();
 		ranges.add(new Range(new Position(1, 3), new Position(1, 7)));
 		ranges.add(new Range(new Position(3, 4), new Position(3, 8)));
-		
+
 		LinkedEditingRanges linkkedEditingRanges = new LinkedEditingRanges(ranges);
 		MockLanguageServer.INSTANCE.setLinkedEditingRanges(linkkedEditingRanges);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "<html>\n  <body>\n    a body text\n  </body>\n</html>");
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 
-		viewer.getTextWidget().setCaretOffset(11); 
+		viewer.getTextWidget().setCaretOffset(11);
 
 		if (!(viewer instanceof ISourceViewer)) {
 			Assert.fail();
@@ -76,7 +72,7 @@ public class LinkedEditingTest {
 		ISourceViewer sourceViewer = (ISourceViewer) viewer;
 
 		viewer.getTextWidget().setSelection(11); // 10-14 <body|>
-		
+
 		Map<org.eclipse.jface.text.Position, Annotation> annotations = new HashMap<>();
 
 		new DisplayHelper() {
@@ -104,13 +100,13 @@ public class LinkedEditingTest {
 		Assert.assertNotNull(annotation);
 		assertTrue(annotation.getType().startsWith("org.eclipse.ui.internal.workbench.texteditor.link"));
 	}
-	
+
 	@Test
-	public void testLinkedEditingExitPolicy() throws CoreException, InvocationTargetException {
+	public void testLinkedEditingExitPolicy() throws CoreException {
 		List<Range> ranges = new ArrayList<>();
 		ranges.add(new Range(new Position(1, 3), new Position(1, 7)));
 		ranges.add(new Range(new Position(3, 4), new Position(3, 8)));
-		
+
 		LinkedEditingRanges linkkedEditingRanges = new LinkedEditingRanges(ranges, "[:A-Z_a-z]*\\Z");
 		MockLanguageServer.INSTANCE.setLinkedEditingRanges(linkkedEditingRanges);
 
@@ -124,7 +120,7 @@ public class LinkedEditingTest {
 		ISourceViewer sourceViewer = (ISourceViewer) viewer;
 
 		// Test linked editing annotation in a tag name position
-		viewer.getTextWidget().setCaretOffset(14); 
+		viewer.getTextWidget().setCaretOffset(14);
 		viewer.getTextWidget().setSelection(14); // 10-14 <body| class="test">
 		new DisplayHelper() {
 			@Override
@@ -155,9 +151,9 @@ public class LinkedEditingTest {
 		assertNotNull(slavePosition);
 		assertEquals(viewer.getTextWidget().getTextRange(masterPosition.getOffset(), masterPosition.getLength()),
 				viewer.getTextWidget().getTextRange(slavePosition.getOffset(), slavePosition.getLength()));
-		
+
 		// Test linked editing annotation out of a tag name position (should be absent)
-		viewer.getTextWidget().setCaretOffset(15); 
+		viewer.getTextWidget().setCaretOffset(15);
 		viewer.getTextWidget().setSelection(15); // 10-14 <body |class="test">
 		new DisplayHelper() {
 			@Override
@@ -172,12 +168,12 @@ public class LinkedEditingTest {
 				return false;
 			}
 		}.waitForCondition(Display.getCurrent(), 3000);
-		
+
 		model = sourceViewer.getAnnotationModel();
 		// No "linked" annotation is to be found at this offset
 		assertFalse(findAnnotations(sourceViewer, 15).stream().anyMatch(a -> a.getType().startsWith("org.eclipse.ui.internal.workbench.texteditor.link")));
 	}
-	
+
 	private List<Annotation> findAnnotations(ISourceViewer sourceViewer, int offset) {
 		List<Annotation> annotations = new ArrayList<>();
 		IAnnotationModel model = sourceViewer.getAnnotationModel();
@@ -189,7 +185,7 @@ public class LinkedEditingTest {
 				annotations.add(annotation);
 			}
 		}
-		
+
 		return annotations;
 	}
 
@@ -202,7 +198,7 @@ public class LinkedEditingTest {
 				return annotation;
 			}
 		}
-		
+
 		return null;
 	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/codelens/LSPCodeMiningTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/codelens/LSPCodeMiningTest.java
@@ -11,9 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.operations.codelens;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -72,8 +71,7 @@ public class LSPCodeMiningTest {
 	}
 
 	@Test
-	public void testLSPCodeMiningActionClientSideHandling()
-			throws BadLocationException, CoreException, InvocationTargetException {
+	public void testLSPCodeMiningActionClientSideHandling() throws BadLocationException, CoreException {
 		String commandID = "test.command";
 		final CodeLens lens = createCodeLens(commandID);
 
@@ -110,7 +108,7 @@ public class LSPCodeMiningTest {
 	@Test
 	public void testLSPCodeMiningActionServerSideHandling()
 			throws InterruptedException, java.util.concurrent.ExecutionException, TimeoutException,
-			BadLocationException, CoreException, InvocationTargetException {
+			BadLocationException, CoreException {
 		final CodeLens lens = createCodeLens(MockLanguageServer.SUPPORTED_COMMAND_ID);
 		Command command = lens.getCommand();
 		JsonObject jsonObject = new JsonObject();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/references/FindReferencesTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/references/FindReferencesTest.java
@@ -11,8 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.references;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -21,7 +20,6 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.lsp4e.operations.references.LSFindReferences;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -35,6 +33,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.services.IEvaluationService;
+import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,13 +54,13 @@ public class FindReferencesTest {
 	}
 
 	@After
-	public void tearDown() throws CoreException {
+	public void tearDown() {
 		IViewPart searchPart = NewSearchUI.getSearchResultView();
 		if (searchPart != null) {
 			searchPart.getViewSite().getPage().hideView(searchPart);
 		}
 	}
-	
+
 	@Test
 	public void findReferencesShowsResultView() throws Exception {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "dummyContent");
@@ -69,15 +68,15 @@ public class FindReferencesTest {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setMockReferences(
 				new Location(testFile.getLocationURI().toString(),	new Range(
 						new Position(1, 1), new Position(1, 2))));
-		
+
 		LSFindReferences handler = new LSFindReferences();
 		IEvaluationService evaluationService = PlatformUI.getWorkbench().getService(IEvaluationService.class);
 		handler.execute(new ExecutionEvent(null, new HashMap<>(), null, evaluationService.getCurrentState()));
-		
+
 		ISearchResultViewPart part = findSearchResultView(3000);
 		assertNotNull("Search results not shown", part);
 	}
-	
+
 	private ISearchResultViewPart findSearchResultView(int timeout) {
 		new DisplayHelper() {
 			@Override

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
@@ -13,9 +13,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.rename;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -73,7 +71,7 @@ import org.junit.Test;
 public class RenameTest {
 
 	@Rule public AllCleanRule clear = new AllCleanRule();
-	
+
 	@Test
 	public void testRenameHandlerEnablement() throws Exception {
 		IProject project = TestUtils.createProject("blah");
@@ -82,7 +80,8 @@ public class RenameTest {
 		editor.selectAndReveal(1, 0);
 		ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
 		Command command = commandService.getCommand(IWorkbenchCommandConstants.FILE_RENAME);
-		assertTrue(command.isEnabled() && command.isHandled());
+		assertTrue(command.isEnabled());
+		assertTrue(command.isHandled());
 	}
 
 	@Test
@@ -91,9 +90,9 @@ public class RenameTest {
 		// this fixed value is not really an optimal solution, since it depends on the following things
 		// to happen within that time frame. Should maybe re-work this in the future towards a more
 		// precise way of steering the execution from the test here
-		
+
 		MockLanguageServer.INSTANCE.setTimeToProceedQueries(delay);
-		
+
 		IProject project = TestUtils.createProject("blah");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
@@ -101,9 +100,10 @@ public class RenameTest {
 		ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
 		Command command = commandService.getCommand(IWorkbenchCommandConstants.FILE_RENAME);
 		assertFalse(command.isEnabled() && command.isHandled());
-		
+
 		Thread.sleep(delay);
-		assertTrue(command.isEnabled() && command.isHandled());
+		assertTrue(command.isEnabled());
+		assertTrue(command.isHandled());
 	}
 
 	@Test
@@ -269,7 +269,7 @@ public class RenameTest {
 			ideShell.getDisplay().removeFilter(SWT.Paint, pressOKonRenameDialogPaint);
 		}
 	}
-	
+
 	@Test
 	public void testPlaceholderUsingPlaceholderFromPrepareRenameResult() throws Exception {
 		IProject project = TestUtils.createProject("blah");
@@ -288,7 +288,7 @@ public class RenameTest {
 		}).join();
 		assertEquals("placeholder", placeholder.get());
 	}
-	
+
 	@Test
 	public void testPlaceholderUsingRangeFromPrepareRenameResult() throws Exception {
 		IProject project = TestUtils.createProject("blah");
@@ -309,7 +309,7 @@ public class RenameTest {
 		}).join();
 		assertEquals("ld", placeholder.get());
 	}
-	
+
 	private void pressOk(Shell dialogShell) {
 		try {
 			Dialog dialog = (Dialog)dialogShell.getData();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
@@ -101,7 +101,7 @@ public class RenameTest {
 		Command command = commandService.getCommand(IWorkbenchCommandConstants.FILE_RENAME);
 		assertFalse(command.isEnabled() && command.isHandled());
 
-		Thread.sleep(delay);
+		Thread.sleep(2 * delay);
 		assertTrue(command.isEnabled());
 		assertTrue(command.isHandled());
 	}


### PR DESCRIPTION
This PR:
1. Removes TestUtils.getTextViewer and replaces its usage with LSPEclipseUtils.getTextViewer
2. Improves RenameTest stability
3. Improves LanguageServiceAccessorTest stability and comprehensibility