### PR TITLE
Implement basic variable substitution

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/AllTests.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/AllTests.java
@@ -19,6 +19,7 @@ import org.eclipse.lsp4e.test.completion.CompleteCompletionTest;
 import org.eclipse.lsp4e.test.completion.CompletionOrderingTests;
 import org.eclipse.lsp4e.test.completion.ContextInformationTest;
 import org.eclipse.lsp4e.test.completion.IncompleteCompletionTest;
+import org.eclipse.lsp4e.test.completion.VariableReplacementTest;
 import org.eclipse.lsp4e.test.debug.DebugTest;
 import org.eclipse.lsp4e.test.definition.DefinitionTest;
 import org.eclipse.lsp4e.test.diagnostics.DiagnosticsTest;
@@ -55,6 +56,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	CompleteCompletionTest.class,
 	IncompleteCompletionTest.class,
 	CompletionOrderingTests.class,
+	VariableReplacementTest.class,
 	ContextInformationTest.class,
 	DocumentDidOpenTest.class,
 	DocumentDidChangeTest.class,

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
@@ -12,7 +12,10 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.completion;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -414,46 +417,6 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		assertEquals(1, proposals.length);
 		((LSCompletionProposal) proposals[0]).apply(viewer.getDocument());
 		assertEquals(" and foo", viewer.getDocument().get());
