### PR TITLE
Use singleThreadExecutor for LS requests

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -252,7 +252,7 @@ public class LanguageServerWrapper {
 				LanguageClientImpl client = serverDefinition.createLanguageClient();
 				String theardNameFormat = "LS-" + serverDefinition.id + "-launcher-%d"; //$NON-NLS-1$ //$NON-NLS-2$
 				ExecutorService executorService = Executors
-						.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat(theardNameFormat).build());
+						.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(theardNameFormat).build());
 				initParams.setProcessId((int) ProcessHandle.current().pid());
 
 				if (rootURI != null) {


### PR DESCRIPTION
This should guarantee that the LS receives the requests in the same order as LSP4E code invokes them.