### PR TITLE
Experimentally use a single dispatcher thread per LS

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
@@ -11,12 +11,15 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.format;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -34,6 +37,7 @@ import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -71,10 +75,11 @@ public class FormatTest {
 
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
+		final long currentStamp = LSPEclipseUtils.getDocumentModificationStamp(viewer.getDocument());
 
 		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
 				.get();
-		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), edits));
+		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), currentStamp, edits));
 
 		ITextEditor textEditor = (ITextEditor) editor;
 		textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
@@ -99,9 +104,11 @@ public class FormatTest {
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
 
+		final long currentStamp = LSPEclipseUtils.getDocumentModificationStamp(viewer.getDocument());
+
 		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
 				.get();
-		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), edits));
+		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), currentStamp, edits));
 
 		ITextEditor textEditor = (ITextEditor) editor;
 		textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
@@ -109,14 +116,56 @@ public class FormatTest {
 
 		TestUtils.closeEditor(editor, false);
 	}
+	
+	@Test(expected=ConcurrentModificationException.class)
+ 	public void testFormattingVersionClashDetected() throws Exception {
+ 		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
+ 		.setTextDocumentSync(TextDocumentSyncKind.Incremental);
+ 		List<TextEdit> formattingTextEdits = new ArrayList<>();
+ 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 0), new Position(0, 1)), "MyF"));
+ 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
+ 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 21), new Position(0, 21)), " Second"));
+ 		MockLanguageServer.INSTANCE.setFormattingTextEdits(formattingTextEdits);
+
+ 		IFile file = TestUtils.createUniqueTestFile(project, "Formatting Other Text");
+ 		IEditorPart editor = TestUtils.openEditor(file);
+ 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+ 		MockLanguageServer.INSTANCE.setTimeToProceedQueries(5000);
+		final long currentStamp = LSPEclipseUtils.getDocumentModificationStamp(viewer.getDocument());
+
+ 		LSPFormatter formatter = new LSPFormatter();
+ 		ISelection selection = viewer.getSelectionProvider().getSelection();
+ 		CompletableFuture<List<? extends TextEdit>> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection);
+
+ 		viewer.getDocument().replace(0, 0, "Hello, ");
+ 		viewer.getDocument().replace(6, 0, "world! ");
+ 		viewer.getDocument().replace(13, 0, "Here is some extra text!");
+ 		List<? extends TextEdit> formatting = edits.get();
+ 		final AtomicReference<Exception> thrown = new AtomicReference<>();
+ 		editor.getSite().getShell().getDisplay().syncExec(() -> {
+ 			try {
+ 				LSPEclipseUtils.applyEditsWithVersionCheck(viewer.getDocument(), currentStamp, formatting);
+ 			} catch (Exception e) {
+ 				thrown.set(e);
+ 			}
+ 		});
+
+ 		final Exception e = thrown.get();
+ 		if (e != null) {
+ 			throw e;
+ 		}
+
+ 	}
 
 	@Test
 	public void testNullFormatting() {
 		IDocument document = new Document("Formatting Other Text");
 		LSPFormatter formatter = new LSPFormatter();
+		final long currentStamp = LSPEclipseUtils.getDocumentModificationStamp(document);
+
 
 		// null is an acceptable response for no changes
-		formatter.applyEdits(document, null);
+		formatter.applyEdits(document,currentStamp,  null);
 
 		assertEquals("Formatting Other Text", document.get());
 	}

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -133,7 +133,7 @@ public final class MockLanguageServer implements LanguageServer {
 		initializeResult.setCapabilities(serverConfigurer.get());
 	}
 
