### PR TITLE
Provide new signature to open URI without UI.getActivePage()

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -74,6 +74,7 @@ import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.lsp4e.refactoring.CreateFileChange;
 import org.eclipse.lsp4e.refactoring.DeleteExternalFile;
 import org.eclipse.lsp4e.refactoring.LSPTextChange;
+import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.Color;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.CreateFile;
@@ -536,13 +537,24 @@ public class LSPEclipseUtils {
 		return document;
 	}
 
+	public static void openInEditor(Location location) {
+		openInEditor(location, UI.getActivePage());
+	}
+
 	public static void openInEditor(Location location, IWorkbenchPage page) {
 		open(location.getUri(), page, location.getRange());
 	}
 
+	public static void openInEditor(LocationLink link) {
+		openInEditor(link, UI.getActivePage());
+	}
+
 	public static void openInEditor(LocationLink link, IWorkbenchPage page) {
 		open(link.getTargetUri(), page, link.getTargetSelectionRange());
+	}
 
+	public static void open(String uri, Range optionalRange) {
+		open(uri, UI.getActivePage(), optionalRange);
 	}
 
 	public static void open(String uri, IWorkbenchPage page, Range optionalRange) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.lsp4e.progress.LSPProgressManager;
 import org.eclipse.lsp4e.ui.Messages;
-import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
 import org.eclipse.lsp4j.ConfigurationParams;
@@ -152,7 +151,7 @@ public class LanguageClientImpl implements LanguageClient {
 		return CompletableFuture.supplyAsync(() -> {
 			PlatformUI.getWorkbench().getDisplay().syncExec(() -> {
 				var location = new Location(params.getUri(), params.getSelection());
-				LSPEclipseUtils.openInEditor(location, UI.getActivePage());
+				LSPEclipseUtils.openInEditor(location);
 			});
 			return new ShowDocumentResult(true);
 		});

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/LSBasedHyperlink.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/LSBasedHyperlink.java
@@ -19,7 +19,6 @@ import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.ui.Messages;
-import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -71,9 +70,9 @@ public class LSBasedHyperlink implements IHyperlink {
 	@Override
 	public void open() {
 		if (location.isLeft()) {
-			LSPEclipseUtils.openInEditor(location.getLeft(), UI.getActivePage());
+			LSPEclipseUtils.openInEditor(location.getLeft());
 		} else {
-			LSPEclipseUtils.openInEditor(location.getRight(), UI.getActivePage());
+			LSPEclipseUtils.openInEditor(location.getRight());
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
@@ -30,7 +30,6 @@ import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.DocumentLink;
 import org.eclipse.lsp4j.DocumentLinkParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -64,7 +63,7 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 
 		@Override
 		public void open() {
-			LSPEclipseUtils.open(uri, UI.getActivePage(), null);
+			LSPEclipseUtils.open(uri, null);
 		}
 
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
@@ -26,7 +26,6 @@ import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.util.Util;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
-import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.LocationEvent;
 import org.eclipse.swt.browser.LocationListener;
@@ -50,7 +49,7 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 		@Override
 		public void changing(LocationEvent event) {
 			if (!"about:blank".equals(event.location)) { //$NON-NLS-1$
-				LSPEclipseUtils.open(event.location, UI.getActivePage(), null);
+				LSPEclipseUtils.open(event.location, null);
 				event.doit = false;
 			}
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
@@ -69,7 +69,7 @@ public class LSPSymbolInWorkspaceHandler extends AbstractHandler {
 		SymbolInformation symbolInformation = (SymbolInformation) dialog.getFirstResult();
 		Location location = symbolInformation.getLocation();
 
-		LSPEclipseUtils.openInEditor(location, UI.getActivePage());
+		LSPEclipseUtils.openInEditor(location);
 		return null;
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/WorkspaceSymbolQuickAccessElement.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/WorkspaceSymbolQuickAccessElement.java
@@ -18,7 +18,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.outline.SymbolsLabelProvider;
-import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.WorkspaceSymbol;
@@ -61,7 +60,7 @@ public class WorkspaceSymbolQuickAccessElement extends QuickAccessElement {
 
 	@Override
 	public void execute() {
-		LSPEclipseUtils.openInEditor(symbol.getLocation().map(Function.identity(), symbol -> new Location(symbol.getUri(), null)), UI.getActivePage());
+		LSPEclipseUtils.openInEditor(symbol.getLocation().map(Function.identity(), symbol -> new Location(symbol.getUri(), null)));
 	}
 
 }


### PR DESCRIPTION
Provide new signature to open URI without UI.getActivePage()

This PR provides new methods in LSPEclipseUtils without having IWorkbenchPage as parameter. The benefit with that is:

 * it simplifies a little the code.
 * it allows for another plugin to use open methods without redefining an utility class UI.getActivePage() since UI class is not exported.