### PR TITLE
LSPEclipseUtils.findMostNested now returns the most nested project

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
@@ -26,7 +26,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.function.BooleanSupplier;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -88,6 +90,25 @@ public class TestUtils {
 			return project;
 		}
 		project.create(null);
+		project.open(null);
+		// configure nature
+		return project;
+	}
+	
+	public static IProject createNestedProject(IProject parent, String projectName) throws CoreException {
+		
+		IFolder nestedFolder = parent.getFolder(projectName);
+		nestedFolder.create(true, true, new NullProgressMonitor());
+		
+		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+		if (project.exists()) {
+			return project;
+		}
+		
+		IProjectDescription desc = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+		desc.setLocation(nestedFolder.getLocation());
+			
+		project.create(desc, null);
 		project.open(null);
 		// configure nature
 		return project;

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -152,24 +152,6 @@ public class LSPEclipseUtilsTest {
 	}
 	
 	@Test
-	public void testURIToResourceMappingWithNestedProject() throws CoreException { // like maven nested modules
-		IProject project1 = null;
-		IProject project2 = null;
-		project1 = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		project2 = TestUtils.createNestedProject(project1, project1.getName() + "suffix");
-		
-		IFile file = project2.getFile("res");
-		file.create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
-		
-		IFile sameFile = project1.getFile(project1.getName() + "suffix/res");
-		
-		Assert.assertTrue(sameFile.exists());
-		
-		Assert.assertEquals(file, LSPEclipseUtils.findResourceFor(file.getLocationURI().toString()));
-		Assert.assertEquals(sameFile, LSPEclipseUtils.findResourceFor(sameFile.getLocationURI().toString()));
-	}
-	
-	@Test
 	public void testReturnMostNestedFileRegardlessArrayOrder() throws CoreException { // like maven nested modules
 		IProject project1 = null;
 		project1 = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
@@ -188,8 +170,6 @@ public class LSPEclipseUtilsTest {
 		Assert.assertEquals(mostNestedFile, LSPEclipseUtils.findMostNested(new IFile[] {someFile, mostNestedFile}));
 	}
 	
-	
-
 	@Test
 	public void testLinkedResourceURIToResourceMapping() throws CoreException, IOException { // bug 577159
 		IProject project1 = null;

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -150,6 +150,45 @@ public class LSPEclipseUtilsTest {
 		Assert.assertEquals(project2, LSPEclipseUtils.findResourceFor(project2.getLocationURI().toString()));
 
 	}
+	
+	@Test
+	public void testURIToResourceMappingWithNestedProject() throws CoreException { // like maven nested modules
+		IProject project1 = null;
+		IProject project2 = null;
+		project1 = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
+		project2 = TestUtils.createNestedProject(project1, project1.getName() + "suffix");
+		
+		IFile file = project2.getFile("res");
+		file.create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
+		
+		IFile sameFile = project1.getFile(project1.getName() + "suffix/res");
+		
+		Assert.assertTrue(sameFile.exists());
+		
+		Assert.assertEquals(file, LSPEclipseUtils.findResourceFor(file.getLocationURI().toString()));
+		Assert.assertEquals(sameFile, LSPEclipseUtils.findResourceFor(sameFile.getLocationURI().toString()));
+	}
+	
+	@Test
+	public void testReturnMostNestedFileRegardlessArrayOrder() throws CoreException { // like maven nested modules
+		IProject project1 = null;
+		project1 = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
+		
+		IFile mostNestedFile = project1.getFile("res");
+		mostNestedFile.create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
+		
+		IFolder folder = project1.getFolder("folder");
+		folder.create(true, true, new NullProgressMonitor());
+		
+		IFile someFile = project1.getFile("folder/res");
+		someFile.create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
+		
+		
+		Assert.assertEquals(mostNestedFile, LSPEclipseUtils.findMostNested(new IFile[] {mostNestedFile, someFile}));
+		Assert.assertEquals(mostNestedFile, LSPEclipseUtils.findMostNested(new IFile[] {someFile, mostNestedFile}));
+	}
+	
+	
 
 	@Test
 	public void testLinkedResourceURIToResourceMapping() throws CoreException, IOException { // bug 577159

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -365,7 +365,7 @@ public class LSPEclipseUtils {
 		}
 	}
 
-	private static IFile findMostNested(IFile[] files) {
+	public static IFile findMostNested(IFile[] files) {
 		int shortestLen = Integer.MAX_VALUE;
 		IFile shortest = null;
 		for (IFile file : files) {
@@ -378,6 +378,7 @@ public class LSPEclipseUtils {
 				IPath path = file.getFullPath();
 				if (path.segmentCount() < shortestLen) {
 					shortest = file;
+					shortestLen = path.segmentCount();
 				}
 			}
 		}


### PR DESCRIPTION
Hello,

I will try to be the most precise possible.

The issue exhibited here only happens when the eclipse workspace contains a file accessible from more than one project which is a common case when working on maven multi modules projects (i think gradle multi modules projects are also impacted but i did not check)

Eclipse workspace with 2 projects : parent_project, nested_project
Where nested_project is contained in parent_project
```
parent_project
|
-- nested_project
    |
    -- file.ext

nested_project
|
-- file.ext   
```

With this kind of workspace, we have two cases:

- When the projects presentation is "Hierarchical", the file edited is the most nested and the method LSPEclipseUtils.findResourceFor(uri) will return the correct IResource (provided the function LSPEclipseUtils.findMostNested works properly)
- When the projects presentation is "Flat", the method   is totaly unreliable because more than one valid value can be returned and the most nested is not necessarily the one edited or the only one edited. (the test LSPEclipseUtilsTest.testURIToResourceMappingWithNestedProject provided in pull request to see the issue)

The bug in LSPEclipseUtils.findMostNested was realy simple like you can see in the code.
The function was returning the first processed IFile instead of the most nested which may leads to return an incorrect IResource from LSPEclipseUtils.findResourceFor(uri)

I think this pull request solves the issues #32, #112

Why?

Because while editing a file and temporary errors pop up then a non empty diagnostic is returned by the language server.
Provided we have a multi modules workspace like described earlier then:

- the call to LSPEclipseUtils.findResourceFor(uri) in LSPDiagnosticsToMarkers.accept(PublishDiagnosticsParams diagnostics) may return the wrong IResource
- then in LSPDiagnosticsToMarkers.updateMarkers(PublishDiagnosticsParams diagnostics, IResource resource) the disconnected boolean will be set to true because the IResource provided is not the one edited :

```
// A language server can scan the whole project and generate diagnostics for files that are not currently open in the IDE
// (the markers will show up in the problem view). If so, need to open the document temporarily but be sure to release it
// when we're done
final boolean disconnect = !diagnostics.getDiagnostics().isEmpty() && LSPEclipseUtils.getExistingDocument(resource) == null;
```
- if  only one file is connected to the language server, the server will be shut down and subsequent calls will return:
java.io.IOException: Stream closed

This pull request may solve issues related to multi modules workspace but only for users using the "Hierarchycal" project presentation. For those using the "Flat" project presentation, i created the issue #258 but i think it won't be a trivial one as LSP4E does not seem to currently support multiple editors for the same file opened from multiple projects.

