### PR TITLE
Fix NullPointerException

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
@@ -86,7 +86,7 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 	}
 
 	private void underline(List<DocumentLink> links) {
-		if (document == null) {
+		if (document == null || links == null) {
 			return;
 		}
 		for (DocumentLink link : links) {


### PR DESCRIPTION
java.lang.NullPointerException Cannot invoke "java.util.List.iterator()" because "links" is null
	at org.eclipse.lsp4e.operations.documentLink.LSPDocumentLinkPresentationReconcilingStrategy.underline(LSPDocumentLinkPresentationReconcilingStrategy.java:92)
	at org.eclipse.lsp4e.operations.documentLink.LSPDocumentLinkPresentationReconcilingStrategy.lambda$5(LSPDocumentLinkPresentationReconcilingStrategy.java:83)