### PR TITLE
Use language server label as background job name if available

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -55,7 +55,7 @@ public class LanguageClientImpl implements LanguageClient {
 	public final void connect(LanguageServer server, LanguageServerWrapper wrapper) {
 		this.server = server;
 		this.wrapper = wrapper;
-		progressManager.connect(server);
+		progressManager.connect(server, wrapper.serverDefinition);
 	}
 
 	protected void setDiagnosticsConsumer(@NonNull Consumer<PublishDiagnosticsParams> diagnosticConsumer) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
@@ -83,6 +83,7 @@ public class Messages extends NLS {
 	public static String DocumentContentSynchronizer_TimeoutThresholdMessage;
 	public static String CreateFile_confirm_title;
 	public static String CreateFile_confirm_message;
+	public static String LSPProgressManager_BackgroundJobName;
 
 	static {
 		NLS.initializeMessages("org.eclipse.lsp4e.ui.messages", Messages.class); //$NON-NLS-1$

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
@@ -89,3 +89,5 @@ DocumentContentSynchronizer_TimeoutThresholdMessage="On-Save action timeout out 
 
 CreateFile_confirm_title=Create file
 CreateFile_confirm_message=Unable to open file ''{0}''. Do you want to create file?
+
+LSPProgressManager_BackgroundJobName=Language Server Background Job


### PR DESCRIPTION
Currently when something unexpected happens in the communication between LSP4E and a Language Server, never ending "Language Server Background Job" entries appear in the progress view.

This PR replaces the label "Language Server Background Job" with the actual name/label of the language server, which simplifies troubleshooting and helps end-users to isolate the offending plugin.

Before:
![image](https://user-images.githubusercontent.com/426959/212497479-c9aae9c3-fba0-44d8-8c81-09bd2b0e5689.png)
After:
![image](https://user-images.githubusercontent.com/426959/212497504-23ab51bb-28e5-4f6e-9587-5cd4ce344075.png)
