### PR TITLE
Improve logging of java.util.concurrent.TimeoutException

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -831,7 +831,7 @@ public class LSPEclipseUtils {
 		return toUri(absolutePath.toFile());
 	}
 
-	public static URI toUri(IResource resource) {
+	public static URI toUri(@NonNull IResource resource) {
 		URI adaptedURI = Adapters.adapt(resource, URI.class, true);
 		if (adaptedURI != null) {
 			return adaptedURI;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -562,11 +562,13 @@ public class LanguageServerWrapper {
 		if (this.initializeFuture != null) {
 			try {
 				this.initializeFuture.get(1, TimeUnit.SECONDS);
-			} catch (ExecutionException | TimeoutException e) {
+			} catch (ExecutionException e) {
 				LanguageServerPlugin.logError(e);
 			} catch (InterruptedException e) {
 				LanguageServerPlugin.logError(e);
 				Thread.currentThread().interrupt();
+			} catch (TimeoutException e) {
+				LanguageServerPlugin.logWarning("Could not get if the workspace folder capability is supported due to timeout after 1 second", e); //$NON-NLS-1$
 			}
 		}
 		return initiallySupportsWorkspaceFolders || supportsWorkspaceFolders(serverCapabilities);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
@@ -88,7 +88,7 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 				checkMarkerResoultion(marker);
 				att = marker.getAttribute(LSP_REMEDIATION);
 			}
-		} catch (IOException | CoreException | ExecutionException | TimeoutException e) {
+		} catch (IOException | CoreException | ExecutionException e) {
 			LanguageServerPlugin.logError(e);
 			return new IMarkerResolution[0];
 		} catch (InterruptedException e) {
@@ -115,7 +115,7 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 		return res.toArray(new IMarkerResolution[res.size()]);
 	}
 
-	private void checkMarkerResoultion(IMarker marker) throws IOException, CoreException, InterruptedException, ExecutionException, TimeoutException {
+	private void checkMarkerResoultion(IMarker marker) throws IOException, CoreException, InterruptedException, ExecutionException {
 		IResource res = marker.getResource();
 		if (res != null && res.getType() == IResource.FILE) {
 			IFile file = (IFile)res;
@@ -142,7 +142,11 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 				});
 			}
 			// wait a bit to avoid showing too much "Computing" without looking like a freeze
-			CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(300, TimeUnit.MILLISECONDS);
+			try {
+				CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(300, TimeUnit.MILLISECONDS);
+			} catch (TimeoutException e) {
+				LanguageServerPlugin.logWarning("Could get code actions due to timeout after 300 miliseconds in `textDocument/codeAction`", e); //$NON-NLS-1$
+			}
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -317,11 +317,13 @@ public class LSCompletionProposal
 			try {
 				languageServer.getTextDocumentService().resolveCompletionItem(item).thenAcceptAsync(this::updateCompletionItem)
 						.get(RESOLVE_TIMEOUT, TimeUnit.MILLISECONDS);
-			} catch (ExecutionException | TimeoutException e) {
+			} catch (ExecutionException e) {
 				LanguageServerPlugin.logError(e);
 			} catch (InterruptedException e) {
 				LanguageServerPlugin.logError(e);
 				Thread.currentThread().interrupt();
+			} catch (TimeoutException e) {
+				LanguageServerPlugin.logWarning("Could not resolve completion items due to timeout after " + RESOLVE_TIMEOUT + " miliseconds in `completionItem/resolve`", e);  //$NON-NLS-1$//$NON-NLS-2$
 			}
 		}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -92,11 +92,13 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 					}
 				})).toArray(CompletableFuture[]::new))
 			).get(500, TimeUnit.MILLISECONDS);
-		} catch (ExecutionException | TimeoutException e) {
+		} catch (ExecutionException e) {
 			LanguageServerPlugin.logError(e);
 		} catch (InterruptedException e) {
 			LanguageServerPlugin.logError(e);
 			Thread.currentThread().interrupt();
+		} catch (TimeoutException e) {
+			LanguageServerPlugin.logWarning("Could not detect hyperlinks due to timeout after 500 miliseconds", e);  //$NON-NLS-1$
 		}
 		if (allLinks.isEmpty()) {
 			return null;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
@@ -87,12 +87,15 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 								.map(future -> {
 									try {
 										return future.get(2, TimeUnit.SECONDS);
-									} catch (ExecutionException | TimeoutException e) {
+									} catch (ExecutionException e) {
 										LanguageServerPlugin.logError(e);
 										return null;
 									} catch (InterruptedException e) {
 										LanguageServerPlugin.logError(e);
 										Thread.currentThread().interrupt();
+										return null;
+									} catch (TimeoutException e) {
+										LanguageServerPlugin.logWarning("Could not detect hyperlinks due to timeout after 2 seconds in `document/Link`", e); //$NON-NLS-1$
 										return null;
 									}
 								}).filter(Objects::nonNull).flatMap(List<DocumentLink>::stream).map(link -> {
@@ -117,12 +120,15 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 							return res;
 						}
 					}).get(2, TimeUnit.SECONDS);
-		} catch (ExecutionException | TimeoutException e) {
+		} catch (ExecutionException e) {
 			LanguageServerPlugin.logError(e);
 			return null;
 		} catch (InterruptedException e) {
 			LanguageServerPlugin.logError(e);
 			Thread.currentThread().interrupt();
+			return null;
+		} catch (TimeoutException e) {
+			LanguageServerPlugin.logWarning("Could not detect hyperlinks due to timeout after 2 seconds", e); //$NON-NLS-1$
 			return null;
 		}
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -74,11 +74,13 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 				if (result != null) {
 					return result;
 				}
