### PR TITLE
initialize currentPercentageMap with 0

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/progress/LSPProgressManager.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/progress/LSPProgressManager.java
@@ -108,7 +108,7 @@ public class LSPProgressManager {
 		Integer percentage = begin.getPercentage();
 		if (percentage != null) {
 			monitor.beginTask(begin.getTitle(), percentage);
-			currentPercentageMap.put(monitor, percentage);
+			currentPercentageMap.put(monitor, 0);
 		} else {
 			monitor.beginTask(begin.getTitle(), IProgressMonitor.UNKNOWN);
 		}


### PR DESCRIPTION
when the map entry is created, not to 100, which would mean that the job has been already done.