-		// TODO check link edit groups
-	}
-
-	@Test
-	public void testDuplicateVariable() throws PartInitException, CoreException {
-		CompletionItem completionItem = createCompletionItem("${1:foo} and ${1:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
-		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
-		MockLanguageServer.INSTANCE
-				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
-		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,""));
-		int invokeOffset = 0;
-		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
-		assertEquals(1, proposals.length);
-		((LSCompletionProposal) proposals[0]).apply(viewer.getDocument());
-		assertEquals("foo and foo", viewer.getDocument().get());
-		// TODO check link edit groups
-	}
-
-	@Test
-	public void testVariableReplacement() throws PartInitException, CoreException {
-		CompletionItem completionItem = createCompletionItem(
-				"${1:$TM_FILENAME_BASE} ${2:$TM_FILENAME} ${3:$TM_FILEPATH} ${4:$TM_DIRECTORY} ${5:$TM_LINE_INDEX} ${6:$TM_LINE_NUMBER} ${7:$TM_CURRENT_LINE} ${8:$TM_SELECTED_TEXT}",
-				CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
-		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
-		MockLanguageServer.INSTANCE
-				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
-		String content = "line1\nline2\nline3";
-		IFile testFile = TestUtils.createUniqueTestFile(project, content);
-		ITextViewer viewer = TestUtils.openTextViewer(testFile);
-		int invokeOffset = 0;
-		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
-		assertEquals(1, proposals.length);
-		((LSCompletionProposal) proposals[0]).apply(viewer.getDocument());
-
-		int lineIndex = completionItem.getTextEdit().getLeft().getRange().getStart().getLine();
-		String fileNameBase = testFile.getFullPath().removeFileExtension().lastSegment();
-		String filePath = testFile.getRawLocation().toOSString();
-		String fileDir = project.getLocation().toOSString();
-		assertEquals(String.format("%s %s %s %s %d %d %s %s%s", fileNameBase, testFile.getName(), filePath, fileDir,
-				lineIndex, lineIndex + 1, "line1", "l", content.substring(1)), viewer.getDocument().get());
 		// TODO check link edit groups
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/VariableReplacementTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/VariableReplacementTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.completion;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.lsp4e.operations.completion.LSCompletionProposal;
+import org.eclipse.lsp4e.test.TestUtils;
+import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.InsertTextFormat;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.ui.PartInitException;
+import org.junit.Test;
+
+public class VariableReplacementTest extends AbstractCompletionTest {
+
+	@Test
+	public void testDuplicateVariable() throws PartInitException, CoreException {
+		CompletionItem completionItem = createCompletionItem("${1:foo} and ${1:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
+		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
+		MockLanguageServer.INSTANCE
+				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,""));
+		int invokeOffset = 0;
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
+		assertEquals(1, proposals.length);
+		((LSCompletionProposal) proposals[0]).apply(viewer.getDocument());
+		assertEquals("foo and foo", viewer.getDocument().get());
+		// TODO check link edit groups
+	}
+
+	@Test
+	public void testVariableReplacement() throws PartInitException, CoreException {
+		CompletionItem completionItem = createCompletionItem(
+				"${1:$TM_FILENAME_BASE} ${2:$TM_FILENAME} ${3:$TM_FILEPATH} ${4:$TM_DIRECTORY} ${5:$TM_LINE_INDEX} ${6:$TM_LINE_NUMBER} ${7:$TM_CURRENT_LINE} ${8:$TM_SELECTED_TEXT}",
+				CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
+		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
+		MockLanguageServer.INSTANCE
+				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+		String content = "line1\nline2\nline3";
+		IFile testFile = TestUtils.createUniqueTestFile(project, content);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
+		int invokeOffset = 0;
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
+		assertEquals(1, proposals.length);
+		viewer.setSelectedRange(2, 3); //ne1
+		((LSCompletionProposal) proposals[0]).apply(viewer, '\0', 0, 0);
+
+		String fileNameBase = testFile.getFullPath().removeFileExtension().lastSegment();
+		String filePath = testFile.getRawLocation().toOSString();
+		String fileDir = project.getLocation().toOSString();
+		assertEquals(String.format("%s %s %s %s %d %d %s %s%s" , fileNameBase, testFile.getName(), filePath, fileDir,
+				0, 1, "line1", "ne1", content.substring(1) ), viewer.getDocument().get());
+		// TODO check link edit groups
+	}
+
+	@Test
+	public void testVariableNameWithoutBraces() throws PartInitException, CoreException {
+		CompletionItem completionItem = createCompletionItem(
+				"$TM_FILENAME_BASE",
+				CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
+		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
+		MockLanguageServer.INSTANCE
+				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+		String content = "line1\nline2\nline3";
+		IFile testFile = TestUtils.createUniqueTestFile(project, content);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
+		int invokeOffset = 0;
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
+		assertEquals(1, proposals.length);
+		((LSCompletionProposal) proposals[0]).apply(viewer.getDocument());
+
+		String fileNameBase = testFile.getFullPath().removeFileExtension().lastSegment();
+		assertEquals(fileNameBase + "ine1\nline2\nline3", viewer.getDocument().get());
+		// TODO check link edit groups
+	}
+	
+	@Test
+	public void testVariableNameWithBraces() throws PartInitException, CoreException {
+		CompletionItem completionItem = createCompletionItem(
+				"${TM_FILENAME_BASE}",
+				CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
+		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
+		MockLanguageServer.INSTANCE
+				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+		String content = "line1\nline2\nline3";
+		IFile testFile = TestUtils.createUniqueTestFile(project, content);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
+		int invokeOffset = 0;
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
+		assertEquals(1, proposals.length);
+		((LSCompletionProposal) proposals[0]).apply(viewer.getDocument());
+
+		String fileNameBase = testFile.getFullPath().removeFileExtension().lastSegment();
+		assertEquals(fileNameBase + "ine1\nline2\nline3", viewer.getDocument().get());
+		// TODO check link edit groups
+	}
+}

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -34,9 +34,13 @@ import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DidChangeNotebookDocumentParams;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidCloseNotebookDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenNotebookDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.DidSaveNotebookDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentLink;
@@ -307,7 +311,27 @@ public final class MockLanguageServer implements LanguageServer {
 
 	@Override
 	public NotebookDocumentService getNotebookDocumentService() {
-		return null;
+		return new NotebookDocumentService() {
+			@Override
+			public void didSave(DidSaveNotebookDocumentParams params) {
+				// TODO Auto-generated method stub
+			}
+
+			@Override
+			public void didOpen(DidOpenNotebookDocumentParams params) {
+				// TODO Auto-generated method stub
+			}
+
+			@Override
+			public void didClose(DidCloseNotebookDocumentParams params) {
+				// TODO Auto-generated method stub
+			}
+
+			@Override
+			public void didChange(DidChangeNotebookDocumentParams params) {
+				// TODO Auto-generated method stub
+			}
+		};
 	}
 
 }


### PR DESCRIPTION
for completion proposals. Just ${var} or $var, without tab stops, choice
nor linked edition.
Fixes https://github.com/eclipse/lsp4e/issues/204