### PR TITLE
UNC paths: Support preferred UNC URI syntax on Windows

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -13,7 +13,9 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.edit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -293,6 +295,17 @@ public class LSPEclipseUtilsTest {
 		Assert.assertEquals("file:///test%20with%20space", LSPEclipseUtils.toUri(new File("/test with space")).toString());
 	}
 
+	@Test
+	public void testUNCwindowsURI() {
+		Assume.assumeTrue(Platform.OS_WIN32.equals(Platform.getOS()));
+		URI preferredURI = URI.create("file://localhost/c$/Windows");
+		URI javaURI = URI.create("file:////localhost/c$/Windows");
+		
+		File file1 = LSPEclipseUtils.fromUri(preferredURI);
+		File file2 = LSPEclipseUtils.fromUri(javaURI);
+		Assert.assertEquals(file1, file2);
+	}
+	
 	@Test
 	public void testToWorkspaceFolder() throws Exception {
 		IProject project = TestUtils.createProject("testToWorkspaceFolder");

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -1098,12 +1098,8 @@ public class LSPEclipseUtils {
 	 * @param uri A file URI, possibly for a UNC path in the newer syntax with the server encoded in the authority
 	 * @return A file
 	 */
-	public static File fromUri(URI uri) {
+	private static File fromUri(URI uri) {
 		return Paths.get(uri).toFile();
-	}
-
-	public static File fromUri(String uri) {
-		return fromUri(URI.create(uri));
 	}
 
 	public static boolean hasCapability(Either<Boolean, ? extends Object> eitherCapability) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -1098,7 +1098,7 @@ public class LSPEclipseUtils {
 	 * @param uri A file URI, possibly for a UNC path in the newer syntax with the server encoded in the authority
 	 * @return A file
 	 */
-	private static File fromUri(URI uri) {
+	public static File fromUri(URI uri) {
 		return Paths.get(uri).toFile();
 	}
 


### PR DESCRIPTION
This change allows LSP4e to cope with a language server that sends URIs for UNC paths on an unmapped network drive in the modern [Microsoft preferred] way, using the authority to convey the server name.

I.e. `\\myserver\myshare\path\to\file` can be accepted in the newer, preferred syntax `file://myserver/myshare/path/to/file` rather than `file:////myserver/myshare/path/to/file`. The traditional `java.io.File` class will only generate and accept URIs in the legacy format, but `java.nio.file.Paths` will accept either and generate the former.

Changing LSP4e to generate the newer syntax would risk breaking any language servers built in Java, and furthermore caused some internal breakages where we convert `File`s to `URI`s and back again. There are, however, only a couple of places that consume URIs from the server, which are trivial to fix. LSP4e doesn't use `URI`s directly to key any lookup tables or dictionaries (it mostly uses eclipse `IFile/IResource/IPath` objects in internal APIs) so there don't seem to be any canonicalisation problems.

See https://docs.microsoft.com/en-us/archive/blogs/ie/file-uris-in-windows
https://en.wikipedia.org/wiki/File_URI_scheme#Windows
https://wiki.eclipse.org/Eclipse/UNC_Paths#Programming_with_UNC_paths
https://bugs.openjdk.org/browse/JDK-4723726

And the notes on https://docs.oracle.com/javase/7/docs/api/java/io/File.html and https://docs.oracle.com/javase/7/docs/api/java/nio/file/Path.html#toUri()