### PR TITLE
Fix encoding

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LoggingStreamConnectionProviderProxy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LoggingStreamConnectionProviderProxy.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.time.OffsetDateTime;
@@ -120,7 +121,7 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 		builder.append(' ');
 		builder.append(id);
 		builder.append(":\n"); //$NON-NLS-1$
-		builder.append(new String(payload));
+		builder.append(new String(payload, StandardCharsets.UTF_8));
 		return builder.toString();
 	}
 
@@ -294,7 +295,7 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 			}
 		}
 		try {
-			Files.write(logFile.toPath(), string.getBytes(), StandardOpenOption.APPEND);
+			Files.write(logFile.toPath(), string.getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND);
 		} catch (IOException e) {
 			LanguageServerPlugin.logError(e);
 		}


### PR DESCRIPTION
Use UTF-8 encoding explicitly so that users who are using regional
charset by default don't end up with corrupted messages, or worse
unhandled exceptions thrown here.

According to the LSP specification:
"The content part is encoded using the charset provided in the
Content-Type field. It defaults to UTF-8, which is the only encoding
supported right now. If a server or client receives a header with a
different encoding than UTF-8 it should respond with an error."

So even though the code in LSP4J reads the Content-Type header and
evaluates it, and it could thus supports different encoding, LSP4E does
not need to support it, and in practice, no server should use that
either.