-	<U> CompletableFuture<U> buildMaybeDelayedFuture(U value) {
+	public <U> CompletableFuture<U> buildMaybeDelayedFuture(U value) {
 		if (delay > 0) {
 			CompletableFuture<U> future = CompletableFuture.runAsync(() -> {
 				try {
@@ -182,6 +182,10 @@ public final class MockLanguageServer implements LanguageServer {
 	@Override
 	public MockTextDocumentService getTextDocumentService() {
 		return textDocumentService;
+	}
+
+	public void setTextDocumentService(MockTextDocumentService custom) {
+		textDocumentService = custom;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -68,8 +68,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private int version = 0;
 	private DidChangeTextDocumentParams changeParams;
 	private long modificationStamp;
-//	private final AtomicReference<CompletableFuture<LanguageServer>> lastChangeFuture;
-	private LanguageServer languageServer;
+
 	private IPreferenceStore store;
 
 	public DocumentContentSynchronizer(@NonNull LanguageServerWrapper languageServerWrapper,
@@ -111,37 +110,10 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 		textDocument.setLanguageId(languageId);
 		textDocument.setVersion(++version);
-//		lastChangeFuture = new AtomicReference<>(languageServerWrapper.getInitializedServer().thenApplyAsync(ls -> {
-//			this.languageServer = ls;
-//			ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument));
-//			return ls;
-//		}));
+
 		this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument)));
 	}
 
-//	/**
-// 	 * Submit an asynchronous call (i.e. to the language server) that be inserted into the current position w.r.t.
-// 	 * document change events
-// 	 *
-// 	 * @param <U> Computation return type
-// 	 * @param fn Asynchronous computation on the language server
-// 	 * @return Asynchronous result object.
-// 	 */
-//	private <U> @NonNull CompletableFuture<U> executeOnCurrentVersionAsync(
-//			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
-//		AtomicReference<CompletableFuture<U>> resValueFuture = new AtomicReference<>();
-//		lastChangeFuture.updateAndGet(f -> {
-//			CompletableFuture<U> valueFuture = f.thenComposeAsync(fn);
-//			resValueFuture.set(valueFuture);
-//			// We ignore any exceptions that happen when executing the given future
-//			return valueFuture.handle((value, error) -> this.languageServer);
-//		});
-//		return resValueFuture.get();
-//	}
-
-//	CompletableFuture<LanguageServer> lastChangeFuture() {
-//		return lastChangeFuture.get();
-//	}
 
 	@Override
 	public void documentChanged(DocumentEvent event) {
@@ -155,10 +127,6 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			changeParams = null;
 
 			changeParamsToSend.getTextDocument().setVersion(++version);
-//			lastChangeFuture.updateAndGet(f -> f.thenApplyAsync(ls -> {
-//				ls.getTextDocumentService().didChange(changeParamsToSend);
-//				return ls;
-//			}));
 			this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didChange(changeParamsToSend));
 		}
 	}
@@ -302,10 +270,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		}
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri.toString());
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(identifier, document.get());
-//		lastChangeFuture.updateAndGet(f -> f.thenApplyAsync(ls -> {
-//  			ls.getTextDocumentService().didSave(params);
-//  			return ls;
-//  		}));
+
 		this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didSave(params));
 
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -55,7 +55,6 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.osgi.util.NLS;
 
 final class DocumentContentSynchronizer implements IDocumentListener {
@@ -127,7 +126,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			changeParams = null;
 
 			changeParamsToSend.getTextDocument().setVersion(++version);
-			this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didChange(changeParamsToSend));
+			languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didChange(changeParamsToSend));
 		}
 	}
 
