### PR TITLE
Backport/format concurrency

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
@@ -15,10 +15,12 @@ import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -30,6 +32,7 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.VersionedResult;
 import org.eclipse.lsp4e.operations.format.LSPFormatter;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -61,7 +64,7 @@ public class FormatTest {
 		LSPFormatter formatter = new LSPFormatter();
 		ITextSelection selection = TextSelection.emptySelection();
 
-		List<? extends TextEdit> edits = formatter.requestFormatting(new Document(), selection).get();
+		List<? extends TextEdit> edits = formatter.requestFormatting(new Document(), selection).get().get();
 		assertEquals(0, edits.size());
 	}
 
@@ -77,7 +80,7 @@ public class FormatTest {
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
 
-		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
+		VersionedResult<List<? extends TextEdit>> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
 				.get();
 		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), edits));
 
@@ -111,11 +114,52 @@ public class FormatTest {
 		
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
-		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection).get();
+		VersionedResult<List<? extends TextEdit>> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection).get();
 		assertEquals(3, editsReceivedToDate.get());
 
 	}
+	
+	@Test(expected=ConcurrentModificationException.class)
+	public void testFormattingVersionClashDetected() throws Exception {
+		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
+		.setTextDocumentSync(TextDocumentSyncKind.Incremental);
+		List<TextEdit> formattingTextEdits = new ArrayList<>();
+		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 0), new Position(0, 1)), "MyF"));
+		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
+		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 21), new Position(0, 21)), " Second"));
+		MockLanguageServer.INSTANCE.setFormattingTextEdits(formattingTextEdits);
 
+		IFile file = TestUtils.createUniqueTestFile(project, "Formatting Other Text");
+		IEditorPart editor = TestUtils.openEditor(file);
+		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		MockLanguageServer.INSTANCE.setTimeToProceedQueries(5000);
+
+		LSPFormatter formatter = new LSPFormatter();
+		ISelection selection = viewer.getSelectionProvider().getSelection();
+		CompletableFuture<VersionedResult<List<? extends TextEdit>>> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection);
+
+		viewer.getDocument().replace(0, 0, "Hello, ");
+		viewer.getDocument().replace(6, 0, "world! ");
+		viewer.getDocument().replace(13, 0, "Here is some extra text!");
+		VersionedResult<List<? extends TextEdit>> formatting = edits.get();
+		final AtomicReference<Exception> thrown = new AtomicReference<>();
+		editor.getSite().getShell().getDisplay().syncExec(() -> {
+			try {
+				LSPEclipseUtils.applyEditsWithVersionCheck(viewer.getDocument(), formatting);
+			} catch (Exception e ) {
+				thrown.set(e);
+			}
+		});
+		
+		final Exception e = thrown.get();
+		if (e != null) {
+			throw e;
+		}
+
+	}
+
+	
+	
 	@Test
 	public void testFormatting()
 			throws CoreException, InterruptedException, ExecutionException {
@@ -132,7 +176,7 @@ public class FormatTest {
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
 
-		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
+		VersionedResult<List<? extends TextEdit>> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
 				.get();
 		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), edits));
 
@@ -144,7 +188,8 @@ public class FormatTest {
 	}
 
 	@Test
