### PR TITLE
[FOR DISCUSSION] - Draft revised API

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
@@ -11,12 +11,15 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.format;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -34,6 +37,7 @@ import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -71,10 +75,11 @@ public class FormatTest {
 
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
+		final long currentStamp = LSPEclipseUtils.getDocumentModificationStamp(viewer.getDocument());
 
 		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
 				.get();
-		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), edits));
+		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), currentStamp, edits));
 
 		ITextEditor textEditor = (ITextEditor) editor;
 		textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
@@ -99,9 +104,11 @@ public class FormatTest {
 		LSPFormatter formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
 
+		final long currentStamp = LSPEclipseUtils.getDocumentModificationStamp(viewer.getDocument());
+
 		List<? extends TextEdit> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection)
 				.get();
-		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), edits));
+		editor.getSite().getShell().getDisplay().syncExec(() -> formatter.applyEdits(viewer.getDocument(), currentStamp, edits));
 
 		ITextEditor textEditor = (ITextEditor) editor;
 		textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
@@ -109,14 +116,56 @@ public class FormatTest {
 
 		TestUtils.closeEditor(editor, false);
 	}
+	
+	@Test(expected=ConcurrentModificationException.class)
+ 	public void testFormattingVersionClashDetected() throws Exception {
+ 		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
+ 		.setTextDocumentSync(TextDocumentSyncKind.Incremental);
+ 		List<TextEdit> formattingTextEdits = new ArrayList<>();
+ 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 0), new Position(0, 1)), "MyF"));
+ 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
+ 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 21), new Position(0, 21)), " Second"));
+ 		MockLanguageServer.INSTANCE.setFormattingTextEdits(formattingTextEdits);
+
+ 		IFile file = TestUtils.createUniqueTestFile(project, "Formatting Other Text");
+ 		IEditorPart editor = TestUtils.openEditor(file);
+ 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+ 		MockLanguageServer.INSTANCE.setTimeToProceedQueries(5000);
+		final long currentStamp = LSPEclipseUtils.getDocumentModificationStamp(viewer.getDocument());
+
+ 		LSPFormatter formatter = new LSPFormatter();
+ 		ISelection selection = viewer.getSelectionProvider().getSelection();
+ 		CompletableFuture<List<? extends TextEdit>> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection);
+
+ 		viewer.getDocument().replace(0, 0, "Hello, ");
+ 		viewer.getDocument().replace(6, 0, "world! ");
+ 		viewer.getDocument().replace(13, 0, "Here is some extra text!");
+ 		List<? extends TextEdit> formatting = edits.get();
+ 		final AtomicReference<Exception> thrown = new AtomicReference<>();
+ 		editor.getSite().getShell().getDisplay().syncExec(() -> {
+ 			try {
+ 				LSPEclipseUtils.applyEditsWithVersionCheck(viewer.getDocument(), currentStamp, formatting);
+ 			} catch (Exception e) {
+ 				thrown.set(e);
+ 			}
+ 		});
+
+ 		final Exception e = thrown.get();
+ 		if (e != null) {
+ 			throw e;
+ 		}
+
+ 	}
 
 	@Test
 	public void testNullFormatting() {
 		IDocument document = new Document("Formatting Other Text");
 		LSPFormatter formatter = new LSPFormatter();
+		final long currentStamp = LSPEclipseUtils.getDocumentModificationStamp(document);
+
 
 		// null is an acceptable response for no changes
-		formatter.applyEdits(document, null);
+		formatter.applyEdits(document,currentStamp,  null);
 
 		assertEquals("Formatting Other Text", document.get());
 	}

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -133,7 +133,7 @@ public final class MockLanguageServer implements LanguageServer {
 		initializeResult.setCapabilities(serverConfigurer.get());
 	}
 
-	<U> CompletableFuture<U> buildMaybeDelayedFuture(U value) {
+	public <U> CompletableFuture<U> buildMaybeDelayedFuture(U value) {
 		if (delay > 0) {
 			CompletableFuture<U> future = CompletableFuture.runAsync(() -> {
 				try {
@@ -182,6 +182,10 @@ public final class MockLanguageServer implements LanguageServer {
 	@Override
 	public MockTextDocumentService getTextDocumentService() {
 		return textDocumentService;
+	}
+
+	public void setTextDocumentService(MockTextDocumentService custom) {
+		textDocumentService = custom;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -68,8 +68,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private int version = 0;
 	private DidChangeTextDocumentParams changeParams;
 	private long modificationStamp;
-//	private final AtomicReference<CompletableFuture<LanguageServer>> lastChangeFuture;
-	private LanguageServer languageServer;
+
 	private IPreferenceStore store;
 
 	public DocumentContentSynchronizer(@NonNull LanguageServerWrapper languageServerWrapper,
@@ -111,37 +110,10 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 		textDocument.setLanguageId(languageId);
 		textDocument.setVersion(++version);
-//		lastChangeFuture = new AtomicReference<>(languageServerWrapper.getInitializedServer().thenApplyAsync(ls -> {
-//			this.languageServer = ls;
-//			ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument));
-//			return ls;
-//		}));
+
 		this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument)));
 	}
 
-//	/**
-// 	 * Submit an asynchronous call (i.e. to the language server) that be inserted into the current position w.r.t.
-// 	 * document change events
-// 	 *
-// 	 * @param <U> Computation return type
-// 	 * @param fn Asynchronous computation on the language server
-// 	 * @return Asynchronous result object.
-// 	 */
-//	private <U> @NonNull CompletableFuture<U> executeOnCurrentVersionAsync(
-//			Function<LanguageServer, ? extends CompletionStage<U>> fn) {
-//		AtomicReference<CompletableFuture<U>> resValueFuture = new AtomicReference<>();
-//		lastChangeFuture.updateAndGet(f -> {
-//			CompletableFuture<U> valueFuture = f.thenComposeAsync(fn);
-//			resValueFuture.set(valueFuture);
-//			// We ignore any exceptions that happen when executing the given future
-//			return valueFuture.handle((value, error) -> this.languageServer);
-//		});
-//		return resValueFuture.get();
-//	}
-
-//	CompletableFuture<LanguageServer> lastChangeFuture() {
-//		return lastChangeFuture.get();
-//	}
 
 	@Override
 	public void documentChanged(DocumentEvent event) {
@@ -155,10 +127,6 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			changeParams = null;
 
 			changeParamsToSend.getTextDocument().setVersion(++version);
-//			lastChangeFuture.updateAndGet(f -> f.thenApplyAsync(ls -> {
-//				ls.getTextDocumentService().didChange(changeParamsToSend);
-//				return ls;
-//			}));
 			this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didChange(changeParamsToSend));
 		}
 	}
@@ -302,10 +270,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		}
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri.toString());
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(identifier, document.get());
-//		lastChangeFuture.updateAndGet(f -> f.thenApplyAsync(ls -> {
-//  			ls.getTextDocumentService().didSave(params);
-//  			return ls;
-//  		}));
+
 		this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didSave(params));
 
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -55,7 +55,6 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.osgi.util.NLS;
 
 final class DocumentContentSynchronizer implements IDocumentListener {
@@ -127,7 +126,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			changeParams = null;
 
 			changeParamsToSend.getTextDocument().setVersion(++version);
-			this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didChange(changeParamsToSend));
+			languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didChange(changeParamsToSend));
 		}
 	}
 