@@ -235,7 +234,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 
 		try {
-			List<TextEdit> edits = this.languageServerWrapper.executeOnLatestVersion(ls -> ls.getTextDocumentService().willSaveWaitUntil(params))
+			List<TextEdit> edits = languageServerWrapper.executeOnLatestVersion(ls -> ls.getTextDocumentService().willSaveWaitUntil(params))
 				.get(lsToWillSaveWaitUntilTimeout(), TimeUnit.SECONDS);
 			try {
 				LSPEclipseUtils.applyEdits(document, edits);
@@ -271,7 +270,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri.toString());
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(identifier, document.get());
 
-		this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didSave(params));
+		languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didSave(params));
 
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -55,6 +55,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.osgi.util.NLS;
 
 final class DocumentContentSynchronizer implements IDocumentListener {
@@ -71,6 +72,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private IPreferenceStore store;
 
 	public DocumentContentSynchronizer(@NonNull LanguageServerWrapper languageServerWrapper,
+			@NonNull LanguageServer languageServer,
 			@NonNull IDocument document, TextDocumentSyncKind syncKind) {
 		this.languageServerWrapper = languageServerWrapper;
 		URI uri = LSPEclipseUtils.toUri(document);
@@ -109,8 +111,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 		textDocument.setLanguageId(languageId);
 		textDocument.setVersion(++version);
-
-		this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument)));
+		languageServer.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument));
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
@@ -40,6 +40,7 @@ public class LanguageServerPlugin extends AbstractUIPlugin {
 	@Override
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
+		LanguageServiceAccessor.shutdownAllDispatchers();
 		super.stop(context);
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -768,7 +768,7 @@ public class LanguageServerWrapper {
 	 * @return Async result
 	 */
 	<T> CompletableFuture<T> executeOnLatestVersion(Function<LanguageServer, ? extends CompletionStage<T>> fn) {
-		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
+ 		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
 	}
 	/**
 	 * Sends a notification to the LS on a single executor thread tied to this server. Use of this guarantees that the server
@@ -800,7 +800,7 @@ public class LanguageServerWrapper {
 				}
 			}
 			return CompletableFuture.completedFuture(null);
-		}, this.dispatcher).thenApply(server -> this);
+		}, this.dispatcher).thenApply(server -> server == null ? null : this);
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -767,7 +767,8 @@ public class LanguageServerWrapper {
 	 * @param fn LS method to invoke
 	 * @return Async result
 	 */
-	<T> CompletableFuture<T> executeOnLatestVersion(Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+	@NonNull
+	<T> CompletableFuture<T> executeOnLatestVersion(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
  		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
 	}
 	/**
@@ -775,7 +776,7 @@ public class LanguageServerWrapper {
 	 * will have seen all previous such requests/notifications (and document updates).
 	 * @param fn LS notification to send
 	 */
-	void notifyOnLatestVersion(Consumer<LanguageServer> fn) {
+	void notifyOnLatestVersion(@NonNull Consumer<LanguageServer> fn) {
 		getInitializedServer().thenAcceptAsync(fn, this.dispatcher);
 	}
 
@@ -790,7 +791,7 @@ public class LanguageServerWrapper {
 	 * @return Async result that guarantees the wrapped server will be active and connected to the document. Wraps
 	 * null if the server does not support the requested capabilities or could not be started.
 	 */
-	CompletableFuture<LanguageServerWrapper> connectIf(IDocument document, Predicate<ServerCapabilities> filter) {
+	@NonNull CompletableFuture<@Nullable LanguageServerWrapper> connectIf(@NonNull IDocument document, @NonNull Predicate<ServerCapabilities> filter) {
 		return getInitializedServer().thenComposeAsync(server -> {
 			if (server != null && (filter == null || filter.test(getServerCapabilities()))) {
 				try {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -666,7 +666,7 @@ public class LanguageServerWrapper {
 				LanguageServerWrapper.this.connectedDocuments.put(uri, listener);
 				return CompletableFuture.completedFuture(languageServer);
 			}
-		}, this.dispatcher).thenApply(theVoid -> languageServer);
+		}, dispatcher).thenApply(theVoid -> languageServer);
 	}
 
 	public void disconnect(URI uri) {
@@ -801,7 +801,7 @@ public class LanguageServerWrapper {
 				}
 			}
 			return CompletableFuture.completedFuture(null);
-		}, this.dispatcher).thenApply(server -> server == null ? null : this);
+		}, dispatcher).thenApply(server -> server == null ? null : this);
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -140,6 +140,16 @@ public class LanguageServiceAccessor {
 			return this.wrapper.getServerCapabilities();
 		}
 
+		/**
+		 * Make a request to the language server such that it will be received only after any pending document updates, and before any subsequent changes
+		 * @param <T> Result type
+		 * @param fn language server operation
+		 * @return Async result
+		 */
+		public @NonNull <T> CompletableFuture<@Nullable T> computeOnLatestVersion(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+			return this.wrapper.executeOnLatestVersion(fn);
+		}
+
 		public boolean isActive() {
 			return this.wrapper.isActive();
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -653,11 +653,12 @@ public class LanguageServiceAccessor {
 	 * @param fn A single method invocation on <code>LanguageServer</code>
 	 * @return Async result aggregated over all applicable lang servers, filtering out nulls.
 	 */
-	public static <T> CompletableFuture<List<T>> computeOnServers(@NonNull IDocument document, Predicate<ServerCapabilities> filter,
+	@NonNull
+	public static <T> CompletableFuture<@NonNull List<@NonNull T>> computeOnServers(@NonNull IDocument document, @NonNull Predicate<ServerCapabilities> filter,
 			Function<LanguageServer, ? extends CompletionStage<T>> fn) {
 
 		// Out-of-line so we can declare it as List rather than ArrayList to avoid type errors below
-		CompletableFuture<List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
+		final CompletableFuture<List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
 
 		return getLSWrappers(document).stream()
 			// Ensure wrappers are started, connected to the document, and filter for capabilities
@@ -679,7 +680,8 @@ public class LanguageServiceAccessor {
 	 * @param next Pending result to include
 	 * @return
 	 */
-	static <T> CompletableFuture<List<T>> combine(CompletableFuture<? extends List<T>> result, CompletableFuture<T> next) {
+	@NonNull
+	static <T> CompletableFuture<@NonNull List<@NonNull T>> combine(@NonNull CompletableFuture<? extends List<@NonNull T>> result, @NonNull CompletableFuture<@Nullable T> next) {
 		return result.thenCombine(next, (List<T> a, T b) -> {
 			if (b != null) {
 				a.add(b);
@@ -691,12 +693,13 @@ public class LanguageServiceAccessor {
 	/**
 	 * Merges two async sets of results into a single async result
 	 * @param <T> Result type
-	 * @param a First async result
-	 * @param b Second async result
+	 * @param first First async result
+	 * @param second Second async result
 	 * @return Async combined result
 	 */
-	public static <T> CompletableFuture<List<T>> concatResults(CompletableFuture<List<T>> a, CompletableFuture<List<T>> b) {
-		return a.thenCombine(b, (c, d) -> {
+	@NonNull
+	public static <T> CompletableFuture<@NonNull List<T>> concatResults(@NonNull CompletableFuture<@NonNull List<T>> first, @NonNull CompletableFuture<@NonNull List<T>> second) {
+		return first.thenCombine(second, (c, d) -> {
 			c.addAll(d);
 			return c;
 		});
@@ -709,7 +712,8 @@ public class LanguageServiceAccessor {
 	 * @param col
 	 * @return A stream (empty if col is null)
 	 */
-	public static <T> Stream<T> streamSafely(Collection<T> col) {
+	@NonNull
+	public static <T> Stream<T> streamSafely(@Nullable Collection<T> col) {
 		return col == null ? Stream.<T>of() : col.stream();
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -75,7 +75,7 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 				LanguageServiceAccessor.computeOnServers(
 									textViewer.getDocument(),
 									capabilities -> LSPEclipseUtils.hasCapability(capabilities.getDefinitionProvider()),
-									ls -> ls.getTextDocumentService().definition(LSPEclipseUtils.toDefinitionParams(params))))
+									ls -> ls.getTextDocumentService().typeDefinition(LSPEclipseUtils.toTypeDefinitionParams(params))))
 				.get(500, TimeUnit.MILLISECONDS)
 				.stream().flatMap(locations -> toHyperlinks(document, linkRegion, locations).stream())
 				.forEach(link -> allLinks.putIfAbsent(link.getLocation(), link));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -191,7 +191,7 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 	 *            the hovered offset.
 	 */
 	private void initiateHoverRequest(@NonNull ITextViewer viewer, int offset) {
-		final IDocument document = viewer.getDocument();
+		final @NonNull IDocument document = viewer.getDocument();
 		this.lastViewer = viewer;
 		try {
 			HoverParams params = LSPEclipseUtils.toHoverParams(offset, document);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -42,6 +42,7 @@ import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.MarkedString;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -192,24 +193,15 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 	private void initiateHoverRequest(@NonNull ITextViewer viewer, int offset) {
 		final IDocument document = viewer.getDocument();
 		this.lastViewer = viewer;
-		this.request = LanguageServiceAccessor
-			.getLanguageServers(document, capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()))
-				.thenApplyAsync(languageServers -> // Async is very important here, otherwise the LS Client thread is in
-													// deadlock and doesn't read bytes from LS
-				languageServers.stream()
-					.map(languageServer -> {
-						try {
-								return languageServer.getTextDocumentService()
-										.hover(LSPEclipseUtils.toHoverParams(offset, document)).get();
-						} catch (ExecutionException | BadLocationException e) {
-							LanguageServerPlugin.logError(e);
-							return null;
-						} catch (InterruptedException e) {
-							LanguageServerPlugin.logError(e);
-							Thread.currentThread().interrupt();
-							return null;
-						}
-					}).filter(Objects::nonNull).collect(Collectors.toList()));
+		try {
+			HoverParams params = LSPEclipseUtils.toHoverParams(offset, document);
+			this.request = LanguageServiceAccessor.computeOnServers(document,
+					capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()),
+					languageServer -> languageServer.getTextDocumentService().hover(params));
+
+		} catch (BadLocationException e) {
+			LanguageServerPlugin.logError(e);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
DRAFT - For design discussion only!!

This PR illustrates a possible solution to the concurrency issues that https://github.com/eclipse/lsp4e/pull/174 was attempting to fix in an ad-hoc manner for a single use case. The present approach is more general and offers an API that should allow many places in the plugin to benefit from stronger ordering guarantees whilst also simplifying their own code.

Motivation:
Following the API of LSP4j on which LSP4e is layered, the code makes heavy use of `CompletableFuture` to interact with the server asynchronously, specifically without blocking the UI thread.

The `CompletableFuture` pattern allows the code to schedule asynchronous blocks of work to be done when the server responds to requests. If the server is multithreaded then response processing need not correlate to the order requests are sent: long-running requests need not block short-running ones. However in order to achieve non-blocking behaviour, the current pattern of usage can cause the code to *dispatch* requests to the server in an unpredictable order.

E.g. if `a()`, `b()` and `c()` are LSP4j-style calls to the language server that each return a `CompletableFuture`, then the code
`a().thenComposeAsync(b);
a().thenComposeAsync(c);`
guarantees that `b` and `c` are seen by the server after `a` *completes*, but can be seen by the server in either order wrt one another.

We think this me be the course of some general erratic behaviour in the code: e.g. the server being sent a `HoverRequest` for a `Location` that does not exist in the server's view of the document, because the server has yet to receive the modification that created it.

Chaining futures together, e.g. `a().thenComposeAsync(b()).thenComposeAsync(c())` avoids this problem, but at the expense of throughput - each operation has to wait for the server to *respond* to the previous request, not just for it to have received it.

Solution:
1. We note that the effect of ordered dispatch could be achieved by simply calling the language server directly rather than via chaining to the completable futures currently exposed by `LanguageServerAccessor` and `LanguageServerWrapper`. This follows when considering that ultimately a call to the exposed proxy is just writing JSON messages in the current thread to a stream, protected by a lock: see https://github.com/eclipse/lsp4j/blob/3b83dafdd0c9ed15e86fbfe6c464f83aaf757505/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/StreamMessageConsumer.java#L66
2. However, while we expect message dispatch to generally be fast, occasionally large messages might take non-negligible time to be serialised to JSON, and it is also possible that writing to the output stream could block if piped to an unresponsive server. Therefore synchronous dispatch could be problematic, particularly if invoked from the UI thread. It is also desirable to oblige requests to the server to at least wait for initialisation to complete.
3. Therefore, a single-threaded executor is created for each language server, using the Java convenience API. This has a single unbounded queue.
4. Once the server is started, document change notifications and any requests made using the new API will be dispatched on this queue in the order in which they are made.
5. Calls using the new API on `LanguageServerWrapper` will be dispatched in the order that they are made. Specifically, any request made from the UI thread will result in the server receiving the request after all previous document updates, and before any new ones. The server's view of a given document should therefore match that of the client *at the point the request was made*. Essentially the server's timeline of modifications should be the same as the client's, just with a possible lag.
6. A convenience API is provided on `LanguageServiceAccessor` to handle the common case of aggregating results over all applicable language servers. This also guarantees that client code invoking it cannot block any server responses or inbound requests/notifications: this is important when considering that https://github.com/eclipse/lsp4j/blob/3b83dafdd0c9ed15e86fbfe6c464f83aaf757505/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java#L184 dispatches synchronously from the thread reading from the server's output stream: if code calls `languageServerFunction().andThen( < arbitrary code block > )` the chained code block will execute on the foreground in the inbound dispatch thread when the future completes. This would block further inbound messages from being read and potentially even lead to deadlock.
7. Document hover, colour mining and hyperlink detection have been ported over to demonstrate this new API.

Note that while the ordering guaranteed in 5 allows the client to predict what the server's view of a document will be when it receives a request, there is still the problem that the document may have changed by the time the response arrives. However, this can be guarded against using an optimistic locking approach. E.g. document formatting can use the following pseudocode:

![image](https://user-images.githubusercontent.com/6334768/192823340-b608d49e-15a1-43cf-97d7-1db1125a49ae.png)

Without the dispatch ordering, it would not be safe to assume that the server would be up to date with `v1` when receiving the format request.

