### PR TITLE
Improve user feedback when on save actions timeout

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
@@ -74,6 +74,9 @@ public class Messages extends NLS {
 	public static String edit_CreateFile;
 	public static String workspaceSymbols;
 	public static String symbolsInFile;
+	public static String DocumentContentSynchronizer_OnSaveActionTimeout;
+	public static String DocumentContentSynchronizer_TimeoutMessage;
+	public static String DocumentContentSynchronizer_TimeoutThresholdMessage;
 
 	static {
 		NLS.initializeMessages("org.eclipse.lsp4e.ui.messages", Messages.class); //$NON-NLS-1$

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
@@ -78,3 +78,7 @@ enableDisableLSJob=Enable/Disable Language Servers
 edit_CreateFile=Create file {0}
 workspaceSymbols=Workspace symbols
 symbolsInFile=Symbols in {0}
+
+DocumentContentSynchronizer_OnSaveActionTimeout="On Save Action Timeout"
+DocumentContentSynchronizer_TimeoutMessage="On-Save action timeout out after {0} seconds for {1}"
+DocumentContentSynchronizer_TimeoutThresholdMessage="On-Save action timeout out after {0} seconds for {1}. On-Save actions will no longer be called for this document"


### PR DESCRIPTION
 by showing a notification (vanishing pop-up on the bottom right corner) and
increasing the default timeout from two to five seconds