### PR TITLE
Fix NPE in SemanticHighlightReconcilerStrategy#hasSemanticTokensFull

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -197,7 +197,7 @@ public class SemanticHighlightReconcilerStrategy
 
 	private boolean hasSemanticTokensFull(final ServerCapabilities serverCapabilities) {
 		return serverCapabilities.getSemanticTokensProvider() != null
-				&& serverCapabilities.getSemanticTokensProvider().getFull().getLeft();
+				&& LSPEclipseUtils.hasCapability(serverCapabilities.getSemanticTokensProvider().getFull());
 	}
 
 	private CompletableFuture<Void> semanticTokensFull(final List<LanguageServer> languageServers, final int version) {


### PR DESCRIPTION
Fixes
```java
java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "org.eclipse.lsp4j.jsonrpc.messages.Either.getLeft()" is null
	at org.eclipse.lsp4e.operations.semanticTokens.SemanticHighlightReconcilerStrategy.hasSemanticTokensFull(SemanticHighlightReconcilerStrategy.java:200)
	at org.eclipse.lsp4e.LanguageServiceAccessor.lambda$15(LanguageServiceAccessor.java:597)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
```