### PR TITLE
Show DocumentSymbol.Detail in Outline View

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsLabelProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsLabelProviderTest.java
@@ -14,7 +14,9 @@ package org.eclipse.lsp4e.test.outline;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.lsp4e.outline.SymbolsLabelProvider;
+import org.eclipse.lsp4e.outline.SymbolsModel;
 import org.eclipse.lsp4e.test.AllCleanRule;
+import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -62,5 +64,47 @@ public class SymbolsLabelProviderTest {
 		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
 		SymbolInformation info = new SymbolInformation("Foo", SymbolKind.Class, INVALID_LOCATION);
 		assertEquals("Foo", labelProvider.getStyledText(info).getString());
+	}
+	
+	@Test
+	public void testDocumentSymbolDetail () {
+		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
+		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+				new Range(new Position(1, 0), new Position(1, 2)),
+				new Range(new Position(1, 0), new Position(1, 2)),
+				" : additional detail");
+		assertEquals("Foo : additional detail", labelProvider.getStyledText(info).getString());		
+	}
+
+	@Test
+	public void testDocumentSymbolDetailWithKind () {
+		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, true);
+		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+				new Range(new Position(1, 0), new Position(1, 2)),
+				new Range(new Position(1, 0), new Position(1, 2)),
+				" : additional detail");
+		assertEquals("Foo : additional detail :Class", labelProvider.getStyledText(info).getString());		
+	}
+
+	@Test
+	public void testDocumentSymbolWithFileDetail () {
+		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
+		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+				new Range(new Position(1, 0), new Position(1, 2)),
+				new Range(new Position(1, 0), new Position(1, 2)),
+				" : additional detail");
+		SymbolsModel.DocumentSymbolWithFile infoWithFile = new SymbolsModel.DocumentSymbolWithFile(info, null);
+		assertEquals("Foo : additional detail", labelProvider.getStyledText(infoWithFile).getString());		
+	}
+
+	@Test
+	public void testDocumentSymbolDetailWithFileWithKind () {
+		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, true);
+		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+				new Range(new Position(1, 0), new Position(1, 2)),
+				new Range(new Position(1, 0), new Position(1, 2)),
+				" : additional detail");
+		SymbolsModel.DocumentSymbolWithFile infoWithFile = new SymbolsModel.DocumentSymbolWithFile(info, null);
+		assertEquals("Foo : additional detail :Class", labelProvider.getStyledText(infoWithFile).getString());		
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
@@ -263,6 +263,7 @@ public class SymbolsLabelProvider extends LabelProvider
 		}
 		String name = null;
 		SymbolKind kind = null;
+		String detail = null;
 		URI location = null;
 		if (element instanceof SymbolInformation symbolInformation) {
 			name = symbolInformation.getName();
@@ -275,9 +276,11 @@ public class SymbolsLabelProvider extends LabelProvider
 		} else if (element instanceof DocumentSymbol documentSymbol) {
 			name = documentSymbol.getName();
 			kind = documentSymbol.getKind();
+			detail = documentSymbol.getDetail();
 		} else if (element instanceof DocumentSymbolWithFile symbolWithFile) {
 			name = symbolWithFile.symbol.getName();
 			kind = symbolWithFile.symbol.getKind();
+			detail = symbolWithFile.symbol.getDetail();
 			IFile file = symbolWithFile.file;
 			if (file != null) {
 				location = file.getLocationURI();
@@ -286,6 +289,11 @@ public class SymbolsLabelProvider extends LabelProvider
 		if (name != null) {
 			res.append(name, null);
 		}
+
+		if (detail != null && !detail.isBlank()) {
+			res.append(detail, StyledString.DECORATIONS_STYLER);
+		}
+
 		if (showKind && kind != null) {
 			res.append(" :", null); //$NON-NLS-1$
 			res.append(kind.toString(), StyledString.DECORATIONS_STYLER);


### PR DESCRIPTION
In this change the SymbolLabelProvider is extended to show the detail string that is part of the DocumentSymbol response.

Addresses  #250.

Signed-off-by: Gerd Grossmannn <gerd.grossmann@avaloq.com>