### PR TITLE
avoid calling LSPEclipseUtils.getDocument(resource) when we already have a document

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
@@ -60,17 +60,20 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 		}
 		if (codeAction.getCommand() != null) {
 			IResource resource = marker.getResource();
-			boolean disconnect = LSPEclipseUtils.getExistingDocument(resource) == null;
-			IDocument document = LSPEclipseUtils.getDocument(resource);
+			IDocument document = LSPEclipseUtils.getExistingDocument(resource);
+			boolean temporaryLoadDocument = document == null;
+			if (temporaryLoadDocument) {
+				document = LSPEclipseUtils.getDocument(resource);
+			}
 			if (document != null) {
 				String languageServerId = marker.getAttribute(LSPDiagnosticsToMarkers.LANGUAGE_SERVER_ID, null);
 				CommandExecutor.executeCommand(codeAction.getCommand(), document, languageServerId);
-			}
-			if (disconnect) {
-				try {
-					FileBuffers.getTextFileBufferManager().disconnect(resource.getFullPath(), LocationKind.IFILE, new NullProgressMonitor());
-				} catch (CoreException e) {
-					LanguageServerPlugin.logError(e);
+				if (temporaryLoadDocument) {
+					try {
+						FileBuffers.getTextFileBufferManager().disconnect(resource.getFullPath(), LocationKind.IFILE, new NullProgressMonitor());
+					} catch (CoreException e) {
+						LanguageServerPlugin.logError(e);
+					}
 				}
 			}
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchQuery.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchQuery.java
@@ -129,9 +129,10 @@ public class LSSearchQuery extends FileSearchQuery {
 	private static Match toMatch(Location location) {
 		IResource resource = LSPEclipseUtils.findResourceFor(location.getUri());
 		if (resource != null) {
-			boolean disconnect = LSPEclipseUtils.getExistingDocument(resource) == null;
-			IDocument document = LSPEclipseUtils.getDocument(resource);
-			if (disconnect) {
+			IDocument document = LSPEclipseUtils.getExistingDocument(resource);
+			boolean temporaryLoadDocument = document == null;
+			if (temporaryLoadDocument) {
+				document = LSPEclipseUtils.getDocument(resource);
 				try {
 					FileBuffers.getTextFileBufferManager().disconnect(resource.getFullPath(), LocationKind.IFILE, new NullProgressMonitor());
 				} catch (CoreException e) {
@@ -140,14 +141,14 @@ public class LSSearchQuery extends FileSearchQuery {
 			}
 			if (document != null) {
 				try {
-				int startOffset = LSPEclipseUtils.toOffset(location.getRange().getStart(), document);
-				int endOffset = LSPEclipseUtils.toOffset(location.getRange().getEnd(), document);
+					int startOffset = LSPEclipseUtils.toOffset(location.getRange().getStart(), document);
+					int endOffset = LSPEclipseUtils.toOffset(location.getRange().getEnd(), document);
 
-				IRegion lineInformation = document.getLineInformationOfOffset(startOffset);
-				LineElement lineEntry = new LineElement(resource, document.getLineOfOffset(startOffset),
-						lineInformation.getOffset(),
-						document.get(lineInformation.getOffset(), lineInformation.getLength()));
-				return new FileMatch((IFile) resource, startOffset, endOffset - startOffset, lineEntry);
+					IRegion lineInformation = document.getLineInformationOfOffset(startOffset);
+					LineElement lineEntry = new LineElement(resource, document.getLineOfOffset(startOffset),
+							lineInformation.getOffset(),
+							document.get(lineInformation.getOffset(), lineInformation.getLength()));
+					return new FileMatch((IFile) resource, startOffset, endOffset - startOffset, lineEntry);
 				} catch (BadLocationException ex) {
 					LanguageServerPlugin.logError(ex);
 				}


### PR DESCRIPTION
Improve on 89dc090203e9a1fd2c07926d0579a1eff303fc44  to avoid calling LSPEclipseUtils.getDocument(resource) when
LSPEclipseUtils.getExistingDocument(resource) already returned a resource, as it is a bit wasteful to run through the same code twice.