### PR TITLE
Check if LSP command is not empty to perform CodeLens action

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
@@ -68,7 +68,7 @@ public class LSPCodeMining extends LineHeaderCodeMining {
 	@Override
 	public final Consumer<MouseEvent> getAction() {
 		final Command command = codeLens.getCommand();
-		if(command != null && command.getCommand() != null) {
+		if(command != null && command.getCommand() != null && !command.getCommand().isEmpty()) {
 			return this::performAction;
 		} else {
 			return null;


### PR DESCRIPTION
The LSP command of command can be never null https://github.com/eclipse/lsp4j/blob/5605ca82252833777dbef82ca13a403dbfb9d906/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend#L2318 so it means that Codelens should check too if the command is not empty to execute it.

In other words if the command of command is emprt, CodeLens will not be clickable. It will fix for instance the following error with XML https://github.com/eclipse/wildwebdeveloper/issues/644