### PR TITLE
Allow limiting the workspace folders for a language server

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -876,6 +876,17 @@ public class LSPEclipseUtils {
 		}
 	}
 
+	/**
+	 * @return a list of folder objects for all open projects of the current workspace
+	 */
+	@NonNull
+	public static List<@NonNull WorkspaceFolder> getWorkspaceFolders() {
+		return Arrays.stream(ResourcesPlugin.getWorkspace().getRoot().getProjects())
+		.filter(IProject::isAccessible) //
+		.map(LSPEclipseUtils::toWorkspaceFolder) //
+		.toList();
+	}
+
 	@NonNull
 	public static WorkspaceFolder toWorkspaceFolder(@NonNull IProject project) {
 		WorkspaceFolder folder = new WorkspaceFolder();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -13,15 +13,11 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -148,10 +144,7 @@ public class LanguageClientImpl implements LanguageClient {
 
 	@Override
 	public CompletableFuture<List<WorkspaceFolder>> workspaceFolders() {
-		return CompletableFuture.completedFuture(Arrays.stream(ResourcesPlugin.getWorkspace().getRoot().getProjects()) //
-			.filter(IProject::isAccessible) //
-			.map(LSPEclipseUtils::toWorkspaceFolder) //
-			.collect(Collectors.toList()));
+		return CompletableFuture.completedFuture(LSPEclipseUtils.getWorkspaceFolders());
 	}
 
 	@Override


### PR DESCRIPTION
This change enables custom language clients to control which workspace folders are send to the language server `initialize` request and during `workspace/didChangeWorkspaceFolders` event by overriding the `workspaceFolders` method.
E.g.
```java
class MyLanguageServerClientImpl extends LanguageServerClientImpl {
   @Override
   public CompletableFuture<List<WorkspaceFolder>> workspaceFolders() {
      return CompletableFuture.completedFuture(
         allProjectsWithNature("my.project.nature").stream() //
         .map(LSPEclipseUtils::toWorkspaceFolder) //
         .collect(Collectors.toList()));
   }
}
```

Without this change the `initialize` request will always contain all workspace projects no matter if they are relevant for the LS or not.
This also means the LS requests configuration settings for all projects via `workspace/configuration`.

Being able to limit the list of workspace folders can improve LS performance for slow language servers that search for resources across projects. It also means less work on the client side to construct JSON messages, e.g. for `workspace/didChangeWorkspaceFolders` and esp. for per-project configurations via `workspace/configuration`.