### PR TITLE
getDocumentContentTypes to ignore FNFE

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -935,7 +935,12 @@ public class LSPEclipseUtils {
 						contentTypes.add(contentType);
 					}
 				} catch (CoreException e) {
-					LanguageServerPlugin.logError("Exception occurred while fetching the content type from the buffer", e); //$NON-NLS-1$;
+					if (!e.getCause() instanceof java.io.FileNotFoundException) {
+						//the content type may be based on path or file name pattern or another subsystem via the ContentTypeManager
+						// so that is not an error condition
+						//otherwise, account for some other unknown CoreException
+						LanguageServerPlugin.logError("Exception occurred while fetching the content type from the buffer", e); //$NON-NLS-1$;
+					}
 				}
 			}
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -935,7 +935,7 @@ public class LSPEclipseUtils {
 						contentTypes.add(contentType);
 					}
 				} catch (CoreException e) {
-					if (!e.getCause() instanceof java.io.FileNotFoundException) {
+					if (!(e.getCause() instanceof java.io.FileNotFoundException)) {
 						//the content type may be based on path or file name pattern or another subsystem via the ContentTypeManager
 						// so that is not an error condition
 						//otherwise, account for some other unknown CoreException


### PR DESCRIPTION
for Errors when creating untitled text files #147

the content type may be based on path or file name pattern or another subsystem via the ContentTypeManager so that is not necessarily an error condition