### PR TITLE
Fix lost error message checkInitialConditions

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
@@ -118,8 +118,7 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 				}
 			}
 		} catch (Exception e) {
-			handleError(e, status);
-			return new RefactoringStatus();
+			status.addFatalError(getErrorMessage(e));
 		}
 		return status;
 	}
@@ -176,21 +175,19 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 				}
 			}
 		} catch (Exception e) {
-			handleError(e, status);
+			status.addFatalError(getErrorMessage(e));
 		}
 		return status;
 	}
 
-	private WorkspaceEdit handleError(Throwable e, RefactoringStatus status) {
+	private String getErrorMessage(Throwable e) {
 		if (e.getCause() instanceof ResponseErrorException) {
 			ResponseError responseError = ((ResponseErrorException) e.getCause()).getResponseError();
-			String message = responseError.getMessage()
+			return responseError.getMessage()
 					+ ((responseError.getData() instanceof String) ? (": " + responseError.getData()) : ""); //$NON-NLS-1$ //$NON-NLS-2$
-			status.addFatalError(message);
 		} else {
-			status.addFatalError(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+			return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
 		}
-		return null;
 	}
 
 	@Override


### PR DESCRIPTION
The method checkInitialConditions was handling the error using an status
which was never returned. In addition the method handleError was
returning a value which was never used.

Both problem has been fixed by removing handleError and adding a method
that just gets the error message. This makes more clear where this error
message is attached. The error handling of checkInitialConditions has
been then fixed accordingly.