### PR TITLE
Improved proposal based on Pr 344

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
@@ -702,17 +702,17 @@ public class LanguageServersTest {
 
 		CompletableFuture<List<LSWPair>> async = LanguageServers.forDocument(document)
 				.withFilter(capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()))
-				.collectAll((w, ls) -> ls.getTextDocumentService().hover(params).thenApply(h -> new LSWPair(w, ls)));
+				.collectAll(w -> w.getTextDocumentService().hover(params).thenApply(h -> new LSWPair(w, w.getServer())));
 
 		final List<LSWPair> result = async.join();
 
 		final AtomicInteger matching = new AtomicInteger();
 
 		assertEquals("Should have had two responses", 2, result.size());
-		assertNotEquals("LS should have been different proxies", result.get(0).server, result.get(1).server);
+		assertNotEquals("LS should have been different proxies", result.get(0).wrapper, result.get(1).wrapper);
 		result.forEach(p -> {
 			p.wrapper.execute(ls -> {
-				if (ls == p.server) {
+				if (ls == p.wrapper.getServer()) {
 					matching.incrementAndGet();
 				}
 				return CompletableFuture.completedFuture(null);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -234,7 +234,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 
 		try {
-			List<TextEdit> edits = languageServerWrapper.executeImpl(ls -> ls.getTextDocumentService().willSaveWaitUntil(params))
+			List<TextEdit> edits = languageServerWrapper.execute(ls -> ls.getTextDocumentService().willSaveWaitUntil(params))
 				.get(lsToWillSaveWaitUntilTimeout(), TimeUnit.SECONDS);
 			try {
 				LSPEclipseUtils.applyEdits(document, edits);
@@ -278,7 +278,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	}
 
 	public CompletableFuture<Void> documentClosed() {
-	   final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(fileUri);
+		final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(fileUri);
 		WILL_SAVE_WAIT_UNTIL_TIMEOUT_MAP.remove(identifier.getUri());
 		// When LS is shut down all documents are being disconnected. No need to send
 		// "didClose" message to the LS that is being shut down or not yet started

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -56,7 +56,6 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.osgi.util.NLS;
 
 final class DocumentContentSynchronizer implements IDocumentListener {
@@ -72,7 +71,6 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private IPreferenceStore store;
 
 	public DocumentContentSynchronizer(@NonNull LanguageServerWrapper languageServerWrapper,
-			@NonNull LanguageServer languageServer,
 			@NonNull IDocument document, TextDocumentSyncKind syncKind) {
 		this.languageServerWrapper = languageServerWrapper;
 		URI uri = LSPEclipseUtils.toUri(document);
@@ -111,7 +109,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 		textDocument.setLanguageId(languageId);
 		textDocument.setVersion(++version);
-		languageServer.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument));
+		languageServerWrapper.sendNotification(ls -> ls.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument)));
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -796,7 +796,7 @@ public class LanguageServerWrapper {
 	}
 
 	/**
-	 * Sends a notification to the wrapped language server
+	 * Sends a notification to the wrapped language server.
 	 *
 	 * @param fn LS notification to send
 	 */
@@ -808,32 +808,16 @@ public class LanguageServerWrapper {
 	}
 
 	/**
-	 * Runs a request on the language server
-	 *
-	 * @param <T> LS response type
-	 * @param fn Code block that will be supplied the LS in a state where it is guaranteed to have been initialized
-	 *
-	 * @return Async result
-	 */
-	public <T> CompletableFuture<T> execute(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
-		// Send the request on the dispatch thread, then additionally make sure the response is delivered
-		// on a thread from the default ForkJoinPool. This makes sure the user can't chain on an arbitrary
-		// long-running block of code that would tie up the server response listener and prevent any more
-		// inbound messages being read
-		return executeImpl(fn).thenApplyAsync(Function.identity());
-	}
-
-	/**
-	 * Runs a request on the language server. Internal hook for the LSPexecutor implementations
+	 * Runs a request on the language server.
 	 *
 	 * @param <T> LS response type
 	 * @param fn LS method to invoke
 	 * @return Async result
 	 */
 	@NonNull
-	<T> CompletableFuture<T> executeImpl(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+	public <T> CompletableFuture<T> execute(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
 		// Run the supplied function, ensuring that it is enqueued on the dispatch thread associated with the
-		// wrapped language server, and is thus guarannteed to be seen in the correct order with respect
+		// wrapped language server, and is thus guaranteed to be seen in the correct order with respect
 		// to e.g. previous document changes
 		//
 		// Note this doesn't get the .thenApplyAsync(Function.identity()) chained on additionally, unlike

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -15,6 +15,7 @@ package org.eclipse.lsp4e;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -106,7 +107,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	public <T> List<@NonNull CompletableFuture<@Nullable T>> computeAll(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
 		return getServers().stream()
 				.map(cf -> cf
-						.thenCompose(w -> w == null ? CompletableFuture.completedFuture(null) : w.executeImpl(ls -> fn.apply(w, ls)).thenApplyAsync(Function.identity())))
+						.thenCompose(w -> w == null ? CompletableFuture.completedFuture(null) : w.execute(ls -> fn.apply(w, ls)).thenApplyAsync(Function.identity())))
 				.toList();
 	}
 
@@ -283,6 +284,23 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	}
 
 
+	/**
+	 * Executor that will run on the supplied wrapper
+	 */
+	public static class LanguageServerWrapperExecutor extends LanguageServers<LanguageServerWrapperExecutor> {
+
+		private final @NonNull LanguageServerWrapper wrapper;
+
+		private LanguageServerWrapperExecutor(final @NonNull LanguageServerWrapper wrapper) {
+			this.wrapper = wrapper;
+		}
+
+		@Override
+		protected @NonNull List<@NonNull CompletableFuture<@Nullable LanguageServerWrapper>> getServers() {
+			return Collections.singletonList(CompletableFuture.completedFuture(wrapper));
+		}
+	}
+
 	private static <T> boolean isEmpty(final T t) {
 		return t == null || ((t instanceof List) && ((List<?>)t).isEmpty());
 	}
@@ -344,7 +362,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	private <T> Stream<CompletableFuture<T>> executeOnServers(
 			BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
 		return getServers().stream().map(cf -> cf.thenCompose(
-				w -> w == null ? CompletableFuture.completedFuture((T) null) : w.executeImpl(ls -> fn.apply(w, ls))));
+				w -> w == null ? CompletableFuture.completedFuture((T) null) : w.execute(ls -> fn.apply(w, ls))));
 	}
 
 	/*
@@ -376,6 +394,15 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 */
 	public static LanguageServerProjectExecutor forProject(final IProject project) {
 		return new LanguageServerProjectExecutor(project);
+	}
+
+	/**
+	 *
+	 * @param wrapper
+	 * @return Executor that will run requests on servers appropriate to the supplied wrapper
+	 */
+	public static LanguageServerWrapperExecutor forWrapper(final @NonNull LanguageServerWrapper wrapper) {
+		return new LanguageServerWrapperExecutor(wrapper);
 	}
 
 	private @NonNull Predicate<ServerCapabilities> filter = s -> true;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/DocumentColorProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/DocumentColorProvider.java
@@ -61,8 +61,8 @@ public class DocumentColorProvider extends AbstractCodeMiningProvider {
 				.withFilter(DocumentColorProvider::isColorProvider)
 				.collectAll(
 					// Need to do some of the result processing inside the function we supply to collectAll(...)
-					// as need the LSW to construct the ColorInformationMining
-					(wrapper, ls) -> ls.getTextDocumentService().documentColor(param)
+					// as need the LS to construct the ColorInformationMining
+					wrapper -> wrapper.getTextDocumentService().documentColor(param)
 								.thenApply(colors -> LanguageServers.streamSafely(colors)
 										.map(color -> toMining(color, document, textDocumentIdentifier, wrapper))))
 				.thenApply(res -> res.stream().flatMap(Function.identity()).filter(Objects::nonNull).toList());


### PR DESCRIPTION
I have worked on #344 and have prepared this proposal (it is an improvement for me) and would be happy if we would merge this or something similar.
The main differences to #344 is that I have extended the LSW so that it can be used to get services from the `LS`, that eliminates the need of having APIs with `(LanguageServerWrapper)` and `(LanguageServerWrapper, LanguageServer)`. I have added copyright headers and improved small things. 
Finally I have added one `LanguageServerExecutor` when the entry point is an existing `(LanguageServerWrapper)`.
I have also removed the TODOs.