@@ -235,7 +234,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 
 		try {
-			List<TextEdit> edits = this.languageServerWrapper.executeOnLatestVersion(ls -> ls.getTextDocumentService().willSaveWaitUntil(params))
+			List<TextEdit> edits = languageServerWrapper.executeOnLatestVersion(ls -> ls.getTextDocumentService().willSaveWaitUntil(params))
 				.get(lsToWillSaveWaitUntilTimeout(), TimeUnit.SECONDS);
 			try {
 				LSPEclipseUtils.applyEdits(document, edits);
@@ -271,7 +270,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri.toString());
 		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(identifier, document.get());
 
-		this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didSave(params));
+		languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didSave(params));
 
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -55,6 +55,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.osgi.util.NLS;
 
 final class DocumentContentSynchronizer implements IDocumentListener {
@@ -71,6 +72,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private IPreferenceStore store;
 
 	public DocumentContentSynchronizer(@NonNull LanguageServerWrapper languageServerWrapper,
+			@NonNull LanguageServer languageServer,
 			@NonNull IDocument document, TextDocumentSyncKind syncKind) {
 		this.languageServerWrapper = languageServerWrapper;
 		URI uri = LSPEclipseUtils.toUri(document);
@@ -109,8 +111,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 		textDocument.setLanguageId(languageId);
 		textDocument.setVersion(++version);
-
-		this.languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument)));
+		languageServer.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument));
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPExecutor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPExecutor.java
@@ -1,0 +1,79 @@
+package org.eclipse.lsp4e;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.services.LanguageServer;
+
+public abstract class LSPExecutor {
+
+
+	// Pluggable strategy for getting the set of LSWrappers to dispatch operations on
+	protected abstract List<CompletableFuture<LanguageServerWrapper>> getServers();
+
+	private Predicate<ServerCapabilities> filter = s -> true;
+
+
+
+	public <T> CompletableFuture<List<T>> collectAll(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+		return null;
+	}
+
+	public <T> List<CompletableFuture<T>> computeAll(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+		return null;
+	}
+
+	public <T> CompletableFuture<Optional<T>> computeFirst(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+		return null;
+	}
+
+
+	public static LSPProjectExecutor forProject(final IProject proj) {
+		// TODO: return LSPProjectExecutor
+		return null;
+	}
+
+	public static LSPDocumentExecutor forDocument(final IDocument document) {
+		// TODO: return LSPDocumentExecutor
+		return null;
+	}
+
+
+	public LSPExecutor withFilter(Predicate<ServerCapabilities> filter) {
+		this.filter = filter;
+		return this;
+	}
+
+
+	public static class LSPDocumentExecutor extends LSPExecutor {
+		public IDocument getDocument() {
+			return null;
+		}
+
+		@Override
+		protected List<CompletableFuture<LanguageServerWrapper>> getServers() {
+			// Compute list of servers from document & filter
+			return null;
+		}
+	}
+
+	public static class LSPProjectExecutor extends LSPExecutor {
+
+		@Override
+		protected List<CompletableFuture<LanguageServerWrapper>> getServers() {
+			// Compute list of servers from project & filter
+			return null;
+		}
+
+	}
+
+
+
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPExecutor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPExecutor.java
@@ -19,7 +19,7 @@ import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.services.LanguageServer;
 
-public abstract class LSPExecutor {
+public abstract class LSPExecutor<E extends LSPExecutor<E>> {
 
 
 	// Pluggable strategy for getting the set of LSWrappers to dispatch operations on
@@ -135,9 +135,9 @@ public abstract class LSPExecutor {
 	}
 
 
-	public LSPExecutor withFilter(final @NonNull Predicate<ServerCapabilities> filter) {
+	public E withFilter(final @NonNull Predicate<ServerCapabilities> filter) {
 		this.filter = filter;
-		return this;
+		return (E)this;
 	}
 
 	/**
@@ -153,7 +153,7 @@ public abstract class LSPExecutor {
 	 * Executor that will run requests on the set of language servers appropriate for the supplied document
 	 *
 	 */
-	public static class LSPDocumentExecutor extends LSPExecutor {
+	public static class LSPDocumentExecutor extends LSPExecutor<LSPDocumentExecutor> {
 
 		private long startVersion;
 
@@ -190,7 +190,7 @@ public abstract class LSPExecutor {
 	 * Executor that will run requests on the set of language servers appropriate for the supplied project
 	 *
 	 */
-	public static class LSPProjectExecutor extends LSPExecutor {
+	public static class LSPProjectExecutor extends LSPExecutor<LSPProjectExecutor> {
 
 		private final IProject project;
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPExecutor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPExecutor.java
@@ -1,13 +1,19 @@
 package org.eclipse.lsp4e;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -18,62 +24,182 @@ public abstract class LSPExecutor {
 	// Pluggable strategy for getting the set of LSWrappers to dispatch operations on
 	protected abstract List<CompletableFuture<LanguageServerWrapper>> getServers();
 
-	private Predicate<ServerCapabilities> filter = s -> true;
+	private @NonNull Predicate<ServerCapabilities> filter = s -> true;
 
+	/**
+	 * Runs an operation on all applicable language servers, returning an async result that will consist
+	 * of all non-empty individual results
+	 *
+	 * @param <T> Type of result being computed on the language server(s)
+	 * @param fn An individual operation to be performed on the language server, which following the LSP4j API
+	 * will return a <code>CompletableFuture&lt;T&gt;</code>. Note that the supplied fn will receive two arguments, the wrapper for the language server,
+	 * as well as the language server itself.
+	 *
+	 * @return Async result
+	 */
+	@NonNull
+	public <T> CompletableFuture<@NonNull List<@NonNull T>> collectAll(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+		final CompletableFuture<List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
+		return getServers().stream()
+			.map(wrapperFuture -> wrapperFuture
+					.thenCompose(w -> w == null ? CompletableFuture.completedFuture((T) null) : w.execute(fn)))
+			.reduce(init, LanguageServiceAccessor::combine, LanguageServiceAccessor::concatResults)
 
-
-	public <T> CompletableFuture<List<T>> collectAll(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
-		return null;
+			// Ensure any subsequent computation added by caller does not block further incoming messages from language servers
+			.thenApplyAsync(Function.identity());
 	}
 
-	public <T> List<CompletableFuture<T>> computeAll(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
-		return null;
+	/**
+	 * Runs an operation on all applicable language servers, returning a list of asynchronous responses that can
+	 * be used to instigate further processing as they complete individually
+	 *
+	 * @param <T> Type of result being computed on the language server(s)
+	 * @param fn An individual operation to be performed on the language server, which following the LSP4j API
+	 * will return a <code>CompletableFuture&lt;T&gt;</code>. Note that the supplied fn will receive two arguments, the wrapper for the language server,
+	 * as well as the language server itself.
+	 *
+	 * @return
+	 */
+	@NonNull
+	public <T> List<@NonNull CompletableFuture<@Nullable T>> computeAll(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+		return getServers().stream()
+				.map(wrapperFuture -> wrapperFuture
+						.thenCompose(w -> w == null ? null : w.execute(fn).thenApplyAsync(Function.identity())))
+				.filter(Objects::nonNull)
+				.collect(Collectors.toList());
 	}
 
+	/**
+	 * Runs an operation on all applicable language servers, returning an async result that will receive the first
+	 * non-null response
+	 * @param <T> Type of result being computed on the language server(s)
+	 * @param fn An individual operation to be performed on the language server, which following the LSP4j API
+	 * will return a <code>CompletableFuture&lt;T&gt;</code>. Note that the supplied fn will receive two arguments, the wrapper for the language server,
+	 * as well as the language server itself.
+	 *
+	 * @return An asynchronous result that will complete with a populated <code>Optional&lt;T&gt;</code> from the first
+	 * non-empty response, and with an empty <code>Optional</code> if none of the servers returned a non-empty result.
+	 */
 	public <T> CompletableFuture<Optional<T>> computeFirst(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
-		return null;
+		final List<CompletableFuture<LanguageServerWrapper>> servers = getServers();
+		if (servers.isEmpty()) {
+			return CompletableFuture.completedFuture(Optional.empty());
+		}
+		final CompletableFuture<Optional<T>> result = new CompletableFuture<>();
+
+		// Dispatch the request to the servers, appending a step to each such that
+		// the first to return a non-null result will be the overall result.
+		// CompletableFuture.anyOf() almost does what we need, but we don't want
+		// a quickly-returned null to trump a slowly-returned result
+		final List<CompletableFuture<T>> intermediate = servers.stream()
+				.map(wrapperFuture -> wrapperFuture
+						.thenCompose(w -> w == null ? null : w.execute(fn)))
+				.filter(Objects::nonNull)
+				.map(cf -> cf.thenApply(t -> {
+					if (!isEmpty(t)) { // TODO: Does this need to be a supplied function to handle all cases?
+						result.complete(Optional.of(t));
+					}
+					return t;
+				})).collect(Collectors.toList());
+
+		// Make sure that if the servers all return null then we give up and supply an empty result
+		// rather than potentially waiting forever...
+		final CompletableFuture<?> fallback = CompletableFuture.allOf(intermediate.toArray(new CompletableFuture[intermediate.size()]));
+		fallback.thenRun(() -> result.complete(Optional.empty()));
+
+		return result.thenApplyAsync(Function.identity());
+	}
+
+	/**
+	 *
+	 * @param project
+	 * @return Executor that will run requests on servers appropriate to the supplied project
+	 */
+	public static LSPProjectExecutor forProject(final IProject project) {
+		return new LSPProjectExecutor(project);
+	}
+
+	/**
+	 *
+	 * @param document
+	 * @return Executor that will run requests on servers appropriate to the supplied document
+	 */
+	public static LSPDocumentExecutor forDocument(final @NonNull IDocument document) {
+		return new LSPDocumentExecutor(document);
 	}
 
 
-	public static LSPProjectExecutor forProject(final IProject proj) {
-		// TODO: return LSPProjectExecutor
-		return null;
-	}
-
-	public static LSPDocumentExecutor forDocument(final IDocument document) {
-		// TODO: return LSPDocumentExecutor
-		return null;
-	}
-
-
-	public LSPExecutor withFilter(Predicate<ServerCapabilities> filter) {
+	public LSPExecutor withFilter(final @NonNull Predicate<ServerCapabilities> filter) {
 		this.filter = filter;
 		return this;
 	}
 
 
+	/**
+	 * Executor that will run requests on the set of language servers appropriate for the supplied document
+	 *
+	 */
 	public static class LSPDocumentExecutor extends LSPExecutor {
-		public IDocument getDocument() {
-			return null;
+
+		private final @NonNull IDocument document;
+
+		private LSPDocumentExecutor(final @NonNull IDocument document) {
+			this.document = document;
+		}
+
+		public @NonNull IDocument getDocument() {
+			return this.document;
 		}
 
 		@Override
 		protected List<CompletableFuture<LanguageServerWrapper>> getServers() {
 			// Compute list of servers from document & filter
-			return null;
+			return LanguageServiceAccessor.getLSWrappers(this.document).stream()
+				.map(wrapper -> wrapper.connectIf(this.document, getFilter()))
+				.collect(Collectors.toList());
 		}
 	}
 
+	/**
+	 * Executor that will run requests on the set of language servers appropriate for the supplied project
+	 *
+	 */
 	public static class LSPProjectExecutor extends LSPExecutor {
+
+		private final IProject project;
+
+		private boolean restartStopped = true;
+
+		LSPProjectExecutor(final IProject project) {
+			this.project = project;
+		}
+
+		/**
+		 * If called, this executor will not attempt to any servers that previously started in this session
+		 * but have since shut down
+		 * @return
+		 */
+		public LSPProjectExecutor excludeInactive() {
+			this.restartStopped = false;
+			return this;
+		}
 
 		@Override
 		protected List<CompletableFuture<LanguageServerWrapper>> getServers() {
 			// Compute list of servers from project & filter
-			return null;
+
+			return LanguageServiceAccessor.getWrappers(this.project, getFilter(), !this.restartStopped);
 		}
 
 	}
 
 
+	public Predicate<ServerCapabilities> getFilter() {
+		return this.filter;
+	}
+
+	private static <T> boolean isEmpty(final T t) {
+		return t == null || ((t instanceof List) && ((List<?>)t).isEmpty());
+	}
 
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPExecutor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPExecutor.java
@@ -134,6 +134,14 @@ public abstract class LSPExecutor {
 		return this;
 	}
 
+	/**
+	 *
+	 * @return True if there is a language server for this project/document & server capabilities
+	 */
+	public boolean anyMatching() {
+		return !getServers().isEmpty();
+	}
+
 
 	/**
 	 * Executor that will run requests on the set of language servers appropriate for the supplied document
@@ -158,6 +166,7 @@ public abstract class LSPExecutor {
 				.map(wrapper -> wrapper.connectIf(this.document, getFilter()))
 				.collect(Collectors.toList());
 		}
+
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
@@ -40,6 +40,7 @@ public class LanguageServerPlugin extends AbstractUIPlugin {
 	@Override
 	public void stop(BundleContext context) throws Exception {
 		plugin = null;
+		LanguageServiceAccessor.shutdownAllDispatchers();
 		super.stop(context);
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -768,7 +768,7 @@ public class LanguageServerWrapper {
 	 * @return Async result
 	 */
 	<T> CompletableFuture<T> executeOnLatestVersion(Function<LanguageServer, ? extends CompletionStage<T>> fn) {
-		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
+ 		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
 	}
 	/**
 	 * Sends a notification to the LS on a single executor thread tied to this server. Use of this guarantees that the server
@@ -800,7 +800,7 @@ public class LanguageServerWrapper {
 				}
 			}
 			return CompletableFuture.completedFuture(null);
-		}, this.dispatcher).thenApply(server -> this);
+		}, this.dispatcher).thenApply(server -> server == null ? null : this);
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -770,11 +770,17 @@ public class LanguageServerWrapper {
 	 * @return Async result
 	 */
 	@NonNull
-	<T> CompletableFuture<T> executeOnLatestVersion(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+	 <T> CompletableFuture<T> executeOnLatestVersion(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
  		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
 	}
 
-	<T> CompletableFuture<T> execute(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+	@NonNull
+	public <T> CompletableFuture<T> execute(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+		return getInitializedServer().thenComposeAsync(fn, this.dispatcher).thenApplyAsync(Function.identity());
+	}
+
+	@NonNull
+	public <T> CompletableFuture<T> execute(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
 		return getInitializedServer().thenComposeAsync(ls -> fn.apply(this, ls), this.dispatcher);
 	}
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -767,7 +767,8 @@ public class LanguageServerWrapper {
 	 * @param fn LS method to invoke
 	 * @return Async result
 	 */
-	<T> CompletableFuture<T> executeOnLatestVersion(Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+	@NonNull
+	<T> CompletableFuture<T> executeOnLatestVersion(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
  		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
 	}
 	/**
@@ -775,7 +776,7 @@ public class LanguageServerWrapper {
 	 * will have seen all previous such requests/notifications (and document updates).
 	 * @param fn LS notification to send
 	 */
-	void notifyOnLatestVersion(Consumer<LanguageServer> fn) {
+	void notifyOnLatestVersion(@NonNull Consumer<LanguageServer> fn) {
 		getInitializedServer().thenAcceptAsync(fn, this.dispatcher);
 	}
 
@@ -790,7 +791,7 @@ public class LanguageServerWrapper {
 	 * @return Async result that guarantees the wrapped server will be active and connected to the document. Wraps
 	 * null if the server does not support the requested capabilities or could not be started.
 	 */
-	CompletableFuture<LanguageServerWrapper> connectIf(IDocument document, Predicate<ServerCapabilities> filter) {
+	@NonNull CompletableFuture<@Nullable LanguageServerWrapper> connectIf(@NonNull IDocument document, @NonNull Predicate<ServerCapabilities> filter) {
 		return getInitializedServer().thenComposeAsync(server -> {
 			if (server != null && (filter == null || filter.test(getServerCapabilities()))) {
 				try {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -666,7 +666,7 @@ public class LanguageServerWrapper {
 				LanguageServerWrapper.this.connectedDocuments.put(uri, listener);
 				return CompletableFuture.completedFuture(languageServer);
 			}
-		}, this.dispatcher).thenApply(theVoid -> languageServer);
+		}, dispatcher).thenApply(theVoid -> languageServer);
 	}
 
 	public void disconnect(URI uri) {
@@ -801,7 +801,7 @@ public class LanguageServerWrapper {
 				}
 			}
 			return CompletableFuture.completedFuture(null);
-		}, this.dispatcher).thenApply(server -> server == null ? null : this);
+		}, dispatcher).thenApply(server -> server == null ? null : this);
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -771,6 +772,10 @@ public class LanguageServerWrapper {
 	@NonNull
 	<T> CompletableFuture<T> executeOnLatestVersion(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
  		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
+	}
+
+	<T> CompletableFuture<T> execute(BiFunction<LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+		return getInitializedServer().thenComposeAsync(ls -> fn.apply(this, ls), this.dispatcher);
 	}
 	/**
 	 * Sends a notification to the LS on a single executor thread tied to this server. Use of this guarantees that the server

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -140,6 +140,16 @@ public class LanguageServiceAccessor {
 			return this.wrapper.getServerCapabilities();
 		}
 
+		/**
+		 * Make a request to the language server such that it will be received only after any pending document updates, and before any subsequent changes
+		 * @param <T> Result type
+		 * @param fn language server operation
+		 * @return Async result
+		 */
+		public @NonNull <T> CompletableFuture<@Nullable T> computeOnLatestVersion(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+			return this.wrapper.executeOnLatestVersion(fn);
+		}
+
 		public boolean isActive() {
 			return this.wrapper.isActive();
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -653,11 +653,12 @@ public class LanguageServiceAccessor {
 	 * @param fn A single method invocation on <code>LanguageServer</code>
 	 * @return Async result aggregated over all applicable lang servers, filtering out nulls.
 	 */
-	public static <T> CompletableFuture<List<T>> computeOnServers(@NonNull IDocument document, Predicate<ServerCapabilities> filter,
+	@NonNull
+	public static <T> CompletableFuture<@NonNull List<@NonNull T>> computeOnServers(@NonNull IDocument document, @NonNull Predicate<ServerCapabilities> filter,
 			Function<LanguageServer, ? extends CompletionStage<T>> fn) {
 
 		// Out-of-line so we can declare it as List rather than ArrayList to avoid type errors below
-		CompletableFuture<List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
+		final CompletableFuture<List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
 
 		return getLSWrappers(document).stream()
 			// Ensure wrappers are started, connected to the document, and filter for capabilities
@@ -679,7 +680,8 @@ public class LanguageServiceAccessor {
 	 * @param next Pending result to include
 	 * @return
 	 */
-	static <T> CompletableFuture<List<T>> combine(CompletableFuture<? extends List<T>> result, CompletableFuture<T> next) {
+	@NonNull
+	static <T> CompletableFuture<@NonNull List<@NonNull T>> combine(@NonNull CompletableFuture<? extends List<@NonNull T>> result, @NonNull CompletableFuture<@Nullable T> next) {
 		return result.thenCombine(next, (List<T> a, T b) -> {
 			if (b != null) {
 				a.add(b);
@@ -691,12 +693,13 @@ public class LanguageServiceAccessor {
 	/**
 	 * Merges two async sets of results into a single async result
 	 * @param <T> Result type
-	 * @param a First async result
-	 * @param b Second async result
+	 * @param first First async result
+	 * @param second Second async result
 	 * @return Async combined result
 	 */
-	public static <T> CompletableFuture<List<T>> concatResults(CompletableFuture<List<T>> a, CompletableFuture<List<T>> b) {
-		return a.thenCombine(b, (c, d) -> {
+	@NonNull
+	public static <T> CompletableFuture<@NonNull List<T>> concatResults(@NonNull CompletableFuture<@NonNull List<T>> first, @NonNull CompletableFuture<@NonNull List<T>> second) {
+		return first.thenCombine(second, (c, d) -> {
 			c.addAll(d);
 			return c;
 		});
@@ -709,7 +712,8 @@ public class LanguageServiceAccessor {
 	 * @param col
 	 * @return A stream (empty if col is null)
 	 */
-	public static <T> Stream<T> streamSafely(Collection<T> col) {
+	@NonNull
+	public static <T> Stream<T> streamSafely(@Nullable Collection<T> col) {
 		return col == null ? Stream.<T>of() : col.stream();
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
@@ -12,23 +12,24 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.codeactions;
 
+import java.net.URI;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.action.ContributionItem;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LSPExecutor;
+import org.eclipse.lsp4e.LSPExecutor.LSPDocumentExecutor;
 import org.eclipse.lsp4e.LanguageServerPlugin;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.LanguageServiceAccessor.LSPDocumentInfo;
+import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.ui.LSPImages;
 import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4e.ui.UI;
@@ -56,8 +57,9 @@ import org.eclipse.ui.texteditor.ITextEditor;
 
 public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchContribution {
 
-	private List<LSPDocumentInfo> infos;
 	private Range range;
+
+	private LSPDocumentExecutor executor;
 
 	@Override
 	public void initialize(IServiceLocator serviceLocator) {
@@ -68,8 +70,9 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 			if (document == null) {
 				return;
 			}
-			infos = LanguageServiceAccessor.getLSPDocumentInfosFor(document,
-					LSPCodeActionMarkerResolution::providesCodeActions);
+
+			executor = LSPExecutor.forDocument(document);
+			executor.withFilter(LSPCodeActionMarkerResolution::providesCodeActions);
 			ITextSelection selection = (ITextSelection) textEditor.getSelectionProvider().getSelection();
 			try {
 				this.range = new Range(LSPEclipseUtils.toPosition(selection.getOffset(), document),
@@ -84,87 +87,83 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 	public void fill(final Menu menu, int index) {
 		final MenuItem item = new MenuItem(menu, SWT.NONE, index);
 		item.setEnabled(false);
-		if (infos.isEmpty()) {
+
+		final URI fileUri = LSPEclipseUtils.toUri(this.executor.getDocument());
+
+		CodeActionContext context = new CodeActionContext(Collections.emptyList());
+		CodeActionParams params = new CodeActionParams();
+		params.setTextDocument(new TextDocumentIdentifier(fileUri.toString()));
+		params.setRange(this.range);
+		params.setContext(context);
+
+		final @NonNull List<@NonNull CompletableFuture<List<Either<Command, CodeAction>>>> actions
+			= executor.computeAll((w, ls) -> ls.getTextDocumentService().codeAction(params)
+					.whenComplete((codeActions, t) -> scheduleMenuUpdate(menu, index, w, t, codeActions)));
+
+		if (actions.isEmpty()) {
 			item.setText(Messages.notImplemented);
 			return;
 		}
-
 		item.setText(Messages.computing);
-		CodeActionContext context = new CodeActionContext(Collections.emptyList());
-		CodeActionParams params = new CodeActionParams();
-		params.setTextDocument(new TextDocumentIdentifier(infos.get(0).getFileUri().toString()));
-		params.setRange(this.range);
-		params.setContext(context);
-		Set<CompletableFuture<?>> runningFutures = new HashSet<>();
-		for (LSPDocumentInfo info : this.infos) {
-			final CompletableFuture<List<Either<Command, CodeAction>>> codeActions = info.getInitializedLanguageClient()
-					.thenComposeAsync(languageServer -> languageServer.getTextDocumentService().codeAction(params));
-			runningFutures.add(codeActions);
-			codeActions.whenComplete((t, u) -> {
-				runningFutures.remove(codeActions);
-				UIJob job = new UIJob(menu.getDisplay(), Messages.updateCodeActions_menu) {
-					@Override
-					public IStatus runInUIThread(IProgressMonitor monitor) {
-						if (u != null) {
-							final MenuItem item = new MenuItem(menu, SWT.NONE, index);
-							item.setText(u.getMessage());
-							item.setImage(LSPImages.getSharedImage(ISharedImages.IMG_DEC_FIELD_ERROR));
-							item.setEnabled(false);
-						} else if (t != null) {
-							for (Either<Command, CodeAction> command : t) {
-								if (command != null) {
-									if (command.isLeft()) {
-										final MenuItem item = new MenuItem(menu, SWT.NONE, index);
-										item.setText(command.getLeft().getTitle());
-										item.addSelectionListener(new SelectionAdapter() {
-											@Override
-											public void widgetSelected(SelectionEvent e) {
-												executeCommand(info, command.getLeft());
-											}
-										});
-									} else if (command.isRight()) {
-										CodeAction codeAction = command.getRight();
-										final MenuItem item = new MenuItem(menu, SWT.NONE, index);
-										item.setText(codeAction.getTitle());
-										item.addSelectionListener(new SelectionAdapter() {
-											@Override
-											public void widgetSelected(SelectionEvent e) {
-												if (codeAction.getEdit() != null) {
-													LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit(), codeAction.getTitle());
-												}
-												if (codeAction.getCommand() != null) {
-													executeCommand(info, codeAction.getCommand());
-												}
-											}
-										});
-									}
-								}
-							}
-						}
-						if (menu.getItemCount() == 1) {
-							item.setText(Messages.codeActions_emptyMenu);
-						} else {
-							item.dispose();
-						}
-						return Status.OK_STATUS;
-					}
-				};
-				job.schedule();
-			});
-		}
+
 		super.fill(menu, index);
 	}
 
-	private void executeCommand(LSPDocumentInfo info, Command command) {
-		ServerCapabilities capabilities = info.getCapabilites();
+	private void scheduleMenuUpdate(final Menu menu, final int index, final LanguageServerWrapper wrapper, final Throwable u, final List<Either<Command, CodeAction>> codeActions) {
+		UIJob job = new UIJob(menu.getDisplay(), Messages.updateCodeActions_menu) {
+			@Override
+			public IStatus runInUIThread(IProgressMonitor monitor) {
+				if (u != null) {
+					final MenuItem item = new MenuItem(menu, SWT.NONE, index);
+					item.setText(u.getMessage());
+					item.setImage(LSPImages.getSharedImage(ISharedImages.IMG_DEC_FIELD_ERROR));
+					item.setEnabled(false);
+				} else if (codeActions != null) {
+					for (Either<Command, CodeAction> command : codeActions) {
+						if (command != null) {
+							if (command.isLeft()) {
+								final MenuItem item = new MenuItem(menu, SWT.NONE, index);
+								item.setText(command.getLeft().getTitle());
+								item.addSelectionListener(new SelectionAdapter() {
+									@Override
+									public void widgetSelected(SelectionEvent e) {
+										executeCommand(wrapper, command.getLeft());
+									}
+								});
+							} else if (command.isRight()) {
+								CodeAction codeAction = command.getRight();
+								final MenuItem item = new MenuItem(menu, SWT.NONE, index);
+								item.setText(codeAction.getTitle());
+								item.addSelectionListener(new SelectionAdapter() {
+									@Override
+									public void widgetSelected(SelectionEvent e) {
+										if (codeAction.getEdit() != null) {
+											LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit(), codeAction.getTitle());
+										}
+										if (codeAction.getCommand() != null) {
+											executeCommand(wrapper, codeAction.getCommand());
+										}
+									}
+								});
+							}
+						}
+					}
+				}
+				return Status.OK_STATUS;
+			}
+		};
+		job.schedule();
+	}
+
+	private void executeCommand(final LanguageServerWrapper wrapper, final Command command) {
+		final ServerCapabilities capabilities = wrapper.getServerCapabilities();
 		if (capabilities != null) {
 			ExecuteCommandOptions provider = capabilities.getExecuteCommandProvider();
 			if (provider != null && provider.getCommands().contains(command.getCommand())) {
 				ExecuteCommandParams params = new ExecuteCommandParams();
 				params.setCommand(command.getCommand());
 				params.setArguments(command.getArguments());
-				info.getInitializedLanguageClient()
-						.thenAcceptAsync(ls -> ls.getWorkspaceService().executeCommand(params));
+				wrapper.execute(ls -> ls.getWorkspaceService().executeCommand(params));
 			}
 		}
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
@@ -71,8 +71,8 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 				return;
 			}
 
-			executor = LSPExecutor.forDocument(document);
-			executor.withFilter(LSPCodeActionMarkerResolution::providesCodeActions);
+			executor = LSPExecutor.forDocument(document)
+				.withFilter(LSPCodeActionMarkerResolution::providesCodeActions);
 			ITextSelection selection = (ITextSelection) textEditor.getSelectionProvider().getSelection();
 			try {
 				this.range = new Range(LSPEclipseUtils.toPosition(selection.getOffset(), document),

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/ColorInformationMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/ColorInformationMining.java
@@ -21,12 +21,12 @@ import org.eclipse.jface.text.codemining.LineContentCodeMining;
 import org.eclipse.jface.util.Geometry;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4j.ColorInformation;
 import org.eclipse.lsp4j.ColorPresentationParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Color;
@@ -57,14 +57,14 @@ public class ColorInformationMining extends LineContentCodeMining {
 
 		private final TextDocumentIdentifier textDocumentIdentifier;
 		private final ColorInformation colorInformation;
-		private final LanguageServer languageServer;
+		private final LanguageServerWrapper languageServerWrapper;
 		private final IDocument document;
 
 		public UpdateColorWithDialog(TextDocumentIdentifier textDocumentIdentifier, ColorInformation colorInformation,
-				LanguageServer languageServer, IDocument document) {
+				LanguageServerWrapper languageServerWrapper, IDocument document) {
 			this.textDocumentIdentifier = textDocumentIdentifier;
 			this.colorInformation = colorInformation;
-			this.languageServer = languageServer;
+			this.languageServerWrapper = languageServerWrapper;
 			this.document = document;
 		}
 
@@ -82,13 +82,15 @@ public class ColorInformationMining extends LineContentCodeMining {
 				// get LSP color presentation list for the picked color
 				ColorPresentationParams params = new ColorPresentationParams(textDocumentIdentifier,
 						LSPEclipseUtils.toColor(rgb), colorInformation.getRange());
-				this.languageServer.getTextDocumentService().colorPresentation(params).thenAcceptAsync(presentations -> {
+				this.languageServerWrapper.execute(ls -> ls.getTextDocumentService().colorPresentation(params)).thenAccept(presentations -> {
 					if (presentations.isEmpty()) {
 						return;
 					}
 					// As ColorDialog cannot be customized (to choose the color presentation (rgb,
 					// hexa, ....) we pick the first color presentation.
 					try {
+
+						// TODO: Should this use optimistic locking and a version check?
 						TextEdit textEdit = presentations.get(0).getTextEdit();
 						LSPEclipseUtils.applyEdit(textEdit, document);
 					} catch (BadLocationException e) {
@@ -101,10 +103,10 @@ public class ColorInformationMining extends LineContentCodeMining {
 	}
 
 	public ColorInformationMining(ColorInformation colorInformation, @NonNull IDocument document,
-			TextDocumentIdentifier textDocumentIdentifier, LanguageServer languageServer,
+			TextDocumentIdentifier textDocumentIdentifier, LanguageServerWrapper languageServerWrapper,
 			DocumentColorProvider colorProvider) throws BadLocationException {
 		super(toPosition(colorInformation.getRange(), document), colorProvider,
-				new UpdateColorWithDialog(textDocumentIdentifier, colorInformation, languageServer, document));
+				new UpdateColorWithDialog(textDocumentIdentifier, colorInformation, languageServerWrapper, document));
 		this.rgba = LSPEclipseUtils.toRGBA(colorInformation.getColor());
 		this.colorProvider = colorProvider;
 		// set label with space to mark the mining as resolved.

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -75,7 +75,7 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 				LanguageServiceAccessor.computeOnServers(
 									textViewer.getDocument(),
 									capabilities -> LSPEclipseUtils.hasCapability(capabilities.getDefinitionProvider()),
-									ls -> ls.getTextDocumentService().definition(LSPEclipseUtils.toDefinitionParams(params))))
+									ls -> ls.getTextDocumentService().typeDefinition(LSPEclipseUtils.toTypeDefinitionParams(params))))
 				.get(500, TimeUnit.MILLISECONDS)
 				.stream().flatMap(locations -> toHyperlinks(document, linkRegion, locations).stream())
 				.forEach(link -> allLinks.putIfAbsent(link.getLocation(), link));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatHandler.java
@@ -52,13 +52,12 @@ public class LSPFormatHandler extends AbstractHandler {
 			final Shell shell = textEditor.getSite().getShell();
 			ISelection selection = HandlerUtil.getCurrentSelection(event);
 			if (document != null && selection instanceof ITextSelection textSelection) {
-				final long originalStamp = LSPEclipseUtils.getDocumentModificationStamp(document);
 				final LSPDocumentExecutor executor = LSPExecutor.forDocument(document);
 				executor.withFilter(LSPFormatter::supportFormatting);
 				try {
 					formatter.requestFormatting(executor, textSelection).thenAccept(res -> res.ifPresent(edits -> shell.getDisplay().asyncExec(() -> {
 						try {
-							formatter.applyEdits(document, originalStamp, edits);
+							formatter.applyEdits(document,edits);
 						} catch (ConcurrentModificationException e) {
 							LanguageServerPlugin.logInfo("Document changed subsequent to format request"); //$NON-NLS-1$
 						}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -191,7 +191,7 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 	 *            the hovered offset.
 	 */
 	private void initiateHoverRequest(@NonNull ITextViewer viewer, int offset) {
-		final IDocument document = viewer.getDocument();
+		final @NonNull IDocument document = viewer.getDocument();
 		this.lastViewer = viewer;
 		try {
 			HoverParams params = LSPEclipseUtils.toHoverParams(offset, document);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -42,6 +42,7 @@ import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.MarkedString;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -192,24 +193,15 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 	private void initiateHoverRequest(@NonNull ITextViewer viewer, int offset) {
 		final IDocument document = viewer.getDocument();
 		this.lastViewer = viewer;
-		this.request = LanguageServiceAccessor
-			.getLanguageServers(document, capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()))
-				.thenApplyAsync(languageServers -> // Async is very important here, otherwise the LS Client thread is in
-													// deadlock and doesn't read bytes from LS
-				languageServers.stream()
-					.map(languageServer -> {
-						try {
-								return languageServer.getTextDocumentService()
-										.hover(LSPEclipseUtils.toHoverParams(offset, document)).get();
-						} catch (ExecutionException | BadLocationException e) {
-							LanguageServerPlugin.logError(e);
-							return null;
-						} catch (InterruptedException e) {
-							LanguageServerPlugin.logError(e);
-							Thread.currentThread().interrupt();
-							return null;
-						}
-					}).filter(Objects::nonNull).collect(Collectors.toList()));
+		try {
+			HoverParams params = LSPEclipseUtils.toHoverParams(offset, document);
+			this.request = LanguageServiceAccessor.computeOnServers(document,
+					capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()),
+					languageServer -> languageServer.getTextDocumentService().hover(params));
+
+		} catch (BadLocationException e) {
+			LanguageServerPlugin.logError(e);
+		}
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -39,8 +39,8 @@ import org.eclipse.jface.text.ITextHoverExtension;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LSPExecutor;
 import org.eclipse.lsp4e.LanguageServerPlugin;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.MarkedString;
@@ -195,10 +195,10 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 		this.lastViewer = viewer;
 		try {
 			HoverParams params = LSPEclipseUtils.toHoverParams(offset, document);
-			this.request = LanguageServiceAccessor.computeOnServers(document,
-					capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()),
-					languageServer -> languageServer.getTextDocumentService().hover(params));
 
+			this.request = LSPExecutor.forDocument(document)
+				.withFilter(capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()))
+				.collectAll((wapper, server) -> server.getTextDocumentService().hover(params));
 		} catch (BadLocationException e) {
 			LanguageServerPlugin.logError(e);
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
@@ -50,8 +50,8 @@ public class LSPSymbolInWorkspaceHandler extends AbstractHandler {
 		}
 
 		IProject project = resource.getProject();
-		final LSPProjectExecutor executor = LSPExecutor.forProject(project);
-		executor.withFilter(capabilities -> LSPEclipseUtils.hasCapability(capabilities.getWorkspaceSymbolProvider()));
+		final LSPProjectExecutor executor = LSPExecutor.forProject(project)
+				.withFilter(capabilities -> LSPEclipseUtils.hasCapability(capabilities.getWorkspaceSymbolProvider()));
 
 		if (!executor.anyMatching()) {
 			return null;


### PR DESCRIPTION
Following the discussions on https://github.com/eclipse/lsp4e/pull/251 about the need to reform the UI to address concurrency problems, I have gone through the existing API, specifically `LanguageServiceAccessor`, `LanguageServerWrapper` and `LSPDocumentInfo` in some detail, to try and understand the use cases.

Please see `LSPExecutor` in the latest commit for an outline of what I think could be implemented.

I have based this commit off of #251 as it will build on some of the work in that branch (but replace some of it), although I possibly should have just kept the design discussion based off master (sorry!)

The core workflow for most uses of the language server goes as follows:
1. Select the Language Servers that apply to the task at hand. This boils down into using either an `IDocument` or an `IProject` as a selector, combined with a server capabilities predicate.
2. Dispatch operations onto the server. All LSP4j calls work asynchronously, returning CompletableFutures, so the dispatch will result in one or more completable futures.
3. Process the results when the CompletableFuture(s) complete.

Stage 3 is complicated by the fact the calling code must deal with potentially more than one language server in play. At the moment, this is handled ad-hoc by the calling code. This results in a lot of messy code at the various call-sites, which tends to obscure what is going on. I think it would reduce boilerplate to handle this as part of the API, and I think this can be done fairly easily as there are only a small number of actual patterns in play, probably reflecting the fact that there are not too many sensible ways of handling multiple results! I propose:
a. Return all the results aggregated as a `CompletableFuture<List<T>>`. This is by far the commonest case in the existing code, and the one I already implemented in #251 .
b. Return all the results separately as `List<CompletableFuture<T>>`. This is a minor use case at present, but crops up in e.g. `LSPCodeActionsMenu` where placeholder items are created and replaced as the server results return one by one.
c. We only want one result, e.g. edits from a format request. This isn't handled well at the moment - there are a couple of instances of just arbitrarily grabbing the result from the first server in the list, with a TODO about maybe selecting the result from the first server to respond. I think I know how to implement this with a bit of CompletableFuture trickery and so we can have a method returning `CompletableFuture<Optional<T>>`

Stages 1 and 2 are complicated by a lot of lifecycle logic, with some pretty subtle considerations. For this reason I propose to implement this part of `LSPExecutor` largely on top of this existing logic inside `LanguageServiceAccessor` and `LanguageServerWrapper`. This avoids the danger of ditching and reimplementing a lot of presumably battle-hardened code. It also provides a smooth migration path: the existing methods can be deprecated and then made internal-only (with any unused ones deleted).

I have proposed a builder-like pattern for the `LSPExecutor` design. I think this works quite well when you have to support a lot of different use cases, many of which are closely related, and you risk having an explosion of overloaded methods. It also offers a degree of future proofing as further customisation could be added on later without breaking existing code.

The basic usage would go something like
```
LSPExecutor.forDocment(document).withCapabilities(s -> s.supportsHover())
    .computeAll((w, ls) -> ls.getHover(position));
```

