### PR TITLE
Announce `workspace/configuration` client capability to LS

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -14,6 +14,7 @@
 package org.eclipse.lsp4e;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -31,6 +32,7 @@ import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
+import org.eclipse.lsp4j.ConfigurationParams;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
@@ -67,6 +69,12 @@ public class LanguageClientImpl implements LanguageClient {
 
 	protected final LanguageServer getLanguageServer() {
 		return server;
+	}
+
+	@Override
+	public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
+		// override as needed
+		return CompletableFuture.completedFuture(Collections.emptyList());
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -289,6 +289,7 @@ public class LanguageServerWrapper {
 				}
 				WorkspaceClientCapabilities workspaceClientCapabilities = new WorkspaceClientCapabilities();
 				workspaceClientCapabilities.setApplyEdit(Boolean.TRUE);
+				workspaceClientCapabilities.setConfiguration(Boolean.TRUE);
 				workspaceClientCapabilities.setExecuteCommand(new ExecuteCommandCapabilities(Boolean.TRUE));
 				workspaceClientCapabilities.setSymbol(new SymbolCapabilities(Boolean.TRUE));
 				workspaceClientCapabilities.setWorkspaceFolders(Boolean.TRUE);


### PR DESCRIPTION
To receive `workspace/configuration` requests from an LS, the LS client needs to announce the respective capability as of LSP v3.6.0. See  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities

![image](https://user-images.githubusercontent.com/426959/194944442-837d2f46-5712-4d97-9d36-d49cbd6b1c03.png)

I encountered this issue while working on a Dart LS client and opened an issue against the Dart SDK https://github.com/dart-lang/sdk/issues/50175 where I got pointed to the spec.