-	public void testNullFormatting() {
+	public void testNullFormatting()
+			throws CoreException, InvocationTargetException, InterruptedException, ExecutionException {
 		IDocument document = new Document("Formatting Other Text");
 		LSPFormatter formatter = new LSPFormatter();
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
@@ -11,8 +11,9 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.format;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
@@ -106,7 +107,7 @@ public class FormatTest {
 		
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		viewer.getDocument().replace(0, 0, "Hello, ");
 		viewer.getDocument().replace(6, 0, "world! ");
@@ -131,7 +132,7 @@ public class FormatTest {
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Formatting Other Text");
 		IEditorPart editor = TestUtils.openEditor(file);
-		ITextViewer viewer = TestUtils.getTextViewer(editor);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		MockLanguageServer.INSTANCE.setTimeToProceedQueries(5000);
 
 		LSPFormatter formatter = new LSPFormatter();

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -133,7 +133,7 @@ public final class MockLanguageServer implements LanguageServer {
 		initializeResult.setCapabilities(serverConfigurer.get());
 	}
 
-	<U> CompletableFuture<U> buildMaybeDelayedFuture(U value) {
+	public <U> CompletableFuture<U> buildMaybeDelayedFuture(U value) {
 		if (delay > 0) {
 			CompletableFuture<U> future = CompletableFuture.runAsync(() -> {
 				try {
@@ -146,6 +146,15 @@ public final class MockLanguageServer implements LanguageServer {
 			return future;
 		}
 		return CompletableFuture.completedFuture(value);
+	}
+
+	/**
+	 * Hook to allow subclassing of the mock text document service
+	 * 
+	 * @param mockService
+	 */
+	public void setTextDocumentService(MockTextDocumentService mockService) {
+		this.textDocumentService = mockService;
 	}
 
 	public static ServerCapabilities defaultServerCapabilities() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -72,10 +72,22 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private int version = 0;
 	private DidChangeTextDocumentParams changeParams;
 	private long modificationStamp;
-	private CompletableFuture<LanguageServer> lastChangeFuture;
 	private final CompletableFuture<LanguageServer> didOpenFuture;
+
+	/**
+	 * Ensures atomic read/write of <code>documentModificationStamp</code> and
+	 * <code>lastChangeFuture</code>
+	 */
 	private final Object guard = new Object();
+	/**
+	 * Caches (opaque) version stamp of last document update event sent to the server
+	 */
 	private long documentModificationStamp = 0L;
+	/** Caches handle to the last call made to the server for this document, allowing
+	 * calls to be chained sequentially. Protected by <code>this.guard</code>
+	 */
+	private CompletableFuture<LanguageServer> lastChangeFuture;
+
 	private LanguageServer languageServer;
 	private IPreferenceStore store;
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -130,7 +130,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
  	 * @param fn Asynchronous computation on the language server
  	 * @return Asynchronous result object.
  	 */
-	private <U> @NonNull CompletableFuture<U> executeOnCurrentVersionAsync(
+	<U> @NonNull CompletableFuture<U> executeOnCurrentVersionAsync(
 			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
 		AtomicReference<CompletableFuture<U>> resValueFuture = new AtomicReference<>();
 		lastChangeFuture.updateAndGet(f -> {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -564,7 +564,7 @@ public class LanguageServerWrapper {
 	 * @param fn Asynchronous computation on the language server
 	 * @return Asynchronous result object.
 	 */
-	<U> @Nullable CompletableFuture< U> executeOnCurrentVersionAsync(URI uri,
+	<U> @Nullable CompletableFuture<VersionedResult<U>> executeOnCurrentVersionAsync(URI uri,
 			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
 		DocumentContentSynchronizer documentContentSynchronizer = connectedDocuments.get(uri);
 		if (documentContentSynchronizer != null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -670,7 +670,7 @@ public class LanguageServerWrapper {
 				DocumentContentSynchronizer listener = new DocumentContentSynchronizer(this, theDocument, syncKind);
 				theDocument.addDocumentListener(listener);
 				LanguageServerWrapper.this.connectedDocuments.put(uri, listener);
-				return listener.lastChangeFuture();
+				return listener.didOpenFuture();
 			}
 		}).thenApply(theVoid -> languageServer);
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -28,8 +28,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -139,6 +141,17 @@ public class LanguageServiceAccessor {
 		public boolean isActive() {
 			return this.wrapper.isActive();
 		}
+
+		/**
+  		 * Submit an asynchronous call (i.e. to the language server) that will be inserted into the current
+  		 * stream of document change events
+  		 *
+  		 * @see org.eclipse.lsp4e.LanguageServerWrapper#executeOnCurrentVersionAsync
+  		 */
+ 		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(
+  				Function<LanguageServer, ? extends CompletionStage<U>> fn) {
+  			return this.wrapper.executeOnCurrentVersionAsync(this.fileUri, fn);
+  		}
 	}
 
 	public static @NonNull List<CompletableFuture<LanguageServer>> getInitializedLanguageServers(@NonNull IFile file,

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -148,7 +148,7 @@ public class LanguageServiceAccessor {
   		 *
   		 * @see org.eclipse.lsp4e.LanguageServerWrapper#executeOnCurrentVersionAsync
   		 */
- 		public <U> @Nullable CompletableFuture<U> executeOnCurrentVersionAsync(
+ 		public <U> @Nullable CompletableFuture<VersionedResult<U>> executeOnCurrentVersionAsync(
   				Function<LanguageServer, ? extends CompletionStage<U>> fn) {
   			return this.wrapper.executeOnCurrentVersionAsync(this.fileUri, fn);
   		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/VersionedResult.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/VersionedResult.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Cocotec Ltd and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Ahmed Hussain (Cocotec Ltd) - initial implementation
+ *
+ *******************************************************************************/
+package org.eclipse.lsp4e;
+
+/**
+ * Groups a result from the language server with the modification stamp that existed on the document
+ * at the time the request to the server was made
+ * @param <T>
+ */
+public class VersionedResult<T> {
+
+	private final long documentModificationStamp;
+
+	private final T t;
+
+	public VersionedResult(final T result, final long documentModificationStamp) {
+		this.t = result;
+		this.documentModificationStamp = documentModificationStamp;
+	}
+
+	public T get() {
+		return this.t;
+	}
+
+	/**
+	 * Modification stamp. See org.eclipse.jface.text.IDocumentExtension4.getModificationStamp()
+	 *
+	 * Note that this is closer to a hash than a timestamp, since comparing stamps for ordering rather than
+	 * equality is not guaranteed to be meaningful.
+	 * @return
+	 */
+	public long getStamp() {
+		return this.documentModificationStamp;
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -86,8 +86,7 @@ public class LSPFormatter {
 					fullFormat ? info.getDocument().getLength() : textSelection.getOffset() + textSelection.getLength(),
 					info.getDocument());
 			params.setRange(new Range(start, end));
-			return info.getInitializedLanguageClient()
-					.thenComposeAsync(server -> server.getTextDocumentService().rangeFormatting(params));
+			return info.executeOnCurrentVersionAsync(server -> server.getTextDocumentService().rangeFormatting(params));
 		}
 
 		DocumentFormattingParams params = new DocumentFormattingParams();


### PR DESCRIPTION
This is the concurrency fix for format which I resubmitted the other week having split it out of the original set of concurrency fixes. I withdrew it and have now revised it to allow the consuming code to detect when the formatting edits were provided by the server based on file content which has since changed. Merely ensuring calls to the server are sent in sequence wrt a given document is not enough, since the UI thread remains unblocked and can have further updated the document. The solution amounts to an optimistic locking model - the code that has requested formatting will be submitting the edits on the UI thread and can thus check whether the content is unchanged from the version of the document on which the format request was dispatch.

Added a couple of test cases to illustrate this.
