### PR TITLE
Use fully quoted/encoded URIs via URI.toASCIIString() #358

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -187,9 +187,7 @@ public final class LSPEclipseUtils {
 		Position start = toPosition(offset, document);
 		final var param = new CompletionParams();
 		param.setPosition(start);
-		final var id = new TextDocumentIdentifier();
-		id.setUri(fileUri.toString());
-		param.setTextDocument(id);
+		param.setTextDocument(toTextDocumentIdentifier(fileUri));
 		return param;
 	}
 
@@ -208,9 +206,7 @@ public final class LSPEclipseUtils {
 		Position start = toPosition(offset, document);
 		final var param = new TextDocumentPositionParams();
 		param.setPosition(start);
-		final var id = new TextDocumentIdentifier();
-		id.setUri(fileUri.toString());
-		param.setTextDocument(id);
+		param.setTextDocument(toTextDocumentIdentifier(fileUri));
 		return param;
 	}
 
@@ -221,7 +217,7 @@ public final class LSPEclipseUtils {
 		param.setPosition(start);
 		final var id = new TextDocumentIdentifier();
 		if (uri != null) {
-			id.setUri(uri.toString());
+			id.setUri(uri.toASCIIString());
 		}
 		param.setTextDocument(id);
 		return param;
@@ -268,6 +264,21 @@ public final class LSPEclipseUtils {
 		return specificParams;
 	}
 
+	@NonNull
+	public static TextDocumentIdentifier toTextDocumentIdentifier(@NonNull final IDocument document) {
+		return toTextDocumentIdentifier(toUri(document));
+	}
+
+	@NonNull
+	public static TextDocumentIdentifier toTextDocumentIdentifier(@NonNull final IResource res) {
+		return toTextDocumentIdentifier(toUri(res));
+	}
+
+	@NonNull
+	public static TextDocumentIdentifier toTextDocumentIdentifier(final URI uri) {
+		return new TextDocumentIdentifier(uri.toASCIIString());
+	}
+
 	private static ITextFileBuffer toBuffer(IDocument document) {
 		ITextFileBufferManager bufferManager = FileBuffers.getTextFileBufferManager();
 		if (bufferManager == null)
@@ -275,7 +286,10 @@ public final class LSPEclipseUtils {
 		return bufferManager.getTextFileBuffer(document);
 	}
 
-	public static URI toUri(IDocument document) {
+	public static URI toUri(@Nullable IDocument document) {
+		if(document == null) {
+			return null;
+		}
 		IFile file = getFile(document);
 		if (file != null) {
 			return toUri(file);
@@ -968,7 +982,7 @@ public final class LSPEclipseUtils {
 		}
 	}
 
-	@Nullable public static IFile getFile(IDocument document) {
+	@Nullable public static IFile getFile(@NonNull IDocument document) {
 		IPath path = toPath(document);
 		return getFile(path);
 	}
@@ -1000,7 +1014,7 @@ public final class LSPEclipseUtils {
 	public static WorkspaceFolder toWorkspaceFolder(@NonNull IProject project) {
 		final var folder = new WorkspaceFolder();
 		URI folderUri = toUri(project);
-		folder.setUri(folderUri != null ? folderUri.toString() : ""); //$NON-NLS-1$
+		folder.setUri(folderUri != null ? folderUri.toASCIIString() : ""); //$NON-NLS-1$
 		folder.setName(project.getName());
 		return folder;
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java
@@ -305,7 +305,7 @@ public class CommandExecutor {
 			}
 		});
 		if (!currentEntry.value.isEmpty()) {
-			changes.put(currentEntry.key.toString(), currentEntry.value);
+			changes.put(currentEntry.key.toASCIIString(), currentEntry.value);
 		}
 		return res;
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
@@ -53,7 +53,6 @@ import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.swt.graphics.Image;
@@ -140,7 +139,7 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 				final var context = new CodeActionContext(Collections.singletonList(diagnostic));
 				final var params = new CodeActionParams();
 				params.setContext(context);
-				params.setTextDocument(new TextDocumentIdentifier(LSPEclipseUtils.toUri(res).toString()));
+				params.setTextDocument(LSPEclipseUtils.toTextDocumentIdentifier(res));
 				params.setRange(diagnostic.getRange());
 				CompletableFuture<List<Either<Command, CodeAction>>> codeAction = lsf
 						.thenComposeAsync(ls -> ls.getTextDocumentService().codeAction(params));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionQuickAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionQuickAssistProcessor.java
@@ -40,7 +40,6 @@ import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
@@ -223,7 +222,7 @@ public class LSPCodeActionQuickAssistProcessor implements IQuickAssistProcessor 
 	private static CodeActionParams prepareCodeActionParams(List<LSPDocumentInfo> infos, int offset, int length) {
 		final var context = new CodeActionContext(Collections.emptyList());
 		final var params = new CodeActionParams();
-		params.setTextDocument(new TextDocumentIdentifier(infos.get(0).getFileUri().toString()));
+		params.setTextDocument(LSPEclipseUtils.toTextDocumentIdentifier(infos.get(0).getFileUri()));
 		try {
 			params.setRange(new Range(LSPEclipseUtils.toPosition(offset, infos.get(0).getDocument()), LSPEclipseUtils
 					.toPosition(offset + (length > 0 ? length : 0), infos.get(0).getDocument())));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
@@ -39,7 +39,6 @@ import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -91,7 +90,7 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 		item.setText(Messages.computing);
 		final var context = new CodeActionContext(Collections.emptyList());
 		final var params = new CodeActionParams();
-		params.setTextDocument(new TextDocumentIdentifier(infos.get(0).getFileUri().toString()));
+		params.setTextDocument(LSPEclipseUtils.toTextDocumentIdentifier(infos.get(0).getFileUri()));
 		params.setRange(this.range);
 		params.setContext(context);
 		final var runningFutures = new HashSet<CompletableFuture<?>>();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/CodeLensProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/CodeLensProvider.java
@@ -27,7 +27,6 @@ import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CodeLensParams;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 public class CodeLensProvider extends AbstractCodeMiningProvider {
@@ -35,7 +34,7 @@ public class CodeLensProvider extends AbstractCodeMiningProvider {
 	private CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(@NonNull IDocument document) {
 		URI docURI = LSPEclipseUtils.toUri(document);
 		if (docURI != null) {
-			final var param = new CodeLensParams(new TextDocumentIdentifier(docURI.toString()));
+			final var param = new CodeLensParams(LSPEclipseUtils.toTextDocumentIdentifier(docURI));
 			final var codeLensResults = Collections.synchronizedList(new ArrayList<LSPCodeMining>());
 			return LanguageServiceAccessor
 					.getLanguageServers(document, capabilities -> capabilities.getCodeLensProvider() != null)

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/DocumentColorProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/DocumentColorProvider.java
@@ -32,7 +32,6 @@ import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4j.DocumentColorParams;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGBA;
 import org.eclipse.swt.widgets.Display;
@@ -54,7 +53,7 @@ public class DocumentColorProvider extends AbstractCodeMiningProvider {
 		URI docURI = LSPEclipseUtils.toUri(document);
 
 		if (docURI != null) {
-			final var textDocumentIdentifier = new TextDocumentIdentifier(docURI.toString());
+			final var textDocumentIdentifier = LSPEclipseUtils.toTextDocumentIdentifier(docURI);
 			final var param = new DocumentColorParams(textDocumentIdentifier);
 			final var colorResults = Collections.synchronizedList(new ArrayList<ColorInformationMining>());
 			return LanguageServiceAccessor.getLanguageServers(document, DocumentColorProvider::isColorProvider)

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -39,7 +39,6 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
@@ -55,7 +54,7 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 				return null;
 			}
 			params = new TextDocumentPositionParams(
-					new TextDocumentIdentifier(uri.toString()),
+					LSPEclipseUtils.toTextDocumentIdentifier(uri),
 					LSPEclipseUtils.toPosition(region.getOffset(), document));
 		} catch (BadLocationException e1) {
 			LanguageServerPlugin.logError(e1);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
@@ -33,7 +33,6 @@ import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.DocumentLink;
 import org.eclipse.lsp4j.DocumentLinkParams;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 
 public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 
@@ -79,7 +78,7 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 		if (uri == null) {
 			return null;
 		}
-		final var params = new DocumentLinkParams(new TextDocumentIdentifier(uri.toString()));
+		final var params = new DocumentLinkParams(LSPEclipseUtils.toTextDocumentIdentifier(uri));
 		try {
 			return LanguageServiceAccessor
 					.getLanguageServers(document,

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
@@ -28,7 +28,6 @@ import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4j.DocumentLink;
 import org.eclipse.lsp4j.DocumentLinkParams;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.widgets.Control;
 
@@ -72,7 +71,7 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 			return;
 		}
 		cancel();
-		final var params = new DocumentLinkParams(new TextDocumentIdentifier(uri.toString()));
+		final var params = new DocumentLinkParams(LSPEclipseUtils.toTextDocumentIdentifier(uri));
 		request = LanguageServiceAccessor
 				.getLanguageServers(document, capabilities -> capabilities.getDocumentLinkProvider() != null)
 				.thenAcceptAsync(languageServers -> CompletableFuture.allOf(languageServers.stream()

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -37,7 +37,6 @@ import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeRequestParams;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.swt.graphics.FontMetrics;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Rectangle;
@@ -121,7 +120,7 @@ public class LSPFoldingReconcilingStrategy
 		if (uri == null) {
 			return;
 		}
-		final var identifier = new TextDocumentIdentifier(uri.toString());
+		final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(uri);
 		final var params = new FoldingRangeRequestParams(identifier);
 		LanguageServiceAccessor.getLanguageServers(document, LSPFoldingReconcilingStrategy::canFold).thenAcceptAsync(servers -> {
 			if (servers.isEmpty()) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -34,7 +34,6 @@ import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ui.editors.text.EditorsUI;
 import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
@@ -86,7 +85,7 @@ public class LSPFormatter {
 
 	private CompletableFuture<List<? extends TextEdit>> requestFormatting(LSPDocumentInfo info,
 			ITextSelection textSelection) throws BadLocationException {
-		final var docId = new TextDocumentIdentifier(info.getFileUri().toString());
+		final var docId = LSPEclipseUtils.toTextDocumentIdentifier(info.getFileUri());
 		ServerCapabilities capabilities = info.getCapabilites();
 		IPreferenceStore store = EditorsUI.getPreferenceStore();
 		int tabWidth = store.getInt(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_TAB_WIDTH);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
@@ -51,7 +51,6 @@ import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.swt.custom.StyledText;
 
 /**
@@ -191,7 +190,7 @@ public class HighlightReconcilingStrategy
 		if(uri == null) {
 			return;
 		}
-		final var identifier = new TextDocumentIdentifier(uri.toString());
+		final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(uri);
 		final var params = new DocumentHighlightParams(identifier, position);
 		request = LanguageServiceAccessor.getLanguageServers(document,
 				capabilities -> LSPEclipseUtils.hasCapability(capabilities.getDocumentHighlightProvider()))

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/InlayHintProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/InlayHintProvider.java
@@ -29,7 +29,6 @@ import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 public class InlayHintProvider extends AbstractCodeMiningProvider {
@@ -46,7 +45,7 @@ public class InlayHintProvider extends AbstractCodeMiningProvider {
 				LanguageServerPlugin.logWarning("Unable to compute end of document", e); //$NON-NLS-1$
 			}
 			Range viewPortRange = new Range(new Position(0,0), end);
-			InlayHintParams param = new InlayHintParams(new TextDocumentIdentifier(docURI.toString()), viewPortRange);
+			InlayHintParams param = new InlayHintParams(LSPEclipseUtils.toTextDocumentIdentifier(docURI), viewPortRange);
 			List<LSPLineContentCodeMining> inlayHintResults = Collections.synchronizedList(new ArrayList<>());
 			return LanguageServiceAccessor
 					.getLanguageServers(document, capabilities -> capabilities.getInlayHintProvider() != null)

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingBase.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingBase.java
@@ -26,7 +26,6 @@ import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4j.LinkedEditingRanges;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 
 public class LSPLinkedEditingBase implements IPreferenceChangeListener {
@@ -64,7 +63,7 @@ public class LSPLinkedEditingBase implements IPreferenceChangeListener {
 		if(uri == null) {
 			return CompletableFuture.completedFuture(null);
 		}
-		final var identifier = new TextDocumentIdentifier(uri.toString());
+		final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(uri);
 		final var params = new TextDocumentPositionParams(identifier, position);
 
 		final var range = new AtomicReference<LinkedEditingRanges>();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchQuery.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchQuery.java
@@ -38,7 +38,6 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.ReferenceContext;
 import org.eclipse.lsp4j.ReferenceParams;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.search.internal.ui.text.FileMatch;
@@ -78,6 +77,7 @@ public class LSSearchQuery extends FileSearchQuery {
 		this.document = document;
 		this.languageServers = languageServers;
 		this.position = LSPEclipseUtils.toPosition(offset, document);
+		final var uri = LSPEclipseUtils.toUri(document);
 		this.filename = Path.fromPortableString(LSPEclipseUtils.toUri(document).getPath()).lastSegment();
 	}
 
@@ -91,7 +91,7 @@ public class LSSearchQuery extends FileSearchQuery {
 			// Execute LSP "references" service
 			final var params = new ReferenceParams();
 			params.setContext(new ReferenceContext(false));
-			params.setTextDocument(new TextDocumentIdentifier(LSPEclipseUtils.toUri(document).toString()));
+			params.setTextDocument(LSPEclipseUtils.toTextDocumentIdentifier(document));
 			params.setPosition(position);
 
 			for (final LanguageServer languageServer : languageServers) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
@@ -37,7 +37,6 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.RenameOptions;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -107,7 +106,7 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 			for (LanguageServer serverToTry : serverList.get(500, TimeUnit.MILLISECONDS)) {
 				// check if prepareRename is supported by the active LSP
 				if (languageServer.equals(serverToTry)) {
-					final var identifier = new TextDocumentIdentifier(LSPEclipseUtils.toUri(document).toString());
+					final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(document);
 					final var params = new PrepareRenameParams();
 					params.setTextDocument(identifier);
 					params.setPosition(LSPEclipseUtils.toPosition(offset, document));
@@ -163,7 +162,7 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 		try {
 			final var params = new RenameParams();
 			params.setPosition(LSPEclipseUtils.toPosition(offset, document));
-			final var identifier = new TextDocumentIdentifier();
+			final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(document);
 			identifier.setUri(LSPEclipseUtils.toUri(document).toString());
 			params.setTextDocument(identifier);
 			params.setNewName(newName);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -44,7 +44,6 @@ import org.eclipse.lsp4j.SemanticTokensLegend;
 import org.eclipse.lsp4j.SemanticTokensParams;
 import org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
@@ -168,7 +167,7 @@ public class SemanticHighlightReconcilerStrategy
 		URI uri = LSPEclipseUtils.toUri(document);
 		if (uri != null) {
 			final var semanticTokensParams = new SemanticTokensParams();
-			semanticTokensParams.setTextDocument(new TextDocumentIdentifier(uri.toString()));
+			semanticTokensParams.setTextDocument(LSPEclipseUtils.toTextDocumentIdentifier(uri));
 			return semanticTokensParams;
 		}
 		return null;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -51,7 +51,6 @@ import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.SymbolInformation;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.ui.IMemento;
@@ -303,7 +302,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			symbols.cancel(true);
 		}
 
-		final var params = new DocumentSymbolParams(new TextDocumentIdentifier(documentURI.toString()));
+		final var params = new DocumentSymbolParams(LSPEclipseUtils.toTextDocumentIdentifier(documentURI));
 		symbols = outlineViewerInput.languageServer.getTextDocumentService().documentSymbol(params);
 		symbols.thenAcceptAsync(response -> {
 			symbolsModel.update(response);


### PR DESCRIPTION
This PR replaces `URI#toString()` calls with `URI#toASCIIString()` calls, either directly or indirectly by using the new `LSPEClipseUtils#toTextDocumentIdentifier` methods to construct `TextDocumentIdentifier` instances.

This addresses https://github.com/eclipse/lsp4e/issues/358