### PR TITLE
[DO NOT MERGE] Enablement for specific input

### DIFF
--- a/org.eclipse.lsp4e/schema/languageServer.exsd
+++ b/org.eclipse.lsp4e/schema/languageServer.exsd
@@ -158,6 +158,7 @@ If set to a number bigger than zero, the server will run until the timeout is re
       <complexType>
          <sequence>
             <element ref="enabledWhen" minOccurs="0" maxOccurs="1"/>
+            <element ref="enabledInputWhen" minOccurs="0" maxOccurs="1"/>
          </sequence>
          <attribute name="id" type="string" use="required">
             <annotation>
@@ -193,6 +194,38 @@ If set to a number bigger than zero, the server will run until the timeout is re
       <annotation>
          <documentation>
             A core Expression that controls the enablement of the ContentTypeToLanguageServer mapping
+         </documentation>
+      </annotation>
+      <complexType>
+         <choice minOccurs="0" maxOccurs="1">
+            <element ref="not"/>
+            <element ref="or"/>
+            <element ref="and"/>
+            <element ref="instanceof"/>
+            <element ref="test"/>
+            <element ref="systemTest"/>
+            <element ref="equals"/>
+            <element ref="count"/>
+            <element ref="with"/>
+            <element ref="resolve"/>
+            <element ref="adapt"/>
+            <element ref="iterate"/>
+            <element ref="reference"/>
+         </choice>
+         <attribute name="description" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="enabledInputWhen">
+      <annotation>
+         <documentation>
+            A core Expression that controls the enablement of the ContentTypeToLanguageServer mapping for a given input
          </documentation>
       </annotation>
       <complexType>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ContentTypeToLSPLaunchConfigEntry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ContentTypeToLSPLaunchConfigEntry.java
