### PR TITLE
Language client configuration provider feature

### DIFF
--- a/org.eclipse.lsp4e/schema/languageServer.exsd
+++ b/org.eclipse.lsp4e/schema/languageServer.exsd
@@ -151,6 +151,16 @@ If set to a number bigger than zero, the server will run until the timeout is re
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="languageClientConfigurationProvider" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.lsp4e.LanguageClientConfigurationProvider"/>
+               </appinfo>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DefaultLanguageClientConfigurationProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DefaultLanguageClientConfigurationProvider.java
@@ -1,0 +1,21 @@
+package org.eclipse.lsp4e;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.ConfigurationParams;
+
+public class DefaultLanguageClientConfigurationProvider implements LanguageClientConfigurationProvider {
+
+	private static final LanguageClientConfigurationProvider INSTANCE = new DefaultLanguageClientConfigurationProvider();
+
+	public static LanguageClientConfigurationProvider getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
+		return CompletableFuture.completedFuture(Collections.emptyList());
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientConfigurationProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientConfigurationProvider.java
@@ -1,0 +1,17 @@
+package org.eclipse.lsp4e;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.eclipse.lsp4j.FormattingOptions;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+public interface LanguageClientConfigurationProvider {
+
+	CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams);
+
+	default void collectFormatting(FormattingOptions formattingOptions, TextDocumentIdentifier identifier, String languageId) {
+		// Do nothing
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -69,7 +68,7 @@ public class LanguageClientImpl implements LanguageClient {
 	@Override
 	public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
 		// override as needed
-		return CompletableFuture.completedFuture(Collections.emptyList());
+		return wrapper.serverDefinition.getLanguageClientConfigurationProvider().configuration(configurationParams);
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -84,6 +84,7 @@ public class LanguageServiceAccessor {
 		private final @NonNull URI fileUri;
 		private final @NonNull IDocument document;
 		private final @NonNull LanguageServerWrapper wrapper;
+		private @Nullable String languageId;
 
 		private LSPDocumentInfo(@NonNull URI fileUri, @NonNull IDocument document,
 				@NonNull LanguageServerWrapper wrapper) {
@@ -124,6 +125,14 @@ public class LanguageServiceAccessor {
 			}
 		}
 
+		public String getLanguageId() {
+			if (languageId == null) {
+				List<IContentType> contentTypes = LSPEclipseUtils.getDocumentContentTypes(this.document);
+				languageId = wrapper.getLanguageId(contentTypes.toArray(new IContentType[0]));
+			}
+			return languageId;
+		}
+
 		public int getVersion() {
 			return wrapper.getVersion(fileUri);
 		}
@@ -138,6 +147,10 @@ public class LanguageServiceAccessor {
 
 		public boolean isActive() {
 			return this.wrapper.isActive();
+		}
+
+		public LanguageClientConfigurationProvider getLanguageClientConfigurationProvider() {
+			return wrapper.serverDefinition.getLanguageClientConfigurationProvider();
 		}
 	}
 


### PR DESCRIPTION
This PR provides a new attribute for languageServer extension point called `languageClientConfigurationProvider`

Here a sample with CSS:

```xml
<extension
         point="org.eclipse.lsp4e.languageServer">
      <server
            class="org.eclipse.wildwebdeveloper.css.CSSLanguageServer"
            languageClientConfigurationProvider="org.eclipse.wildwebdeveloper.css.CSSLanguageClientConfigurationProvider"
           ...>
```

This languageClientConfigurationProvider expects an implementation of LanguageClientConfigurationProvider which looks like this:

```java
package org.eclipse.lsp4e;

import java.util.List;
import java.util.concurrent.CompletableFuture;

import org.eclipse.lsp4j.ConfigurationParams;
import org.eclipse.lsp4j.FormattingOptions;
import org.eclipse.lsp4j.TextDocumentIdentifier;

public interface LanguageClientConfigurationProvider {

	CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams);

	default void collectFormatting(FormattingOptions formattingOptions, TextDocumentIdentifier identifier, String languageId) {
		// Do nothing
	}
}

```

This API gives the capability to:

 * defines client configuration (instead of implementing LanguageClientImpl)
 * collect special formatting options that the language server could require to format like the CSS language server.