### PR TITLE
Fix suspected concurrency bug in debug logging

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -258,8 +258,8 @@ public class LanguageServerWrapper {
 				}
 
 				UnaryOperator<MessageConsumer> wrapper = consumer -> (message -> {
-					consumer.consume(message);
 					logMessage(message);
+					consumer.consume(message);
 					final StreamConnectionProvider currentConnectionProvider = this.lspStreamProvider;
 					if (currentConnectionProvider != null && isActive()) {
 						currentConnectionProvider.handleMessage(message, this.languageServer, rootURI);


### PR DESCRIPTION
We get random `ConcurrentModificationExceptions` when running with json wire logging (via setting `org.eclipse.lsp4e/debug` to true), e.g.:

![image](https://user-images.githubusercontent.com/6334768/181598903-4dd86a8b-2bee-4b65-8318-a329258417cb.png)




We thought these might be the smoking gun for a bug we were investigating, but I think they're an artifact of the toString() method traversing collections while the ultimate endpoint message consumer may be mutating (e.g. by sorting) the message.

These turn up a fair bit when running our integration tests with this tracing turned on, and go away when these two lines are swapped (`logMessage()` is fully synchronous, while `consumer.consume()` might well not be).