@@ -33,7 +33,7 @@ public class ContentTypeToLSPLaunchConfigEntry extends ContentTypeToLanguageServ
 
 	public ContentTypeToLSPLaunchConfigEntry(@NonNull IContentType contentType, @NonNull ILaunchConfiguration launchConfig,
 			@NonNull Set<String> launchModes) {
-		super(contentType, new LaunchConfigurationLanguageServerDefinition(launchConfig, launchModes), null);
+		super(contentType, new LaunchConfigurationLanguageServerDefinition(launchConfig, launchModes), null, null);
 		this.launchConfiguration = launchConfig;
 		this.launchModes = Collections.unmodifiableSet(launchModes);
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ContentTypeToLanguageServerDefinition.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ContentTypeToLanguageServerDefinition.java
@@ -19,17 +19,20 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
 import org.eclipse.lsp4e.enablement.EnablementTester;
+import org.eclipse.lsp4e.enablement.InputEnablementTester;
 
 public class ContentTypeToLanguageServerDefinition extends SimpleEntry<IContentType, LanguageServerDefinition> {
 
 	private static final long serialVersionUID = 6002703726009331762L;
 	private final EnablementTester enablement;
+	private final InputEnablementTester inputEnablement;
 
 	public ContentTypeToLanguageServerDefinition(@NonNull IContentType contentType,
 			@NonNull LanguageServerDefinition provider,
-			@Nullable EnablementTester enablement) {
+			@Nullable EnablementTester enablement, InputEnablementTester inputEnablement) {
 		super(contentType, provider);
 		this.enablement = enablement;
+		this.inputEnablement = inputEnablement;
 	}
 
 	public boolean isEnabled() {
@@ -38,6 +41,10 @@ public class ContentTypeToLanguageServerDefinition extends SimpleEntry<IContentT
 
 	public void setUserEnabled(boolean enabled) {
 		LanguageServerPlugin.getDefault().getPreferenceStore().setValue(getPreferencesKey(), String.valueOf(enabled));
+	}
+
+	public boolean isEnabledFor(Object o) {
+		return isEnabled() && (inputEnablement == null || inputEnablement.evaluate(o));
 	}
 
 	public boolean isUserEnabled() {
@@ -49,7 +56,6 @@ public class ContentTypeToLanguageServerDefinition extends SimpleEntry<IContentT
 
 	public boolean isExtensionEnabled() {
 		return enablement != null ? enablement.evaluate() : true;
-
 	}
 
 	public EnablementTester getEnablementCondition() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -180,7 +180,7 @@ public class LanguageServiceAccessor {
 					final IContentDescription contentDesc = editorFile.getContentDescription();
 					if(contentDesc == null)
 						continue;
-					if (contentType.equals(contentDesc.getContentType()) && contentTypeToLSDefinition.isEnabled()) {
+					if (contentType.equals(contentDesc.getContentType()) && contentTypeToLSDefinition.isEnabledFor(editor.getEditorInput())) {
 						getInitializedLanguageServer(editorFile, lsDefinition, capabilities -> true);
 					}
 				}
@@ -306,7 +306,7 @@ public class LanguageServiceAccessor {
 			}
 
 			for (final ContentTypeToLanguageServerDefinition mapping : lsRegistry.findProviderFor(contentType)) {
-				if (!mapping.isEnabled()) {
+				if (!mapping.isEnabledFor(file)) {
 					continue;
 				}
 				final LanguageServerDefinition serverDefinition = mapping.getValue();
@@ -365,7 +365,7 @@ public class LanguageServiceAccessor {
 			}
 
 			for (final ContentTypeToLanguageServerDefinition mapping : lsRegistry.findProviderFor(contentType)) {
-				if (!mapping.isEnabled()) {
+				if (!mapping.isEnabledFor(document)) {
 					continue;
 				}
 				final LanguageServerDefinition serverDefinition = mapping.getValue();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/enablement/InputEnablementTester.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/enablement/InputEnablementTester.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2022 VMware Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Alex Boyko (VMware Inc.) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.enablement;
+
+import java.util.function.Supplier;
+
+import org.eclipse.core.expressions.EvaluationContext;
+import org.eclipse.core.expressions.EvaluationResult;
+import org.eclipse.core.expressions.Expression;
+import org.eclipse.core.expressions.IEvaluationContext;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.lsp4e.LanguageServerPlugin;
+
+public final class InputEnablementTester {
+
+	private final Expression expression;
+	private final String description;
+	private final Supplier<IEvaluationContext> parent;
+
+	public InputEnablementTester(Supplier<IEvaluationContext> parent, Expression expression, String description) {
+		this.description = description;
+		this.expression = expression;
+		this.parent = parent;
+	}
+
+	/**
+	 *
+	 * @return enablement test description
+	 */
+	public String getDescription() {
+		return description;
+	}
+
+	/**
+	 * Evaluates enablement expression
+	 *
+	 * @return true if expression evaluates to true, false otherwise
+	 */
+	public boolean evaluate(Object input) {
+		try {
+			EvaluationContext context = new EvaluationContext(parent.get(), input);
+			context.setAllowPluginActivation(true);
+			return expression.evaluate(context).equals(EvaluationResult.TRUE);
+		} catch (CoreException e) {
+			LanguageServerPlugin.logError("Error occured during evaluation of enablement for the input expression", e); //$NON-NLS-1$
+		}
+		return false;
+	}
+
+
+}


### PR DESCRIPTION
`enabledWhen` doesn't have editor input, fie, document or any kind of input context for evaluation. It is used in `ContentTypeToLanguageServerDefinition#isEnabled()` calls. These calls are made also from content type -> LS preference page which is independent of any input context.

I'm curious if it is worth making a similar `enabledInputWhen` tester able to take input context such as `IDocument`, `IEditorInput`, `IFile` etc. Therefore whenever there is input available we'd pass it over to ContentTypeToLanguageServerDefinition#isEnabledFor(Object input)` rather than `isEnabled()`. The PR adds implementation for this.

The goal i have in mind is start Boot LS for a workspace that has at least one java project with spring boot on the classpath. Shut down Boot LS if there are no more Spring Boot projects left in the workspace. Now if Boot LS is shut down and user opens a Java file (or any other boot related content-type files) in an editor I wouldn't want to start Boot LS for a file that does not belong to a Spring Boot project. Hence, the `enabledInputWhen` would help in this case.
What do you think? Do you see any issues/obstacles achieving the goal above with the proposed PR?

Thanks in advance for feedback on this topic!!!