-			} catch (ExecutionException | TimeoutException e) {
+			} catch (ExecutionException e) {
 				LanguageServerPlugin.logError(e);
 			} catch (InterruptedException e) {
 				LanguageServerPlugin.logError(e);
 				Thread.currentThread().interrupt();
+			} catch (TimeoutException e) {
+				LanguageServerPlugin.logWarning("Could not get hover information due to timeout after 500 miliseconds", e); //$NON-NLS-1$
 			}
 		}
 		return null;
@@ -166,11 +168,13 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 				this.lastRegion = new Region(regionStartOffset[0], regionEndOffset[0] - regionStartOffset[0]);
 				return this.lastRegion;
 			}
-		} catch (ExecutionException | TimeoutException e1) {
-			LanguageServerPlugin.logError(e1);
-		} catch (InterruptedException e1) {
-			LanguageServerPlugin.logError(e1);
+		} catch (ExecutionException e) {
+			LanguageServerPlugin.logError(e);
+		} catch (InterruptedException e) {
+			LanguageServerPlugin.logError(e);
 			Thread.currentThread().interrupt();
+		} catch (TimeoutException e) {
+			LanguageServerPlugin.logWarning("Could not get hover region due to timeout after 500 miliseconds", e); //$NON-NLS-1$
 		}
 		this.lastRegion = new Region(offset, 0);
 		return this.lastRegion;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSFindReferences.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSFindReferences.java
@@ -91,11 +91,13 @@ public class LSFindReferences extends AbstractHandler implements IHandler {
 					.getLanguageServers(LSPEclipseUtils.getDocument(editor),
 							capabilities -> LSPEclipseUtils.hasCapability(capabilities.getReferencesProvider()))
 					.get(50, TimeUnit.MILLISECONDS).isEmpty();
-		} catch (TimeoutException | java.util.concurrent.ExecutionException e) {
+		} catch (java.util.concurrent.ExecutionException e) {
 			LanguageServerPlugin.logError(e);
 		} catch (InterruptedException e) {
 			LanguageServerPlugin.logError(e);
 			Thread.currentThread().interrupt();
+		} catch (TimeoutException e) {
+			LanguageServerPlugin.logWarning("Could not get language server due to timeout after 50 miliseconds", e); //$NON-NLS-1$
 		}
 		return false;
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
@@ -151,11 +151,13 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 						}
 					}
 				}
-			} catch (ExecutionException | TimeoutException e) {
+			} catch (ExecutionException e) {
 				LanguageServerPlugin.logError(e);
 			} catch (InterruptedException e) {
 				LanguageServerPlugin.logError(e);
 				Thread.currentThread().interrupt();
+			} catch (TimeoutException e) {
+				LanguageServerPlugin.logWarning("Could not get workspace symbols due to timeout after 1 seconds in `workspace/symbol`", e); //$NON-NLS-1$
 			}
 		}
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/WorkspaceSymbolsQuickAccessProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/WorkspaceSymbolsQuickAccessProvider.java
@@ -67,10 +67,12 @@ public class WorkspaceSymbolsQuickAccessProvider implements IQuickAccessComputer
 							res.addAll(LSPSymbolInWorkspaceDialog.eitherToWorkspaceSymbols(symbols).stream().map(WorkspaceSymbolQuickAccessElement::new)
 									.collect(Collectors.toList()));
 						}
-					})).toArray(CompletableFuture[]::new)).get(1000, TimeUnit.MILLISECONDS);
+					})).toArray(CompletableFuture[]::new)).get(1, TimeUnit.SECONDS);
 		}
-		catch (ExecutionException | TimeoutException | InterruptedException e) {
+		catch (ExecutionException | InterruptedException e) {
 			LanguageServerPlugin.logError(e);
+		} catch (TimeoutException e) {
+			LanguageServerPlugin.logWarning("Could not get workspace symbols due to timeout after 1 second in `workspace/symbol`", e); //$NON-NLS-1$
 		}
 
 		return res.toArray(new QuickAccessElement[res.size()]);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -74,9 +74,6 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 		public final ITextEditor textEditor;
 
 		@Nullable
-		private final IPath documentPath;
-
-		@Nullable
 		public final IFile documentFile;
 
 		@Nullable
@@ -84,9 +81,15 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 
 		public OutlineViewerInput(IDocument document, LanguageServer languageServer, @Nullable ITextEditor textEditor) {
 			this.document = document;
-			documentPath = LSPEclipseUtils.toPath(document);
-			documentFile = documentPath == null ? null : LSPEclipseUtils.getFile(documentPath);
-			documentURI = documentFile == null ? null : LSPEclipseUtils.toUri(documentFile);
+			IPath path = LSPEclipseUtils.toPath(document);
+			if (path == null) {
+				documentFile = null;
+				documentURI = null;
+			} else {
+				IFile file = LSPEclipseUtils.getFile(path);
+				documentFile = file;
+				documentURI = file == null ? null : LSPEclipseUtils.toUri(file);
+			}
 			this.languageServer = languageServer;
 			this.textEditor = textEditor;
 		}


### PR DESCRIPTION
If the server is not responsive enough logging errors without any other
context than a stacktrace looks to the end user a bit scary, as if the
IDE would be broken.

Instead reporting a warning with a message that explains the context and
include the timeout that was not met.