### PR TITLE
[DO NOT MERGE] Add a 'test' showing that a blocking server can block the UI thread

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,7 @@ import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
 import org.junit.Before;
@@ -264,6 +266,105 @@ public class DocumentDidChangeTest {
 			message.append(System.lineSeparator());
 		});
 		assertTrue(message.toString(), tooEarlyHover.isEmpty() && tooLateHover.isEmpty());
+	}
+	
+	@Test
+	public void testBlockingServerBlocksUIThread() throws Exception {
+
+		final Vector<Integer> tooEarlyHover = new Vector<>();
+		final Vector<Integer> tooLateHover = new Vector<>();
+		final AtomicInteger uiDispatchCount = new AtomicInteger();
+		
+		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
+		.setTextDocumentSync(TextDocumentSyncKind.Incremental);
+		MockLanguageServer.INSTANCE.setTextDocumentService(new MockTextDocumentService(MockLanguageServer.INSTANCE::buildMaybeDelayedFuture) {
+			int changeVersion = 0;
+			@Override
+			public synchronized void didChange(DidChangeTextDocumentParams params) {
+				super.didChange(params);
+				changeVersion++;
+				try {
+					Thread.sleep(1000);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+			}
+			
+			@Override
+			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
+				final int targetVersionForRequest = position.getPosition().getCharacter();
+				if (targetVersionForRequest < changeVersion) {
+					tooLateHover.add(targetVersionForRequest);
+				} else if (targetVersionForRequest > changeVersion){
+					tooEarlyHover.add(targetVersionForRequest);
+				}
+				return super.hover(position);
+			}
+		});
+		
+		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		MockLanguageServer.INSTANCE.setHover(hoverResponse);
+		CompletableFuture<?> initial = CompletableFuture.completedFuture(null);
+		
+		IFile testFile = TestUtils.createUniqueTestFile(project, "");
+		IEditorPart editor = TestUtils.openEditor(testFile);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		final IDocument document = viewer.getDocument();
+		final URI uri = LSPEclipseUtils.toUri(document);
+		StyledText text = viewer.getTextWidget();
+		Thread.sleep(1000);
+		
+		final long startTime = System.currentTimeMillis();
+		
+		final StringBuilder bulkyText = new StringBuilder();
+		
+		// Construct a reasonably bulky payload for the document updates: if the
+		// payload is small then buffering will mitigate any back-pressure from the server
+		// (typically 8k for a unix pipe)
+		for (int i = 0; i < 1000; i++) {
+			bulkyText.append("Some Text; ");
+		}
+		
+		final String content = bulkyText.toString();
+		
+		for (int i = 0; i < 20; i++) {
+			final int current = i + 1;
+			text.append(content + "\n");
+			final HoverParams params = new HoverParams();
+			final Position position = new Position();
+			position.setCharacter(current);
+			position.setLine(0);
+			params.setPosition(position);
+			
+			CompletableFuture<?> hoverFuture = LanguageServiceAccessor.getLanguageServers(document, capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()))
+			.thenApply(languageServers -> // Async is very important here, otherwise the LS Client thread is in
+												// deadlock and doesn't read bytes from LS
+			languageServers.stream()
+				.map(languageServer -> {
+					if (Display.getCurrent() != null) {
+						uiDispatchCount.incrementAndGet();
+					}
+					try {
+						return languageServer.getTextDocumentService().hover(params);
+					} catch (Exception e) {
+						
+					}
+					return CompletableFuture.completedFuture(null);
+				}).collect(Collectors.toList()));
+			initial = CompletableFuture.allOf(initial, hoverFuture);
+		}
+		
+		final long dispatchTime = System.currentTimeMillis();
+		
+		initial.join();
+		
+		final long finishTime = System.currentTimeMillis();
+		
+		System.err.println("Dispatch time = " + (dispatchTime - startTime)/ 1000.0);
+		System.err.println("Test time = " + (finishTime - startTime)/ 1000.0);
+		
+		System.err.println("UI dispatch count = " + uiDispatchCount.get());
+		
 	}
 
 	@Test


### PR DESCRIPTION
The effect of some of the concurrency changes recently means that many of the server calls will dispatch on the UI thread. If the server is blocking then this can in turn cause the UI to block.

This is not *necessarily* a problem for all language servers, but it might be in certain circumstances. A language server that is completely single threaded in nature might need to wait for a long computation (e.g. a refactoring) to finish before it can respond to further input. Even a multi-threaded language server that is capable of queueing requests and handling multiple ongoing computations simultaneously can obviously become overloaded.

The mechanism for back-pressure isn't immediately obvious, and will depend on connection between client and server, but for the default stdin/stdio stream-backed connection, then once the server becomes tied up it will stop reading from its input stream. If the streams are unbuffered, then the language client will block attempting to write. I am reliably informed that 8k is a normal-ish default buffer size for a unix pipe, so have created a payload in this test that will fill up the buffer in a couple of requests.

The results are obviously environment dependent, but I get dispatch timings of 14s and every hover request dispatched on the UI thread (i.e. `Display.getCurrent() != null`)