### PR TITLE
Minor refactoring

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
-Bundle-Version: 0.15.0.qualifier
+Bundle-Version: 0.15.1.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/DSPImages.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/DSPImages.java
@@ -21,7 +21,7 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
 
-public class DSPImages {
+public final class DSPImages {
 	private DSPImages() {
 		// private constructor to avoid instances, requested by sonar
 	}

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/DSPImages.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/DSPImages.java
@@ -66,7 +66,7 @@ public final class DSPImages {
 	}
 
 	private static URL makeIconFileURL(String prefix, String name) {
-		StringBuilder buffer = new StringBuilder(prefix);
+		final var buffer = new StringBuilder(prefix);
 		buffer.append(name);
 		try {
 			return new URL(fgIconBaseURL, buffer.toString());

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/breakpoints/DSPBreakpointAdapter.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/breakpoints/DSPBreakpointAdapter.java
@@ -28,7 +28,7 @@ public class DSPBreakpointAdapter implements IToggleBreakpointsTarget {
 		if (textEditor != null) {
 			IResource resource = textEditor.getEditorInput().getAdapter(IResource.class);
 			if (resource != null) {
-				ITextSelection textSelection = (ITextSelection) selection;
+				final var textSelection = (ITextSelection) selection;
 				int lineNumber = textSelection.getStartLine();
 				IBreakpoint[] breakpoints = DebugPlugin.getDefault().getBreakpointManager()
 						.getBreakpoints(DSPPlugin.ID_DSP_DEBUG_MODEL);
@@ -43,7 +43,7 @@ public class DSPBreakpointAdapter implements IToggleBreakpointsTarget {
 					}
 				}
 				// create line breakpoint (doc line numbers start at 0)
-				DSPLineBreakpoint lineBreakpoint = new DSPLineBreakpoint(resource, lineNumber + 1);
+				final var lineBreakpoint = new DSPLineBreakpoint(resource, lineNumber + 1);
 				DebugPlugin.getDefault().getBreakpointManager().addBreakpoint(lineBreakpoint);
 			}
 		}

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/breakpoints/DocumentUtils.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/breakpoints/DocumentUtils.java
@@ -25,7 +25,8 @@ import org.eclipse.jface.text.IDocument;
 /*
  * All this is mostly copied from LSPEclipseUtils.
  */
-public class DocumentUtils {
+final class DocumentUtils {
+
 	private static ITextFileBuffer toBuffer(IDocument document) {
 		ITextFileBufferManager bufferManager = FileBuffers.getTextFileBufferManager();
 		if (bufferManager == null)
@@ -102,5 +103,8 @@ public class DocumentUtils {
 		} else {
 			return null;
 		}
+	}
+
+	private DocumentUtils() {
 	}
 }

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPStreamsProxy.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPStreamsProxy.java
@@ -51,7 +51,7 @@ public class DSPStreamsProxy implements IStreamsProxy2 {
 	public void write(String input) throws IOException {
 		String trimmed = input.trim();
 		if (!trimmed.isEmpty()) {
-			EvaluateArguments args = new EvaluateArguments();
+			final var args = new EvaluateArguments();
 			args.setContext(EvaluateArgumentsContext.REPL);
 			args.setExpression(trimmed);
 			IAdaptable adaptable = DebugUITools.getDebugContext();

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPBreakpointManager.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPBreakpointManager.java
@@ -170,7 +170,7 @@ public class DSPBreakpointManager implements IBreakpointManagerListener, IBreakp
 				lineNumber = -1;
 			}
 
-			Source source = new Source();
+			final var source = new Source();
 			source.setName(name);
 			source.setPath(path);
 
@@ -211,7 +211,7 @@ public class DSPBreakpointManager implements IBreakpointManagerListener, IBreakp
 	}
 
 	private CompletableFuture<Void> sendBreakpoints() {
-		List<CompletableFuture<Void>> all = new ArrayList<>();
+		final var all = new ArrayList<CompletableFuture<Void>>();
 		for (Iterator<Entry<Source, List<SourceBreakpoint>>> iterator = targetBreakpoints.entrySet()
 				.iterator(); iterator.hasNext();) {
 			Entry<Source, List<SourceBreakpoint>> entry = iterator.next();
@@ -221,7 +221,7 @@ public class DSPBreakpointManager implements IBreakpointManagerListener, IBreakp
 			int[] lines = bps.stream().mapToInt(SourceBreakpoint::getLine).toArray();
 			SourceBreakpoint[] sourceBps = bps.toArray(new SourceBreakpoint[bps.size()]);
 
-			SetBreakpointsArguments arguments = new SetBreakpointsArguments();
+			final var arguments = new SetBreakpointsArguments();
 			arguments.setSource(source);
 			arguments.setLines(lines);
 			arguments.setBreakpoints(sourceBps);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
@@ -217,7 +217,7 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 	}
 
 	private CompletableFuture<?> initialize(Map<String, Object> dspParameters, IProgressMonitor monitor) {
-		InitializeRequestArguments arguments = new InitializeRequestArguments();
+		final var arguments = new InitializeRequestArguments();
 		arguments.setClientID("lsp4e.debug");
 		String adapterId = "adapterId";
 		if (dspParameters.get("type") instanceof String type) {
@@ -404,7 +404,7 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 			fSentTerminateRequest = true;
 			getDebugProtocolServer().terminate(new TerminateArguments()).thenRunAsync(this::terminated);
 		} else {
-			DisconnectArguments arguments = new DisconnectArguments();
+			final var arguments = new DisconnectArguments();
 			arguments.setTerminateDebuggee(true);
 			getDebugProtocolServer().disconnect(arguments).thenRunAsync(this::terminated);
 		}
@@ -534,7 +534,7 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 			CompletableFuture<ThreadsResponse> threads2 = getDebugProtocolServer().threads();
 			CompletableFuture<DSPThread[]> future = threads2.thenApplyAsync(threadsResponse -> {
 				synchronized (threads) {
-					Map<Integer, DSPThread> lastThreads = new TreeMap<>(threads);
+					final var lastThreads = new TreeMap<Integer, DSPThread>(threads);
 					threads.clear();
 					Thread[] body = threadsResponse.getThreads();
 					for (Thread thread : body) {
@@ -667,7 +667,7 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 		if (cmd.length() > 0) {
 			cmd.setLength(cmd.length() - 1);
 		}
-		ProcessBuilder processBuilder = new ProcessBuilder(args.getArgs());
+		final var processBuilder = new ProcessBuilder(args.getArgs());
 		// processBuilder.inheritIO();
 		if (args.getCwd() != null) {
 			processBuilder.directory(new File(args.getCwd()));
@@ -698,7 +698,7 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 			} catch (InterruptedException e) {
 				java.lang.Thread.currentThread().interrupt();
 			}
-			RunInTerminalResponse response = new RunInTerminalResponse();
+			final var response = new RunInTerminalResponse();
 			// TODO, no standard way of getting ID. Can via reflection and/or custom
 			// launcher like CDT does.
 			response.setProcessId(null); // Explicitly indicate we don't know the process id

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPStackFrame.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPStackFrame.java
@@ -10,7 +10,6 @@ package org.eclipse.lsp4e.debug.debugmodel;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
@@ -135,10 +134,10 @@ public class DSPStackFrame extends DSPDebugElement implements IStackFrame {
 	@Override
 	public IVariable[] getVariables() throws DebugException {
 		if (cachedVariables == null) {
-			ScopesArguments arguments = new ScopesArguments();
+			final var arguments = new ScopesArguments();
 			arguments.setFrameId(stackFrame.getId());
 			Scope[] scopes = complete(getDebugTarget().getDebugProtocolServer().scopes(arguments)).getScopes();
-			List<DSPVariable> vars = new ArrayList<>();
+			final var vars = new ArrayList<DSPVariable>();
 			for (Scope scope : scopes) {
 				DSPVariable variable = new DSPVariable(getDebugTarget(), -1, scope.getName(), "",
 						scope.getVariablesReference());
@@ -228,7 +227,7 @@ public class DSPStackFrame extends DSPDebugElement implements IStackFrame {
 	 * @return future with an IVariable that has the result
 	 */
 	public CompletableFuture<IVariable> evaluate(String expression) {
-		EvaluateArguments args = new EvaluateArguments();
+		final var args = new EvaluateArguments();
 		args.setContext(EvaluateArgumentsContext.HOVER);
 		args.setFrameId(getFrameId());
 		args.setExpression(expression);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPThread.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPThread.java
@@ -109,7 +109,7 @@ public class DSPThread extends DSPDebugElement implements IThread {
 		continued();
 		stepping = true;
 		fireResumeEvent(DebugEvent.STEP_OVER);
-		StepOutArguments arguments = new StepOutArguments();
+		final var arguments = new StepOutArguments();
 		arguments.setThreadId(id);
 		getDebugProtocolServer().stepOut(arguments).exceptionally(this::handleExceptionalResume);
 	}
@@ -119,7 +119,7 @@ public class DSPThread extends DSPDebugElement implements IThread {
 		continued();
 		stepping = true;
 		fireResumeEvent(DebugEvent.STEP_OVER);
-		NextArguments arguments = new NextArguments();
+		final var arguments = new NextArguments();
 		arguments.setThreadId(id);
 		getDebugProtocolServer().next(arguments).exceptionally(this::handleExceptionalResume);
 	}
@@ -129,7 +129,7 @@ public class DSPThread extends DSPDebugElement implements IThread {
 		continued();
 		stepping = true;
 		fireResumeEvent(DebugEvent.STEP_INTO);
-		StepInArguments arguments = new StepInArguments();
+		final var arguments = new StepInArguments();
 		arguments.setThreadId(id);
 		getDebugProtocolServer().stepIn(arguments).exceptionally(this::handleExceptionalResume);
 	}
@@ -139,7 +139,7 @@ public class DSPThread extends DSPDebugElement implements IThread {
 		continued();
 		stepping = true;
 		fireResumeEvent(DebugEvent.RESUME);
-		ContinueArguments arguments = new ContinueArguments();
+		final var arguments = new ContinueArguments();
 		arguments.setThreadId(id);
 		getDebugProtocolServer().continue_(arguments).thenAccept(response -> {
 			if (response == null || response.getAllThreadsContinued() == null || response.getAllThreadsContinued()) {
@@ -181,7 +181,7 @@ public class DSPThread extends DSPDebugElement implements IThread {
 
 	@Override
 	public void suspend() throws DebugException {
-		PauseArguments arguments = new PauseArguments();
+		final var arguments = new PauseArguments();
 		arguments.setThreadId(id);
 		getDebugProtocolServer().pause(arguments).exceptionally(t -> {
 			DSPPlugin.logError("Failed to suspend debug adapter", t);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPValue.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPValue.java
@@ -9,7 +9,6 @@
 package org.eclipse.lsp4e.debug.debugmodel;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IValue;
@@ -44,12 +43,12 @@ public final class DSPValue extends DSPDebugElement implements IValue {
 			return new IVariable[0];
 		}
 		if (cachedVariables == null) {
-			VariablesArguments arguments = new VariablesArguments();
+			final var arguments = new VariablesArguments();
 			arguments.setVariablesReference(variablesReference);
 			Variable[] targetVariables = complete(getDebugTarget().getDebugProtocolServer().variables(arguments))
 					.getVariables();
 
-			List<DSPVariable> variables = new ArrayList<>();
+			final var variables = new ArrayList<DSPVariable>();
 			for (Variable variable : targetVariables) {
 				variables.add(new DSPVariable(getDebugTarget(), variablesReference, variable.getName(),
 						variable.getValue(), variable.getVariablesReference()));

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPVariable.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPVariable.java
@@ -35,7 +35,7 @@ public class DSPVariable extends DSPDebugElement implements IVariable {
 
 	@Override
 	public void setValue(String expression) throws DebugException {
-		SetVariableArguments setVariableArgs = new SetVariableArguments();
+		final var setVariableArgs = new SetVariableArguments();
 		setVariableArgs.setVariablesReference(parentVariablesReference);
 		setVariableArgs.setValue(expression);
 		setVariableArgs.setName(getName());

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
@@ -11,7 +11,6 @@ package org.eclipse.lsp4e.debug.launcher;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Type;
 import java.net.Socket;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -196,8 +195,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 	@Override
 	public void launch(ILaunchConfiguration configuration, String mode, ILaunch launch, IProgressMonitor monitor)
 			throws CoreException {
-		DSPLaunchDelegateLaunchBuilder builder = new DSPLaunchDelegateLaunchBuilder(configuration, mode, launch,
-				monitor);
+		final var builder = new DSPLaunchDelegateLaunchBuilder(configuration, mode, launch, monitor);
 		builder.launchNotConnect = DSPPlugin.DSP_MODE_LAUNCH
 				.equals(configuration.getAttribute(DSPPlugin.ATTR_DSP_MODE, DSPPlugin.DSP_MODE_LAUNCH));
 		builder.debugCmd = configuration.getAttribute(DSPPlugin.ATTR_DSP_CMD, (String) null);
@@ -214,8 +212,8 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 	}
 
 	private Map<String, Object> jsonToMap(String dspParametersJson) {
-		Gson gson = new Gson();
-		Type type = new TypeToken<Map<String, Object>>() {
+		final var gson = new Gson();
+		final var type = new TypeToken<Map<String, Object>>() {
 		}.getType();
 		Map<String, Object> dspParameters = gson.fromJson(dspParametersJson, type);
 		if (dspParameters == null) {
@@ -227,7 +225,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 	public void launch(DSPLaunchDelegateLaunchBuilder builder) throws CoreException {
 		// Make a copy so we can modify locally as needed.
 		builder = new DSPLaunchDelegateLaunchBuilder(builder);
-		SubMonitor subMonitor = SubMonitor.convert(builder.monitor, 100);
+		final var subMonitor = SubMonitor.convert(builder.monitor, 100);
 		builder.dspParameters = new HashMap<>(builder.dspParameters);
 
 		boolean customDebugAdapter = builder.configuration.getAttribute(DSPPlugin.ATTR_CUSTOM_DEBUG_ADAPTER, false);
@@ -268,7 +266,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 		try {
 
 			if (builder.launchNotConnect) {
-				List<String> command = new ArrayList<>();
+				final var command = new ArrayList<String>();
 
 				if (builder.debugCmd == null) {
 					abort("Debug command unspecified.", null); //$NON-NLS-1$
@@ -291,7 +289,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 							"Debug Adapter");
 					builder.launch.setAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, initialCaptureOutput);
 
-					List<Byte> bytes = Collections.synchronizedList(new LinkedList<>());
+					final var bytes = Collections.synchronizedList(new LinkedList<Byte>());
 					inputStream = new InputStream() {
 						@Override
 						public int read() throws IOException {
@@ -385,7 +383,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 	 */
 	protected IDebugTarget createDebugTarget(SubMonitor subMonitor, Runnable cleanup, InputStream inputStream,
 			OutputStream outputStream, ILaunch launch, Map<String, Object> dspParameters) throws CoreException {
-		DSPDebugTarget target = new DSPDebugTarget(launch, cleanup, inputStream, outputStream, dspParameters);
+		final var target = new DSPDebugTarget(launch, cleanup, inputStream, outputStream, dspParameters);
 		target.initialize(subMonitor.split(80));
 		return target;
 	}

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPMainTab.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPMainTab.java
@@ -65,7 +65,7 @@ public class DSPMainTab extends AbstractLaunchConfigurationTab {
 
 	@Override
 	public void createControl(Composite parent) {
-		Composite comp = new Composite(parent, SWT.NONE);
+		final var comp = new Composite(parent, SWT.NONE);
 		setControl(comp);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), getHelpContextId());
 		comp.setLayout(new GridLayout(1, true));
@@ -91,7 +91,7 @@ public class DSPMainTab extends AbstractLaunchConfigurationTab {
 		debugAdapterSettingsGroup.setLayout(new GridLayout(2, false));
 		debugAdapterSettingsGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
-		Label debugText = new Label(debugAdapterSettingsGroup, SWT.NONE);
+		final var debugText = new Label(debugAdapterSettingsGroup, SWT.NONE);
 		debugText.setText("Launch specific debug adapters using these settings.");
 		debugText.setLayoutData(GridDataFactory.fillDefaults().span(2, 1).create());
 
@@ -101,13 +101,13 @@ public class DSPMainTab extends AbstractLaunchConfigurationTab {
 		launchDebugServer.setLayoutData(GridDataFactory.fillDefaults().span(2, 1).create());
 		launchDebugServer.setSelection(true);
 
-		Label programLabel = new Label(debugAdapterSettingsGroup, SWT.NONE);
+		final var programLabel = new Label(debugAdapterSettingsGroup, SWT.NONE);
 		programLabel.setText("&Command:");
 		programLabel.setLayoutData(new GridData(GridData.BEGINNING));
 		debugCommandText = new Text(debugAdapterSettingsGroup, SWT.SINGLE | SWT.BORDER);
 		debugCommandText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		debugCommandText.addModifyListener(e -> updateLaunchConfigurationDialog());
-		Label argsLabel = new Label(debugAdapterSettingsGroup, SWT.NONE);
+		final var argsLabel = new Label(debugAdapterSettingsGroup, SWT.NONE);
 		argsLabel.setText("&Arguments:");
 		argsLabel.setLayoutData(new GridData(GridData.BEGINNING));
 
@@ -115,7 +115,7 @@ public class DSPMainTab extends AbstractLaunchConfigurationTab {
 		debugArgsText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		debugArgsText.addModifyListener(e -> updateLaunchConfigurationDialog());
 
-		Composite filler = new Composite(debugAdapterSettingsGroup, SWT.NONE);
+		final var filler = new Composite(debugAdapterSettingsGroup, SWT.NONE);
 		filler.setLayoutData(new GridData(0, 0));
 		monitorAdapterLauncherProcessCheckbox = new Button(debugAdapterSettingsGroup, SWT.CHECK);
 		GridData layoutData = new GridData(SWT.LEFT, SWT.DEFAULT, true, false);
@@ -129,14 +129,14 @@ public class DSPMainTab extends AbstractLaunchConfigurationTab {
 		connectDebugServer.addSelectionListener(widgetSelectedAdapter(e -> updateLaunchConfigurationDialog()));
 		connectDebugServer.setLayoutData(GridDataFactory.fillDefaults().span(2, 1).create());
 
-		Label serverHostLabel = new Label(debugAdapterSettingsGroup, SWT.NONE);
+		final var serverHostLabel = new Label(debugAdapterSettingsGroup, SWT.NONE);
 		serverHostLabel.setText("Server &Host:");
 		serverHostLabel.setLayoutData(new GridData(GridData.BEGINNING));
 		serverHost = new Text(debugAdapterSettingsGroup, SWT.SINGLE | SWT.BORDER);
 		serverHost.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 		serverHost.addModifyListener(e -> updateLaunchConfigurationDialog());
 
-		Label serverPortLabel = new Label(debugAdapterSettingsGroup, SWT.NONE);
+		final var serverPortLabel = new Label(debugAdapterSettingsGroup, SWT.NONE);
 		serverPortLabel.setText("Server &Port:");
 		serverPortLabel.setLayoutData(new GridData(GridData.BEGINNING));
 		serverPort = new Text(debugAdapterSettingsGroup, SWT.SINGLE | SWT.BORDER);
@@ -158,7 +158,7 @@ public class DSPMainTab extends AbstractLaunchConfigurationTab {
 		launchParametersGroup.setLayout(new GridLayout());
 		launchParametersGroup.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-		Label jsonLabel = new Label(launchParametersGroup, SWT.NONE);
+		final var jsonLabel = new Label(launchParametersGroup, SWT.NONE);
 		jsonLabel.setText("Launch &Parameters (Json):");
 		jsonLabel.setLayoutData(new GridData(GridData.BEGINNING));
 

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/presentation/DAPWatchExpression.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/presentation/DAPWatchExpression.java
@@ -26,7 +26,7 @@ public class DAPWatchExpression implements IWatchExpressionDelegate {
 	@Override
 	public void evaluateExpression(String expression, IDebugElement context, IWatchExpressionListener listener) {
 		if (context.getDebugTarget() instanceof DSPDebugTarget dapDebugger) {
-			EvaluateArguments args = new EvaluateArguments();
+			final var args = new EvaluateArguments();
 			args.setExpression(expression);
 			DSPStackFrame frame = Adapters.adapt(context, DSPStackFrame.class);
 			args.setFrameId(frame.getFrameId());

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
@@ -13,8 +13,7 @@
 package org.eclipse.lsp4e.test.diagnostics;
 
 import static org.eclipse.lsp4e.test.TestUtils.waitForAndAssertCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -216,7 +215,7 @@ public class DiagnosticsTest {
 		}
 	}
 
-	private class MarkerRedrawCountListener implements IResourceChangeListener, IntSupplier {
+	private static final class MarkerRedrawCountListener implements IResourceChangeListener, IntSupplier {
 		private int resourceChanges = 0;
 
 		@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -65,7 +65,7 @@ public class ConnectDocumentToLanguageServerSetupParticipant implements IDocumen
 		if (document == null) {
 			return;
 		}
-		Job job = new Job("Initialize Language Servers for " + location.toFile().getName()) { //$NON-NLS-1$
+		final var job = new Job("Initialize Language Servers for " + location.toFile().getName()) { //$NON-NLS-1$
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				ITextFileBuffer buffer = ITextFileBufferManager.DEFAULT.getTextFileBuffer(document);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -92,7 +92,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		this.store = LanguageServerPlugin.getDefault().getPreferenceStore();
 
 		// add a document buffer
-		TextDocumentItem textDocument = new TextDocumentItem();
+		final var textDocument = new TextDocumentItem();
 		textDocument.setUri(fileUri.toString());
 		textDocument.setText(document.get());
 
@@ -169,7 +169,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			int length = event.getLength();
 			try {
 				// try to convert the Eclipse start/end offset to LS range.
-				Range range = new Range(LSPEclipseUtils.toPosition(offset, document),
+				final var range = new Range(LSPEclipseUtils.toPosition(offset, document),
 						LSPEclipseUtils.toPosition(offset + length, document));
 				changeEvent.setRange(range);
 				changeEvent.setText(newText);
@@ -227,9 +227,9 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			return;
 		}
 
-		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
+		final var identifier = new TextDocumentIdentifier(uri);
 		// Use @link{TextDocumentSaveReason.Manual} as the platform does not give enough information to be accurate
-		WillSaveTextDocumentParams params = new WillSaveTextDocumentParams(identifier, TextDocumentSaveReason.Manual);
+		final var params = new WillSaveTextDocumentParams(identifier, TextDocumentSaveReason.Manual);
 
 
 		try {
@@ -269,8 +269,8 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 				return;
 			}
 		}
-		TextDocumentIdentifier identifier = new TextDocumentIdentifier(fileUri.toString());
-		DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(identifier, document.get());
+		final var identifier = new TextDocumentIdentifier(fileUri.toString());
+		final var params = new DidSaveTextDocumentParams(identifier, document.get());
 //		lastChangeFuture.updateAndGet(f -> f.thenApplyAsync(ls -> {
 //  			ls.getTextDocumentService().didSave(params);
 //  			return ls;
@@ -285,8 +285,8 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		// When LS is shut down all documents are being disconnected. No need to send
 		// "didClose" message to the LS that is being shut down or not yet started
 		if (languageServerWrapper.isActive()) {
-			TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri);
-			DidCloseTextDocumentParams params = new DidCloseTextDocumentParams(identifier);
+			final var identifier = new TextDocumentIdentifier(uri);
+			final var params = new DidCloseTextDocumentParams(identifier);
 			languageServerWrapper.notifyOnLatestVersion(ls -> ls.getTextDocumentService().didClose(params));
 		}
 		return CompletableFuture.completedFuture(null);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -142,7 +142,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
 /**
  * Some utility methods to convert between Eclipse and LS-API types
  */
-public class LSPEclipseUtils {
+public final class LSPEclipseUtils {
 
 	private static final String DEFAULT_LABEL = "LSP Workspace Edit"; //$NON-NLS-1$
 	public static final String HTTP = "http"; //$NON-NLS-1$

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -614,8 +614,8 @@ public final class LSPEclipseUtils {
 			int endChar = matcher.group(5) != null ? Integer.parseInt(matcher.group(5)) : startChar;
 
 			// Positions are zero-based
-			Position start = new Position(startLine - 1, startChar - 1);
-			Position end = new Position(endLine - 1, endChar - 1);
+			final var start = new Position(startLine - 1, startChar - 1);
+			final var end = new Position(endLine - 1, endChar - 1);
 			return new Range(start, end);
 		} catch (IllegalArgumentException e) {
 			// not a valid URI, no range
@@ -757,7 +757,7 @@ public final class LSPEclipseUtils {
 			try {
 				Method getSourceViewerMethod= AbstractTextEditor.class.getDeclaredMethod("getSourceViewer"); //$NON-NLS-1$
 				getSourceViewerMethod.setAccessible(true);
-				ITextViewer viewer = (ITextViewer) getSourceViewerMethod.invoke(editor);
+				final var viewer = (ITextViewer) getSourceViewerMethod.invoke(editor);
 				return (viewer == null) ? null : viewer.getDocument();
 			} catch (Exception ex) {
 				LanguageServerPlugin.logError(ex);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -112,7 +112,7 @@ public class LanguageClientImpl implements LanguageClient {
 	@Override
 	public final CompletableFuture<ApplyWorkspaceEditResponse> applyEdit(ApplyWorkspaceEditParams params) {
 		return CompletableFuture.supplyAsync(() -> {
-			Job job = new Job(Messages.serverEdit) {
+			final var job = new Job(Messages.serverEdit) {
 				@Override
 				public IStatus run(IProgressMonitor monitor) {
 					LSPEclipseUtils.applyWorkspaceEdit(params.getEdit(), params.getLabel());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -1022,7 +1022,7 @@ public class LanguageServerWrapper {
 	 * Resource listener that translates Eclipse resource events into LSP workspace folder events
 	 * and dispatches them if the language server is still active
 	 */
-	private class WorkspaceFolderListener implements IResourceChangeListener {
+	private final class WorkspaceFolderListener implements IResourceChangeListener {
 		@Override
 		public void resourceChanged(IResourceChangeEvent event) {
 			WorkspaceFoldersChangeEvent workspaceFolderEvent = toWorkspaceFolderEvent(event);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -258,7 +258,7 @@ public class LanguageServerWrapper {
 	 * @throws IOException
 	 */
 	public synchronized void start() throws IOException {
-		final Map<URI, IDocument> filesToReconnect = new HashMap<>();
+		final var filesToReconnect = new HashMap<URI, IDocument>();
 		if (this.languageServer != null) {
 			if (isActive()) {
 				return;
@@ -323,7 +323,7 @@ public class LanguageServerWrapper {
 				if (Platform.getProduct() != null) {
 					name = Platform.getProduct().getName();
 				}
-				WorkspaceClientCapabilities workspaceClientCapabilities = new WorkspaceClientCapabilities();
+				final var workspaceClientCapabilities = new WorkspaceClientCapabilities();
 				workspaceClientCapabilities.setApplyEdit(Boolean.TRUE);
 				workspaceClientCapabilities.setConfiguration(Boolean.TRUE);
 				workspaceClientCapabilities.setExecuteCommand(new ExecuteCommandCapabilities(Boolean.TRUE));
@@ -335,8 +335,8 @@ public class LanguageServerWrapper {
 						ResourceOperationKind.Delete, ResourceOperationKind.Rename));
 				editCapabilities.setFailureHandling(FailureHandlingKind.Undo);
 				workspaceClientCapabilities.setWorkspaceEdit(editCapabilities);
-				TextDocumentClientCapabilities textDocumentClientCapabilities = new TextDocumentClientCapabilities();
-				CodeActionCapabilities codeAction = new CodeActionCapabilities(new CodeActionLiteralSupportCapabilities(
+				final var textDocumentClientCapabilities = new TextDocumentClientCapabilities();
+				final var codeAction = new CodeActionCapabilities(new CodeActionLiteralSupportCapabilities(
 						new CodeActionKindCapabilities(Arrays.asList(CodeActionKind.QuickFix, CodeActionKind.Refactor,
 								CodeActionKind.RefactorExtract, CodeActionKind.RefactorInline,
 								CodeActionKind.RefactorRewrite, CodeActionKind.Source,
@@ -348,21 +348,21 @@ public class LanguageServerWrapper {
 				textDocumentClientCapabilities.setCodeLens(new CodeLensCapabilities());
 				textDocumentClientCapabilities.setInlayHint(new InlayHintCapabilities());
 				textDocumentClientCapabilities.setColorProvider(new ColorProviderCapabilities());
-				CompletionItemCapabilities completionItemCapabilities = new CompletionItemCapabilities(Boolean.TRUE);
+				final var completionItemCapabilities = new CompletionItemCapabilities(Boolean.TRUE);
 				completionItemCapabilities
 						.setDocumentationFormat(Arrays.asList(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
 				completionItemCapabilities.setInsertTextModeSupport(new CompletionItemInsertTextModeSupportCapabilities(List.of(InsertTextMode.AsIs, InsertTextMode.AdjustIndentation)));
 				completionItemCapabilities.setResolveSupport(new CompletionItemResolveSupportCapabilities(List.of("documentation", "detail", "additionalTextEdits"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				textDocumentClientCapabilities.setCompletion(new CompletionCapabilities(completionItemCapabilities));
-				DefinitionCapabilities definitionCapabilities = new DefinitionCapabilities();
+				final var definitionCapabilities = new DefinitionCapabilities();
 				definitionCapabilities.setLinkSupport(Boolean.TRUE);
 				textDocumentClientCapabilities.setDefinition(definitionCapabilities);
-				TypeDefinitionCapabilities typeDefinitionCapabilities = new TypeDefinitionCapabilities();
+				final var typeDefinitionCapabilities = new TypeDefinitionCapabilities();
 				typeDefinitionCapabilities.setLinkSupport(Boolean.TRUE);
 				textDocumentClientCapabilities.setTypeDefinition(typeDefinitionCapabilities);
 				textDocumentClientCapabilities.setDocumentHighlight(new DocumentHighlightCapabilities());
 				textDocumentClientCapabilities.setDocumentLink(new DocumentLinkCapabilities());
-				DocumentSymbolCapabilities documentSymbol = new DocumentSymbolCapabilities();
+				final var documentSymbol = new DocumentSymbolCapabilities();
 				documentSymbol.setHierarchicalDocumentSymbolSupport(true);
 				documentSymbol.setSymbolKind(new SymbolKindCapabilities(Arrays.asList(SymbolKind.Array,
 						SymbolKind.Boolean, SymbolKind.Class, SymbolKind.Constant, SymbolKind.Constructor,
@@ -374,7 +374,7 @@ public class LanguageServerWrapper {
 				textDocumentClientCapabilities.setDocumentSymbol(documentSymbol);
 				textDocumentClientCapabilities.setFoldingRange(new FoldingRangeCapabilities());
 				textDocumentClientCapabilities.setFormatting(new FormattingCapabilities(Boolean.TRUE));
-				HoverCapabilities hoverCapabilities = new HoverCapabilities();
+				final var hoverCapabilities = new HoverCapabilities();
 				hoverCapabilities.setContentFormat(Arrays.asList(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
 				textDocumentClientCapabilities.setHover(hoverCapabilities);
 				textDocumentClientCapabilities.setOnTypeFormatting(null); // TODO
@@ -427,12 +427,12 @@ public class LanguageServerWrapper {
 
 	private ClientInfo getClientInfo(String name) {
 		String pluginVersion = Platform.getBundle(LanguageServerPlugin.PLUGIN_ID).getVersion().toString();
-		ClientInfo clientInfo = new ClientInfo(name, pluginVersion);
+		final var clientInfo = new ClientInfo(name, pluginVersion);
 		return clientInfo;
 	}
 
 	private WindowClientCapabilities getWindowClientCapabilities() {
-		WindowClientCapabilities windowClientCapabilities = new WindowClientCapabilities();
+		final var windowClientCapabilities = new WindowClientCapabilities();
 		windowClientCapabilities.setShowDocument(new ShowDocumentCapabilities(true));
 		windowClientCapabilities.setWorkDoneProgress(true);
 		windowClientCapabilities.setShowMessage(new WindowShowMessageRequestCapabilities());
@@ -663,7 +663,7 @@ public class LanguageServerWrapper {
 			return null;
 		}
 		if (document == null) {
-			IFile docFile = (IFile) LSPEclipseUtils.findResourceFor(uri);
+			final var docFile = (IFile) LSPEclipseUtils.findResourceFor(uri);
 			document = LSPEclipseUtils.getDocument(docFile);
 		}
 		if (document == null) {
@@ -677,7 +677,7 @@ public class LanguageServerWrapper {
 				}
 				TextDocumentSyncKind syncKind = initializeFuture == null ? null
 						: serverCapabilities.getTextDocumentSync().map(Functions.identity(), TextDocumentSyncOptions::getChange);
-				DocumentContentSynchronizer listener = new DocumentContentSynchronizer(this, theDocument, syncKind);
+				final var listener = new DocumentContentSynchronizer(this, theDocument, syncKind);
 				theDocument.addDocumentListener(listener);
 				LanguageServerWrapper.this.connectedDocuments.put(uri, listener);
 			}
@@ -707,7 +707,7 @@ public class LanguageServerWrapper {
 	}
 
 	public void disconnectContentType(@NonNull IContentType contentType) {
-		List<URI> urisToDisconnect = new ArrayList<>();
+		final var urisToDisconnect = new ArrayList<URI>();
 		for (URI uri : connectedDocuments.keySet()) {
 			IFile[] foundFiles = ResourcesPlugin.getWorkspace().getRoot()
 					.findFilesForLocationURI(uri);
@@ -764,7 +764,7 @@ public class LanguageServerWrapper {
 
 		if (initializeFuture != null && !this.initializeFuture.isDone()) {
 			if (Display.getCurrent() != null) { // UI Thread
-				Job waitForInitialization = new Job(Messages.initializeLanguageServer_job) {
+				final var waitForInitialization = new Job(Messages.initializeLanguageServer_job) {
 					@Override
 					protected IStatus run(IProgressMonitor monitor) {
 						initializeFuture.join();
@@ -880,7 +880,7 @@ public class LanguageServerWrapper {
 					setWorkspaceFoldersEnablement(true);
 				}
 			} else if ("workspace/executeCommand".equals(reg.getMethod())) { //$NON-NLS-1$
-				Gson gson = new Gson(); // TODO? retrieve the GSon used by LS
+				final var gson = new Gson(); // TODO? retrieve the GSon used by LS
 				ExecuteCommandOptions executeCommandOptions = gson.fromJson((JsonObject) reg.getRegisterOptions(),
 						ExecuteCommandOptions.class);
 				List<String> newCommands = executeCommandOptions.getCommands();
@@ -1044,7 +1044,7 @@ public class LanguageServerWrapper {
 			}
 
 			// If a project delete then the delta is null, but we get the project in the top-level resource
-			WorkspaceFoldersChangeEvent wsFolderEvent = new WorkspaceFoldersChangeEvent();
+			final var wsFolderEvent = new WorkspaceFoldersChangeEvent();
 			if (isPreDeletEvent(e)) {
 				final IResource resource = e.getResource();
 				if (resource instanceof IProject project) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
@@ -404,7 +404,7 @@ public class LanguageServersRegistry {
 	/**
 	 * internal class to capture content-type mappings for language servers
 	 */
-	private static class ContentTypeMapping {
+	private static final class ContentTypeMapping {
 
 		@NonNull public final String id;
 		@NonNull public final IContentType contentType;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
@@ -269,8 +269,8 @@ public class LanguageServersRegistry {
 			}
 		}
 
-		Map<String, LanguageServerDefinition> servers = new HashMap<>();
-		List<ContentTypeMapping> contentTypes = new ArrayList<>();
+		final var servers = new HashMap<String, LanguageServerDefinition>();
+		final var contentTypes = new ArrayList<ContentTypeMapping>();
 		for (IConfigurationElement extension : Platform.getExtensionRegistry().getConfigurationElementsFor(EXTENSION_POINT_ID)) {
 			String id = extension.getAttribute(ID_ATTRIBUTE);
 			if (id != null && !id.isEmpty()) {
@@ -362,7 +362,7 @@ public class LanguageServersRegistry {
 	}
 
 	public void registerAssociation(@NonNull IContentType contentType, @NonNull ILaunchConfiguration launchConfig, @NonNull Set<String> launchMode) {
-		ContentTypeToLSPLaunchConfigEntry mapping = new ContentTypeToLSPLaunchConfigEntry(contentType, launchConfig,
+		final var mapping = new ContentTypeToLSPLaunchConfigEntry(contentType, launchConfig,
 				launchMode);
 		connections.add(mapping);
 		persistContentTypeToLaunchConfigurationMapping();
@@ -465,7 +465,7 @@ public class LanguageServersRegistry {
 	 * @return definitions that can support the following content-types
 	 */
 	private Set<LanguageServerDefinition> getAvailableLSFor(Collection<IContentType> contentTypes) {
-		Set<LanguageServerDefinition> res = new HashSet<>();
+		final var res = new HashSet<LanguageServerDefinition>();
 		contentTypes = expandToSuperTypes(contentTypes);
 		for (ContentTypeToLanguageServerDefinition mapping : this.connections) {
 			if (mapping.isEnabled() && contentTypes.contains(mapping.getKey())) {
@@ -476,7 +476,7 @@ public class LanguageServersRegistry {
 	}
 
 	private Collection<IContentType> expandToSuperTypes(Collection<IContentType> contentTypes) {
-		ArrayList<IContentType> res = new ArrayList<>(contentTypes);
+		final var res = new ArrayList<IContentType>(contentTypes);
 		for (int i = 0; i < res.size(); i++) {
 			IContentType current = res.get(i);
 			IContentType base = current.getBaseType();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -568,7 +568,7 @@ public class LanguageServiceAccessor {
 	@NonNull
 	public static List<@NonNull LanguageServer> getLanguageServers(@Nullable IProject project,
 			Predicate<ServerCapabilities> request, boolean onlyActiveLS) {
-		List<@NonNull LanguageServer> serverInfos = new ArrayList<>();
+		final var serverInfos = new ArrayList<@NonNull LanguageServer>();
 		for (LanguageServerWrapper wrapper : startedServers) {
 			if ((!onlyActiveLS || wrapper.isActive()) && (project == null || wrapper.canOperate(project))) {
 				@Nullable
@@ -590,7 +590,7 @@ public class LanguageServiceAccessor {
 
 	@NonNull public static List<@NonNull LSPDocumentInfo> getLSPDocumentInfosFor(@NonNull IDocument document, @NonNull Predicate<ServerCapabilities> capabilityRequest) {
 		URI fileUri = LSPEclipseUtils.toUri(document);
-		List<LSPDocumentInfo> res = new ArrayList<>();
+		final var res = new ArrayList<LSPDocumentInfo>();
 		try {
 			getLSWrappers(document).stream().filter(wrapper -> wrapper.getServerCapabilities() == null
 					|| capabilityRequest.test(wrapper.getServerCapabilities())).forEach(wrapper -> {
@@ -621,7 +621,7 @@ public class LanguageServiceAccessor {
 		if (uri == null) {
 			return CompletableFuture.completedFuture(Collections.emptyList());
 		}
-		final List<@NonNull LanguageServer> res = Collections.synchronizedList(new ArrayList<>());
+		final var res = Collections.synchronizedList(new ArrayList<@NonNull LanguageServer>());
 		try {
 			return CompletableFuture.allOf(getLSWrappers(document).stream()
 					.map(wrapper -> wrapper.getInitializedServer().thenComposeAsync(server -> {
@@ -669,7 +669,7 @@ public class LanguageServiceAccessor {
 			Function<LanguageServer, ? extends CompletionStage<T>> fn) {
 
 		// Out-of-line so we can declare it as List rather than ArrayList to avoid type errors below
-		CompletableFuture<List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
+		final CompletableFuture<List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
 
 		return getLSWrappers(document).stream()
 			// Ensure wrappers are started, connected to the document, and filter for capabilities

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LaunchConfigurationStreamProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LaunchConfigurationStreamProvider.java
@@ -163,7 +163,7 @@ public class LaunchConfigurationStreamProvider implements StreamConnectionProvid
 				try {
 					Method systemProcessGetter = RuntimeProcess.class.getDeclaredMethod("getSystemProcess"); //$NON-NLS-1$
 					systemProcessGetter.setAccessible(true);
-					Process systemProcess = (Process) systemProcessGetter.invoke(process);
+					final var systemProcess = (Process) systemProcessGetter.invoke(process);
 					this.outputStream = systemProcess.getOutputStream();
 				} catch (ReflectiveOperationException ex) {
 					LanguageServerPlugin.logError(ex);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LoggingStreamConnectionProviderProxy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LoggingStreamConnectionProviderProxy.java
@@ -43,7 +43,7 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 		if (root == null) {
 			return null;
 		}
-		File logFolder = new File(root.addTrailingSeparator().toPortableString(), "languageServers-log"); //$NON-NLS-1$
+		final var logFolder = new File(root.addTrailingSeparator().toPortableString(), "languageServers-log"); //$NON-NLS-1$
 		if (!(logFolder.exists() || logFolder.mkdirs()) || !logFolder.isDirectory() || !logFolder.canWrite()) {
 			return null;
 		}
@@ -113,7 +113,7 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 
 	private String message(String direction, byte[] payload) {
 		String now = OffsetDateTime.now().toString();
-		StringBuilder builder = new StringBuilder(payload.length + id.length() + direction.length() + now.length() + 10);
+		final var builder = new StringBuilder(payload.length + id.length() + direction.length() + now.length() + 10);
 		builder.append("\n["); //$NON-NLS-1$
 		builder.append(now);
 		builder.append("] "); //$NON-NLS-1$
@@ -143,7 +143,7 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 				@Override
 				public int read(byte[] b, int off, int len) throws IOException {
 					int bytes = super.read(b, off, len);
-					byte[] payload = new byte[bytes];
+					final var payload = new byte[bytes];
 					System.arraycopy(b, off, payload, 0, bytes);
 					if (logToConsole || logToFile) {
 						String s = infoMessage(payload);
@@ -171,7 +171,7 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 				@Override
 				public int read(byte[] b, int off, int len) throws IOException {
 					int bytes = super.read(b, off, len);
-					byte[] payload = new byte[bytes];
+					final var payload = new byte[bytes];
 					System.arraycopy(b, off, payload, 0, bytes);
 					if (logToConsole || logToFile) {
 						String s = errorMessage(payload);
@@ -276,7 +276,7 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 			if (LanguageServerPlugin.PLUGIN_ID.equals(existing[i].getName()))
 				return (MessageConsole) existing[i];
 		// no console found, so create a new one
-		MessageConsole myConsole = new MessageConsole(LanguageServerPlugin.PLUGIN_ID, null);
+		final var myConsole = new MessageConsole(LanguageServerPlugin.PLUGIN_ID, null);
 		conMan.addConsoles(new IConsole[] { myConsole });
 		return myConsole;
 	}
@@ -309,7 +309,7 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 		if (logFolder == null) {
 			return null;
 		}
-		File file = new File(logFolder, id + ".log"); //$NON-NLS-1$
+		final var file = new File(logFolder, id + ".log"); //$NON-NLS-1$
 		if (file.exists() && !(file.isFile() && file.canWrite())) {
 			return null;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ServerMessageHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ServerMessageHandler.java
@@ -35,7 +35,7 @@ public class ServerMessageHandler {
 		// this class shouldn't be instantiated
 	}
 
-	private static class LSPNotification extends AbstractNotificationPopup {
+	private static final class LSPNotification extends AbstractNotificationPopup {
 
 		private final String label;
 		private final MessageParams messageParams;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ServerMessageHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ServerMessageHandler.java
@@ -54,7 +54,7 @@ public class ServerMessageHandler {
 
 		@Override
 		protected void createContentArea(Composite parent) {
-			Label messageLabel = new Label(parent, SWT.WRAP);
+			final var messageLabel = new Label(parent, SWT.WRAP);
 			messageLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 			messageLabel.setText(messageParams.getMessage());
 		}
@@ -93,7 +93,7 @@ public class ServerMessageHandler {
 
 	public static void showMessage(String title, MessageParams params) {
 		Display.getDefault().asyncExec(() -> {
-			AbstractNotificationPopup notification = new LSPNotification(String.format("LSP (%s)", title), //$NON-NLS-1$
+			final var notification = new LSPNotification(String.format("LSP (%s)", title), //$NON-NLS-1$
 					params);
 			notification.open();
 		});
@@ -101,13 +101,13 @@ public class ServerMessageHandler {
 
 	public static CompletableFuture<MessageActionItem> showMessageRequest(LanguageServerWrapper wrapper, ShowMessageRequestParams params) {
 		String[] options = params.getActions().stream().map(MessageActionItem::getTitle).toArray(String[]::new);
-		CompletableFuture<MessageActionItem> future = new CompletableFuture<>();
+		final var future = new CompletableFuture<MessageActionItem>();
 
 		Display.getDefault().asyncExec(() -> {
-			Shell shell = new Shell(Display.getCurrent());
-			MessageDialog dialog = new MessageDialog(shell, wrapper.serverDefinition.label,
+			final var shell = new Shell(Display.getCurrent());
+			final var dialog = new MessageDialog(shell, wrapper.serverDefinition.label,
 					null, params.getMessage(), MessageDialog.INFORMATION, 0, options);
-			MessageActionItem result = new MessageActionItem();
+			final var result = new MessageActionItem();
 			int dialogResult = dialog.open();
 			if (dialogResult != SWT.DEFAULT) { // the dialog was not dismissed without pressing a button (ESC key, close box, etc.)
 				result.setTitle(options[dialogResult]);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java
@@ -129,7 +129,7 @@ public class CommandExecutor {
 			}
 			// Server can handle command
 			return languageServerFuture.thenApplyAsync(server -> {
-				ExecuteCommandParams params = new ExecuteCommandParams();
+				final var params = new ExecuteCommandParams();
 				params.setCommand(command.getCommand());
 				params.setArguments(command.getArguments());
 				return server.getWorkspaceService().executeCommand(params);
@@ -220,7 +220,7 @@ public class CommandExecutor {
 			coreCommand.define(commandId, null, category, parameters);
 		}
 
-		Map<Object, Object> parameters = new HashMap<>();
+		final var parameters = new HashMap<Object, Object>();
 		parameters.put(LSP_COMMAND_PARAMETER_ID, command);
 		parameters.put(LSP_PATH_PARAMETER_ID, context);
 		ParameterizedCommand parameterizedCommand = ParameterizedCommand.generateCommand(coreCommand, parameters);
@@ -244,11 +244,11 @@ public class CommandExecutor {
 	 * workspace edit...
 	 */
 	private static WorkspaceEdit createWorkspaceEdit(List<Object> commandArguments, IDocument document) {
-		WorkspaceEdit res = new WorkspaceEdit();
-		Map<String, List<TextEdit>> changes = new HashMap<>();
+		final var res = new WorkspaceEdit();
+		final var changes = new HashMap<String, List<TextEdit>>();
 		res.setChanges(changes);
 		URI initialUri = LSPEclipseUtils.toUri(document);
-		Pair<URI, List<TextEdit>> currentEntry = new Pair<>(initialUri, new ArrayList<>());
+		final var currentEntry = new Pair<URI, List<TextEdit>>(initialUri, new ArrayList<>());
 		commandArguments.stream().flatMap(item -> {
 			if (item instanceof List<?> list) {
 				return list.stream();
@@ -268,7 +268,7 @@ public class CommandExecutor {
 			} else if (arg instanceof TextEdit textEdit) {
 				currentEntry.value.add(textEdit);
 			} else if (arg instanceof Map) {
-				Gson gson = new Gson(); // TODO? retrieve the GSon used by LS
+				final var gson = new Gson(); // TODO? retrieve the GSon used by LS
 				TextEdit edit = gson.fromJson(gson.toJson(arg), TextEdit.class);
 				if (edit != null) {
 					currentEntry.value.add(edit);
@@ -283,7 +283,7 @@ public class CommandExecutor {
 					}
 				}
 			} else if (arg instanceof JsonArray jsonArray) {
-				Gson gson = new Gson(); // TODO? retrieve the GSon used by LS
+				final var gson = new Gson(); // TODO? retrieve the GSon used by LS
 				jsonArray.forEach(elt -> {
 					TextEdit edit = gson.fromJson(gson.toJson(elt), TextEdit.class);
 					if (edit != null) {
@@ -291,7 +291,7 @@ public class CommandExecutor {
 					}
 				});
 			} else if (arg instanceof JsonObject jsonObject) {
-				Gson gson = new Gson(); // TODO? retrieve the GSon used by LS
+				final var gson = new Gson(); // TODO? retrieve the GSon used by LS
 				WorkspaceEdit wEdit = gson.fromJson(jsonObject, WorkspaceEdit.class);
 				Map<String, List<TextEdit>> entries = wEdit.getChanges();
 				if (wEdit != null && !entries.isEmpty()) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/LSPCommandHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/LSPCommandHandler.java
@@ -51,11 +51,11 @@ public abstract class LSPCommandHandler extends AbstractHandler {
 
 	@Override
 	public final Object execute(ExecutionEvent event) throws ExecutionException {
-		Command command = (Command) event.getObjectParameterForExecution(LSP_COMMAND_PARAMETER_ID);
+		final var command = (Command) event.getObjectParameterForExecution(LSP_COMMAND_PARAMETER_ID);
 		if (command == null) {
 			return null;
 		}
-		IPath path = (IPath) event.getObjectParameterForExecution(LSP_PATH_PARAMETER_ID);
+		final var path = (IPath) event.getObjectParameterForExecution(LSP_PATH_PARAMETER_ID);
 		if (path == null) {
 			return null;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/enablement/EnablementTester.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/enablement/EnablementTester.java
@@ -58,7 +58,7 @@ public final class EnablementTester {
 	 */
 	public boolean evaluate() {
 		try {
-			EvaluationContext context = new EvaluationContext(parent.get(), new Object());
+			final var context = new EvaluationContext(parent.get(), new Object());
 			context.setAllowPluginActivation(true);
 			return expression.evaluate(context).equals(EvaluationResult.TRUE);
 		} catch (CoreException e) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
@@ -115,7 +115,7 @@ public class CodeActionCompletionProposal implements ICompletionProposal {
 		if (capabilities != null) {
 			ExecuteCommandOptions provider = capabilities.getExecuteCommandProvider();
 			if (provider != null && provider.getCommands().contains(command.getCommand())) {
-				ExecuteCommandParams params = new ExecuteCommandParams();
+				final var params = new ExecuteCommandParams();
 				params.setCommand(command.getCommand());
 				params.setArguments(command.getArguments());
 				this.finfo.getInitializedLanguageClient()

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
@@ -113,8 +113,8 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 		} else if (att == null) {
 			return new IMarkerResolution[0];
 		}
-		List<Either<Command, CodeAction>> commands = (List<Either<Command, CodeAction>>) att;
-		List<IMarkerResolution> res = new ArrayList<>(commands.size());
+		final var commands = (List<Either<Command, CodeAction>>) att;
+		final var res = new ArrayList<IMarkerResolution>(commands.size());
 		for (Either<Command, CodeAction> command : commands) {
 			if (command != null) {
 				if (command.isLeft()) {
@@ -130,15 +130,15 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 	private void checkMarkerResoultion(IMarker marker) throws IOException, CoreException, InterruptedException, ExecutionException {
 		IResource res = marker.getResource();
 		if (res != null && res.getType() == IResource.FILE) {
-			IFile file = (IFile)res;
+			final var file = (IFile) res;
 			Object[] attributes = marker.getAttributes(new String[]{LSPDiagnosticsToMarkers.LANGUAGE_SERVER_ID, LSPDiagnosticsToMarkers.LSP_DIAGNOSTIC});
-			String languageServerId = (String) attributes[0];
-			List<CompletableFuture<?>> futures = new ArrayList<>();
-			Diagnostic diagnostic = (Diagnostic) attributes[1];
+			final var languageServerId = (String) attributes[0];
+			final var futures = new ArrayList<CompletableFuture<?>>();
+			final var diagnostic = (Diagnostic) attributes[1];
 			for (CompletableFuture<LanguageServer> lsf : getLanguageServerFutures(file, languageServerId)) {
 				marker.setAttribute(LSP_REMEDIATION, COMPUTING);
-				CodeActionContext context = new CodeActionContext(Collections.singletonList(diagnostic));
-				CodeActionParams params = new CodeActionParams();
+				final var context = new CodeActionContext(Collections.singletonList(diagnostic));
+				final var params = new CodeActionParams();
 				params.setContext(context);
 				params.setTextDocument(new TextDocumentIdentifier(LSPEclipseUtils.toUri(res).toString()));
 				params.setRange(diagnostic.getRange());
@@ -198,7 +198,7 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 				if (quickAssistant != null) {
 					Field f = QuickAssistAssistant.class.getDeclaredField("fQuickAssistAssistantImpl"); //$NON-NLS-1$
 					f.setAccessible(true);
-					ContentAssistant ca = (ContentAssistant) f.get(quickAssistant);
+					final var ca = (ContentAssistant) f.get(quickAssistant);
 					Method m = ContentAssistant.class.getDeclaredMethod("isProposalPopupActive"); //$NON-NLS-1$
 					m.setAccessible(true);
 					boolean isProposalPopupActive = (Boolean) m.invoke(ca);
@@ -214,7 +214,7 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 				if (hoverShowing) {
 					Field f = TextViewer.class.getDeclaredField("fTextHoverManager"); //$NON-NLS-1$
 					f.setAccessible(true);
-					AbstractInformationControlManager manager = (AbstractInformationControlManager) f.get(textViewer);
+					final var manager = (AbstractInformationControlManager) f.get(textViewer);
 					if (manager != null) {
 						manager.showInformation();
 					}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionQuickAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionQuickAssistProcessor.java
@@ -112,7 +112,7 @@ public class LSPCodeActionQuickAssistProcessor implements IQuickAssistProcessor 
 		}
 
 		CodeActionParams params = prepareCodeActionParams(infos, invocationContext.getOffset(), invocationContext.getLength());
-		List<Either<Command, CodeAction>> possibleProposals = Collections.synchronizedList(new ArrayList<>());
+		final var possibleProposals = Collections.synchronizedList(new ArrayList<Either<Command, CodeAction>>());
 		List<CompletableFuture<Void>> futures = infos.stream()
 				.map(info -> info.getInitializedLanguageClient()
 						.thenComposeAsync(ls -> ls.getTextDocumentService().codeAction(params).thenAcceptAsync(
@@ -221,8 +221,8 @@ public class LSPCodeActionQuickAssistProcessor implements IQuickAssistProcessor 
 	}
 
 	private static CodeActionParams prepareCodeActionParams(List<LSPDocumentInfo> infos, int offset, int length) {
-		CodeActionContext context = new CodeActionContext(Collections.emptyList());
-		CodeActionParams params = new CodeActionParams();
+		final var context = new CodeActionContext(Collections.emptyList());
+		final var params = new CodeActionParams();
 		params.setTextDocument(new TextDocumentIdentifier(infos.get(0).getFileUri().toString()));
 		try {
 			params.setRange(new Range(LSPEclipseUtils.toPosition(offset, infos.get(0).getDocument()), LSPEclipseUtils

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionsMenu.java
@@ -15,7 +15,6 @@ package org.eclipse.lsp4e.operations.codeactions;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -63,14 +62,14 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 	public void initialize(IServiceLocator serviceLocator) {
 		IEditorPart editor = UI.getActiveTextEditor();
 		if (editor != null) {
-			ITextEditor textEditor = (ITextEditor) editor;
+			final var textEditor = (ITextEditor) editor;
 			IDocument document = LSPEclipseUtils.getDocument(textEditor);
 			if (document == null) {
 				return;
 			}
 			infos = LanguageServiceAccessor.getLSPDocumentInfosFor(document,
 					LSPCodeActionMarkerResolution::providesCodeActions);
-			ITextSelection selection = (ITextSelection) textEditor.getSelectionProvider().getSelection();
+			final var selection = (ITextSelection) textEditor.getSelectionProvider().getSelection();
 			try {
 				this.range = new Range(LSPEclipseUtils.toPosition(selection.getOffset(), document),
 						LSPEclipseUtils.toPosition(selection.getOffset() + selection.getLength(), document));
@@ -82,7 +81,7 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 
 	@Override
 	public void fill(final Menu menu, int index) {
-		final MenuItem item = new MenuItem(menu, SWT.NONE, index);
+		final var item = new MenuItem(menu, SWT.NONE, index);
 		item.setEnabled(false);
 		if (infos.isEmpty()) {
 			item.setText(Messages.notImplemented);
@@ -90,31 +89,31 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 		}
 
 		item.setText(Messages.computing);
-		CodeActionContext context = new CodeActionContext(Collections.emptyList());
-		CodeActionParams params = new CodeActionParams();
+		final var context = new CodeActionContext(Collections.emptyList());
+		final var params = new CodeActionParams();
 		params.setTextDocument(new TextDocumentIdentifier(infos.get(0).getFileUri().toString()));
 		params.setRange(this.range);
 		params.setContext(context);
-		Set<CompletableFuture<?>> runningFutures = new HashSet<>();
-		for (LSPDocumentInfo info : this.infos) {
+		final var runningFutures = new HashSet<CompletableFuture<?>>();
+		for (final LSPDocumentInfo info : this.infos) {
 			final CompletableFuture<List<Either<Command, CodeAction>>> codeActions = info.getInitializedLanguageClient()
 					.thenComposeAsync(languageServer -> languageServer.getTextDocumentService().codeAction(params));
 			runningFutures.add(codeActions);
 			codeActions.whenComplete((t, u) -> {
 				runningFutures.remove(codeActions);
-				UIJob job = new UIJob(menu.getDisplay(), Messages.updateCodeActions_menu) {
+				final var job = new UIJob(menu.getDisplay(), Messages.updateCodeActions_menu) {
 					@Override
 					public IStatus runInUIThread(IProgressMonitor monitor) {
 						if (u != null) {
-							final MenuItem item = new MenuItem(menu, SWT.NONE, index);
+							final var item = new MenuItem(menu, SWT.NONE, index);
 							item.setText(u.getMessage());
 							item.setImage(LSPImages.getSharedImage(ISharedImages.IMG_DEC_FIELD_ERROR));
 							item.setEnabled(false);
 						} else if (t != null) {
 							for (Either<Command, CodeAction> command : t) {
 								if (command != null) {
-									final MenuItem item = new MenuItem(menu, SWT.NONE, index);
-									CodeActionCompletionProposal proposal = new CodeActionCompletionProposal(command, info);
+									final var item = new MenuItem(menu, SWT.NONE, index);
+									final var proposal = new CodeActionCompletionProposal(command, info);
 									item.setText(proposal.getDisplayString());
 									item.addSelectionListener(new SelectionAdapter() {
 										@Override
@@ -144,7 +143,7 @@ public class LSPCodeActionsMenu extends ContributionItem implements IWorkbenchCo
 		if (capabilities != null) {
 			ExecuteCommandOptions provider = capabilities.getExecuteCommandProvider();
 			if (provider != null && provider.getCommands().contains(command.getCommand())) {
-				ExecuteCommandParams params = new ExecuteCommandParams();
+				final var params = new ExecuteCommandParams();
 				params.setCommand(command.getCommand());
 				params.setArguments(command.getArguments());
 				info.getInitializedLanguageClient()

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/CodeLensProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/CodeLensProvider.java
@@ -35,8 +35,8 @@ public class CodeLensProvider extends AbstractCodeMiningProvider {
 	private CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(@NonNull IDocument document) {
 		URI docURI = LSPEclipseUtils.toUri(document);
 		if (docURI != null) {
-			CodeLensParams param = new CodeLensParams(new TextDocumentIdentifier(docURI.toString()));
-			List<LSPCodeMining> codeLensResults = Collections.synchronizedList(new ArrayList<>());
+			final var param = new CodeLensParams(new TextDocumentIdentifier(docURI.toString()));
+			final var codeLensResults = Collections.synchronizedList(new ArrayList<LSPCodeMining>());
 			return LanguageServiceAccessor
 					.getLanguageServers(document, capabilities -> capabilities.getCodeLensProvider() != null)
 					.thenComposeAsync(languageServers -> CompletableFuture.allOf(languageServers.stream()

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/ColorInformationMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/ColorInformationMining.java
@@ -53,7 +53,7 @@ public class ColorInformationMining extends LineContentCodeMining {
 	 * text color declaration.
 	 *
 	 */
-	private static class UpdateColorWithDialog implements Consumer<MouseEvent> {
+	private static final class UpdateColorWithDialog implements Consumer<MouseEvent> {
 
 		private final TextDocumentIdentifier textDocumentIdentifier;
 		private final ColorInformation colorInformation;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/ColorInformationMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/ColorInformationMining.java
@@ -70,8 +70,8 @@ public class ColorInformationMining extends LineContentCodeMining {
 
 		@Override
 		public void accept(MouseEvent event) {
-			StyledText styledText = (StyledText) event.widget;
-			Shell shell = new Shell(styledText.getDisplay());
+			final var styledText = (StyledText) event.widget;
+			final var shell = new Shell(styledText.getDisplay());
 			Rectangle location = Geometry.toDisplay(styledText, new Rectangle(event.x, event.y, 1, 1));
 			shell.setLocation(location.x, location.y);
 			// Open color dialog
@@ -80,7 +80,7 @@ public class ColorInformationMining extends LineContentCodeMining {
 			RGB rgb = dialog.open();
 			if (rgb != null) {
 				// get LSP color presentation list for the picked color
-				ColorPresentationParams params = new ColorPresentationParams(textDocumentIdentifier,
+				final var params = new ColorPresentationParams(textDocumentIdentifier,
 						LSPEclipseUtils.toColor(rgb), colorInformation.getRange());
 				this.languageServer.getTextDocumentService().colorPresentation(params)
 						.thenAcceptAsync(presentations -> {
@@ -120,7 +120,7 @@ public class ColorInformationMining extends LineContentCodeMining {
 		int size = getSquareSize(fontMetrics);
 		x += fontMetrics.getLeading();
 		y += fontMetrics.getDescent();
-		Rectangle rect = new Rectangle(x, y, size, size);
+		final var rect = new Rectangle(x, y, size, size);
 		// Fill square
 		gc.setBackground(colorProvider.getColor(this.rgba, textWidget.getDisplay()));
 		gc.fillRectangle(rect);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/DocumentColorProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/DocumentColorProvider.java
@@ -54,9 +54,9 @@ public class DocumentColorProvider extends AbstractCodeMiningProvider {
 		URI docURI = LSPEclipseUtils.toUri(document);
 
 		if (docURI != null) {
-			TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(docURI.toString());
-			DocumentColorParams param = new DocumentColorParams(textDocumentIdentifier);
-			final List<ColorInformationMining> colorResults = Collections.synchronizedList(new ArrayList<>());
+			final var textDocumentIdentifier = new TextDocumentIdentifier(docURI.toString());
+			final var param = new DocumentColorParams(textDocumentIdentifier);
+			final var colorResults = Collections.synchronizedList(new ArrayList<ColorInformationMining>());
 			return LanguageServiceAccessor.getLanguageServers(document, DocumentColorProvider::isColorProvider)
 					.thenComposeAsync(languageServers -> CompletableFuture
 							.allOf(languageServers.stream().map(languageServer -> languageServer

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -480,7 +480,7 @@ public class LSCompletionProposal
 				textEdit.getRange().getEnd().setCharacter(textEdit.getRange().getEnd().getCharacter() + commonSize);
 			}
 			insertText = textEdit.getNewText();
-			LinkedHashMap<String, List<LinkedPosition>> regions = new LinkedHashMap<>();
+			final var regions = new LinkedHashMap<String, List<LinkedPosition>>();
 			int insertionOffset = LSPEclipseUtils.toOffset(textEdit.getRange().getStart(), document);
 			insertionOffset = computeNewOffset(item.getAdditionalTextEdits(), insertionOffset, document);
 			if (item.getInsertTextMode() == InsertTextMode.AdjustIndentation) {
@@ -493,7 +493,7 @@ public class LSCompletionProposal
 				while ((currentSnippetOffsetInInsertText = insertText.indexOf('$', currentSnippetOffsetInInsertText)) != -1) {
 					final var keyBuilder = new StringBuilder();
 					boolean isChoice = false;
-					List<String> snippetProposals = new ArrayList<>();
+					final var snippetProposals = new ArrayList<String>();
 					int offsetInSnippet = 1;
 					while (currentSnippetOffsetInInsertText + offsetInSnippet < insertText.length() && Character.isDigit(insertText.charAt(currentSnippetOffsetInInsertText + offsetInSnippet))) {
 						keyBuilder.append(insertText.charAt(currentSnippetOffsetInInsertText + offsetInSnippet));
@@ -561,7 +561,7 @@ public class LSCompletionProposal
 			textEdit.setNewText(insertText); // insertText now has placeholder removed
 			List<TextEdit> additionalEdits = item.getAdditionalTextEdits();
 			if (additionalEdits != null && !additionalEdits.isEmpty()) {
-				List<TextEdit> allEdits = new ArrayList<>();
+				final var allEdits = new ArrayList<TextEdit>();
 				allEdits.add(textEdit);
 				additionalEdits.stream().forEach(te -> {
 					int shift = offset - this.initialOffset;
@@ -587,9 +587,9 @@ public class LSCompletionProposal
 
 			boolean onlyPlaceCaret = regions.size() == 1 && regions.values().iterator().next().size() == 1 && regions.values().iterator().next().stream().noneMatch(ProposalPosition.class::isInstance);
 			if (viewer != null && !regions.isEmpty() && !onlyPlaceCaret) {
-				LinkedModeModel model = new LinkedModeModel();
+				final var model = new LinkedModeModel();
 				for (List<LinkedPosition> positions: regions.values()) {
-					LinkedPositionGroup group = new LinkedPositionGroup();
+					final var group = new LinkedPositionGroup();
 					for (LinkedPosition position : positions) {
 						group.addPosition(position);
 					}
@@ -597,7 +597,7 @@ public class LSCompletionProposal
 				}
 				model.forceInstall();
 
-				LinkedModeUI ui = new EditorLinkedModeUI(model, viewer);
+				final var ui = new EditorLinkedModeUI(model, viewer);
 				// ui.setSimpleMode(true);
 				// ui.setExitPolicy(new ExitPolicy(closingCharacter, document));
 				// ui.setExitPosition(getTextViewer(), exit, 0, Integer.MAX_VALUE);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
@@ -22,7 +22,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -123,7 +122,7 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 			return createErrorProposal(offset, e);
 		}
 
-		LSCompletionProposal[] completeProposals = new LSCompletionProposal[proposals.size()];
+		final var completeProposals = new LSCompletionProposal[proposals.size()];
 		int i = 0;
 		for (ICompletionProposal proposal : proposals) {
 			if (proposal instanceof LSCompletionProposal completeProposal) {
@@ -260,13 +259,12 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 	}
 
 	private static IContextInformation toContextInformation(SignatureInformation information) {
-		StringBuilder signature = new StringBuilder(information.getLabel());
+		final var signature = new StringBuilder(information.getLabel());
 		String docString = LSPEclipseUtils.getDocString(information.getDocumentation());
 		if (docString!=null && !docString.isEmpty()) {
 			signature.append('\n').append(docString);
 		}
-		IContextInformation contextInformation = new ContextInformation(
-				information.getLabel(), signature.toString());
+		final var contextInformation = new ContextInformation(information.getLabel(), signature.toString());
 		return contextInformation;
 	}
 
@@ -294,7 +292,7 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 		if (additionalTriggers == null) {
 			additionalTriggers = Collections.emptySet();
 		}
-		Set<Character> triggers = new HashSet<>(initialArray.length);
+		final var triggers = new HashSet<Character>(initialArray.length);
 		for (char c : initialArray) {
 			triggers.add(c);
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -64,10 +63,10 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 		}
 		IRegion r = findWord(textViewer.getDocument(), region.getOffset());
 		final IRegion linkRegion = r != null ? r : region;
-		Map<Either<Location, LocationLink>,LSBasedHyperlink> allLinks = Collections.synchronizedMap(new LinkedHashMap<>());
+		final var allLinks = Collections.synchronizedMap(new LinkedHashMap<Either<Location, LocationLink>,LSBasedHyperlink>());
 		try {
 			// Collect definitions
-			Collection<CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>>> allFutures = Collections.synchronizedCollection(new ArrayList<>());
+			final var allFutures = Collections.synchronizedCollection(new ArrayList<CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>>>());
 			CompletableFuture.allOf(
 				LanguageServiceAccessor
 					.getLanguageServers(textViewer.getDocument(), capabilities -> LSPEclipseUtils.hasCapability(capabilities.getDefinitionProvider()))

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -109,13 +108,13 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 			return;
 		}
 		if (annotationModel instanceof IAnnotationModelExtension annotationModelExtension) {
-			Set<Annotation> toRemove = new HashSet<>();
+			final var toRemove = new HashSet<Annotation>();
 			annotationModel.getAnnotationIterator().forEachRemaining(annotation -> {
 				if (annotation instanceof DiagnosticAnnotation) {
 					toRemove.add(annotation);
 				}
 			});
-			Map<Annotation, Position> toAdd = new HashMap<>(diagnostics.getDiagnostics().size(), 1.f);
+			final var toAdd = new HashMap<Annotation, Position>(diagnostics.getDiagnostics().size(), 1.f);
 			diagnostics.getDiagnostics().forEach(diagnostic -> {
 				try {
 					int startOffset = LSPEclipseUtils.toOffset(diagnostic.getRange().getStart(), sourceViewer.getDocument());
@@ -130,12 +129,12 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 	}
 
 	private void updateMarkers(PublishDiagnosticsParams diagnostics, IResource resource) throws CoreException {
-		Set<IMarker> toDeleteMarkers = new HashSet<>(
+		final var toDeleteMarkers = new HashSet<IMarker>(
 				Arrays.asList(resource.findMarkers(markerType, false, IResource.DEPTH_ONE)));
 		toDeleteMarkers
 				.removeIf(marker -> !Objects.equals(marker.getAttribute(LANGUAGE_SERVER_ID, ""), languageServerId)); //$NON-NLS-1$
-		List<Diagnostic> newDiagnostics = new ArrayList<>();
-		Map<IMarker, Diagnostic> toUpdate = new HashMap<>();
+		final var newDiagnostics = new ArrayList<Diagnostic>();
+		final var toUpdate = new HashMap<IMarker, Diagnostic>();
 
 		// A language server can scan the whole project and generate diagnostics for files that are not currently open in the IDE
 		// (the markers will show up in the problem view). If so, need to open the document temporarily but be sure to release it
@@ -220,7 +219,7 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 
 	private @NonNull Map<String, Object> computeMarkerAttributes(@Nullable IDocument document,
 			@NonNull Diagnostic diagnostic, @NonNull IResource resource) {
-		Map<String, Object> attributes = new HashMap<>(8);
+		final var attributes = new HashMap<String, Object>(8);
 		attributes.put(LSP_DIAGNOSTIC, diagnostic);
 		attributes.put(LANGUAGE_SERVER_ID, languageServerId);
 		attributes.put(IMarker.MESSAGE, diagnostic.getMessage());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
@@ -79,7 +79,7 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 		if (uri == null) {
 			return null;
 		}
-		final DocumentLinkParams params = new DocumentLinkParams(new TextDocumentIdentifier(uri.toString()));
+		final var params = new DocumentLinkParams(new TextDocumentIdentifier(uri.toString()));
 		try {
 			return LanguageServiceAccessor
 					.getLanguageServers(document,
@@ -108,7 +108,7 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 												textViewer.getDocument());
 										int end = LSPEclipseUtils.toOffset(link.getRange().getEnd(),
 												textViewer.getDocument());
-										IRegion linkRegion = new Region(start, end - start);
+										final var linkRegion = new Region(start, end - start);
 										if (TextUtilities.overlaps(region, linkRegion) && link.getTarget() != null) {
 											jfaceLink = new DocumentHyperlink(link.getTarget(), linkRegion);
 										}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
@@ -72,7 +72,7 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 			return;
 		}
 		cancel();
-		final DocumentLinkParams params = new DocumentLinkParams(new TextDocumentIdentifier(uri.toString()));
+		final var params = new DocumentLinkParams(new TextDocumentIdentifier(uri.toString()));
 		request = LanguageServiceAccessor
 				.getLanguageServers(document, capabilities -> capabilities.getDocumentLinkProvider() != null)
 				.thenAcceptAsync(languageServers -> CompletableFuture.allOf(languageServers.stream()
@@ -95,7 +95,7 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 				int start = LSPEclipseUtils.toOffset(link.getRange().getStart(), document);
 				int end = LSPEclipseUtils.toOffset(link.getRange().getEnd(), document);
 				int length = end - start;
-				IRegion linkRegion = new Region(start, length);
+				final var linkRegion = new Region(start, length);
 
 				// Update existing style range with underline or create a new style range with
 				// underline
@@ -107,7 +107,7 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 					for (StyleRange s : styleRanges) {
 						s.underline = true;
 					}
-					TextPresentation presentation = new TextPresentation(linkRegion, 100);
+					final var presentation = new TextPresentation(linkRegion, 100);
 					presentation.replaceStyleRanges(styleRanges);
 					viewer.changeTextPresentation(presentation, false);
 
@@ -118,7 +118,7 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 					styleRange.start = start;
 					styleRange.length = length;
 
-					TextPresentation presentation = new TextPresentation(linkRegion, 100);
+					final var presentation = new TextPresentation(linkRegion, 100);
 					presentation.replaceStyleRange(styleRange);
 					viewer.changeTextPresentation(presentation, false);
 				}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -121,8 +121,8 @@ public class LSPFoldingReconcilingStrategy
 		if (uri == null) {
 			return;
 		}
-		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri.toString());
-		FoldingRangeRequestParams params = new FoldingRangeRequestParams(identifier);
+		final var identifier = new TextDocumentIdentifier(uri.toString());
+		final var params = new FoldingRangeRequestParams(identifier);
 		LanguageServiceAccessor.getLanguageServers(document, LSPFoldingReconcilingStrategy::canFold).thenAcceptAsync(servers -> {
 			if (servers.isEmpty()) {
 				return;
@@ -136,10 +136,10 @@ public class LSPFoldingReconcilingStrategy
 	private void applyFolding(List<FoldingRange> ranges) {
 		// these are what are passed off to the annotation model to
 		// actually create and maintain the annotations
-		List<Annotation> modifications = new ArrayList<>();
-		List<FoldingAnnotation> deletions = new ArrayList<>();
-		List<FoldingAnnotation> existing = new ArrayList<>();
-		Map<Annotation, Position> additions = new HashMap<>();
+		final var modifications = new ArrayList<Annotation>();
+		final var deletions = new ArrayList<FoldingAnnotation>();
+		final var existing = new ArrayList<FoldingAnnotation>();
+		final var additions = new HashMap<Annotation, Position>();
 
 		// find and mark all folding annotations with length 0 for deletion
 		markInvalidAnnotationsForDeletion(deletions, existing);
@@ -229,7 +229,7 @@ public class LSPFoldingReconcilingStrategy
 			throws BadLocationException {
 		int startOffset = document.getLineOffset(line);
 		int endOffset = document.getLineOffset(endLineNumber) + document.getLineLength(endLineNumber);
-		Position newPos = new Position(startOffset, endOffset - startOffset);
+		final var newPos = new Position(startOffset, endOffset - startOffset);
 		if (!existing.isEmpty()) {
 			FoldingAnnotation existingAnnotation = existing.remove(existing.size() - 1);
 			updateAnnotations(existingAnnotation, newPos, modifications, deletions);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -86,7 +86,7 @@ public class LSPFormatter {
 
 	private CompletableFuture<List<? extends TextEdit>> requestFormatting(LSPDocumentInfo info,
 			ITextSelection textSelection) throws BadLocationException {
-		TextDocumentIdentifier docId = new TextDocumentIdentifier(info.getFileUri().toString());
+		final var docId = new TextDocumentIdentifier(info.getFileUri().toString());
 		ServerCapabilities capabilities = info.getCapabilites();
 		IPreferenceStore store = EditorsUI.getPreferenceStore();
 		int tabWidth = store.getInt(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_TAB_WIDTH);
@@ -96,7 +96,7 @@ public class LSPFormatter {
 				&& isDocumentRangeFormattingSupported(capabilities)
 				&& (!isDocumentFormattingSupported(capabilities)
 						|| textSelection.getLength() != 0)) {
-			DocumentRangeFormattingParams params = new DocumentRangeFormattingParams();
+			final var params = new DocumentRangeFormattingParams();
 			params.setTextDocument(docId);
 			params.setOptions(new FormattingOptions(tabWidth, insertSpaces));
 			boolean fullFormat = textSelection.getLength() == 0;
@@ -109,7 +109,7 @@ public class LSPFormatter {
 					.thenComposeAsync(server -> server.getTextDocumentService().rangeFormatting(params));
 		}
 
-		DocumentFormattingParams params = new DocumentFormattingParams();
+		final var params = new DocumentFormattingParams();
 		params.setTextDocument(docId);
 		params.setOptions(new FormattingOptions(tabWidth, insertSpaces));
 		return info.getInitializedLanguageClient()

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
@@ -16,7 +16,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 
@@ -192,8 +191,8 @@ public class HighlightReconcilingStrategy
 		if(uri == null) {
 			return;
 		}
-		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri.toString());
-		DocumentHighlightParams params = new DocumentHighlightParams(identifier, position);
+		final var identifier = new TextDocumentIdentifier(uri.toString());
+		final var params = new DocumentHighlightParams(identifier, position);
 		request = LanguageServiceAccessor.getLanguageServers(document,
 				capabilities -> LSPEclipseUtils.hasCapability(capabilities.getDocumentHighlightProvider()))
 				.thenAcceptAsync(languageServers ->
@@ -225,7 +224,7 @@ public class HighlightReconcilingStrategy
 	 *            annotation model to update.
 	 */
 	private void updateAnnotations(List<? extends DocumentHighlight> highlights, IAnnotationModel annotationModel) {
-		Map<Annotation, org.eclipse.jface.text.Position> annotationMap = new HashMap<>(highlights.size());
+		final var annotationMap = new HashMap<Annotation, org.eclipse.jface.text.Position>(highlights.size());
 		for (DocumentHighlight h : highlights) {
 			if (h != null) {
 				try {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
@@ -80,11 +80,11 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 	@Override
 	protected void createContent(Composite parent) {
 		super.createContent(parent);
-		Browser b = (Browser) (parent.getChildren()[0]);
+		final var b = (Browser) (parent.getChildren()[0]);
 		b.addProgressListener(ProgressListener.completedAdapter(event -> {
 			if (getInput() == null)
 				return;
-			Browser browser = (Browser) event.getSource();
+			final var browser = (Browser) event.getSource();
 			@Nullable
 			Point constraints = getSizeConstraints();
 			Point hint = computeSizeHint();
@@ -163,7 +163,7 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 		}
 
 		int headIndex = html.indexOf(HEAD);
-		StringBuilder builder = new StringBuilder(html.length() + style.length());
+		final var builder = new StringBuilder(html.length() + style.length());
 		builder.append(html.substring(0, headIndex + HEAD.length()));
 		builder.append(style);
 		if (hlStyle != null) {
@@ -179,7 +179,7 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 	}
 
 	private static @NonNull CharSequence toHTMLrgb(RGB rgb) {
-		StringBuilder builder = new StringBuilder(7);
+		final var builder = new StringBuilder(7);
 		builder.append('#');
 		appendAsHexString(builder, rgb.red);
 		appendAsHexString(builder, rgb.green);
@@ -199,8 +199,7 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 	public IInformationControlCreator getInformationPresenterControlCreator() {
 		return parent -> {
 			if (BrowserInformationControl.isAvailable(parent)) {
-				BrowserInformationControl res = new FocusableBrowserInformationControl(parent, JFaceResources.DEFAULT_FONT,
-						true);
+				final var res = new FocusableBrowserInformationControl(parent, JFaceResources.DEFAULT_FONT, true);
 				res.addLocationListener(HYPER_LINK_LISTENER);
 				return res;
 			} else {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/InlayHintProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/InlayHintProvider.java
@@ -39,7 +39,7 @@ public class InlayHintProvider extends AbstractCodeMiningProvider {
 		if (docURI != null) {
 			// Eclipse seems to request minings only when the document is loaded (or changed), rather than
 			// whenever the viewport [displayed area] changes, so request minings for the whole document in one go.
-			Position end = new Position(0,0);
+			var end = new Position(0,0);
 			try {
 				end = LSPEclipseUtils.toPosition(document.getLength(), document);
 			} catch (BadLocationException e) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingBase.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingBase.java
@@ -64,10 +64,10 @@ public class LSPLinkedEditingBase implements IPreferenceChangeListener {
 		if(uri == null) {
 			return CompletableFuture.completedFuture(null);
 		}
-		TextDocumentIdentifier identifier = new TextDocumentIdentifier(uri.toString());
-		TextDocumentPositionParams params = new TextDocumentPositionParams(identifier, position);
+		final var identifier = new TextDocumentIdentifier(uri.toString());
+		final var params = new TextDocumentPositionParams(identifier, position);
 
-		AtomicReference<LinkedEditingRanges> range = new AtomicReference<>();
+		final var range = new AtomicReference<LinkedEditingRanges>();
 		return LanguageServiceAccessor.getLanguageServers(document,
 					capabilities -> LSPEclipseUtils.hasCapability(capabilities.getLinkedEditingRangeProvider()))
 				.thenComposeAsync(languageServers ->

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
@@ -221,7 +221,7 @@ public class LSPLinkedEditingReconcilingStrategy extends LSPLinkedEditingBase im
 			return null;
 		}
 		try {
-			StringBuilder sb = new StringBuilder(fDocument.get(selectedRegion.getOffset(), selectedRegion.getLength())); 	// The range text before the insertion
+			final var sb = new StringBuilder(fDocument.get(selectedRegion.getOffset(), selectedRegion.getLength())); 	// The range text before the insertion
 			String newChars = event.character == 0 ? "" : Character.toString(event.character); //$NON-NLS-1$
 			sb.replace(offset - selectedRegion.getOffset(), offset - selectedRegion.getOffset() + selectedRegion.getLength(), newChars);
 			return sb.toString();
@@ -241,7 +241,7 @@ public class LSPLinkedEditingReconcilingStrategy extends LSPLinkedEditingBase im
 	}
 
 	private LinkedPositionGroup toJFaceGroup(@NonNull LinkedEditingRanges ranges) throws BadLocationException {
-		LinkedPositionGroup res = new LinkedPositionGroup();
+		final var res = new LinkedPositionGroup();
 		for (Range range : ranges.getRanges()) {
 			int startOffset = LSPEclipseUtils.toOffset(range.getStart(), fDocument);
 			int length = LSPEclipseUtils.toOffset(range.getEnd(), fDocument) - startOffset;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSFindReferences.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSFindReferences.java
@@ -55,7 +55,7 @@ public class LSFindReferences extends AbstractHandler implements IHandler {
 						return;
 					}
 					try {
-						LSSearchQuery query = new LSSearchQuery(document, offset, languageServers);
+						final var query = new LSSearchQuery(document, offset, languageServers);
 						HandlerUtil.getActiveShell(event).getDisplay().asyncExec(() -> NewSearchUI.runQueryInBackground(query));
 					} catch (BadLocationException e) {
 						LanguageServerPlugin.logError(e);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchQuery.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchQuery.java
@@ -84,17 +84,17 @@ public class LSSearchQuery extends FileSearchQuery {
 	@Override
 	public IStatus run(IProgressMonitor monitor) throws OperationCanceledException {
 		startTime = System.currentTimeMillis();
-		AbstractTextSearchResult textResult = (AbstractTextSearchResult) getSearchResult();
+		final var textResult = (AbstractTextSearchResult) getSearchResult();
 		textResult.removeAll();
 
 		try {
 			// Execute LSP "references" service
-			ReferenceParams params = new ReferenceParams();
+			final var params = new ReferenceParams();
 			params.setContext(new ReferenceContext(false));
 			params.setTextDocument(new TextDocumentIdentifier(LSPEclipseUtils.toUri(document).toString()));
 			params.setPosition(position);
 
-			for (LanguageServer languageServer : languageServers) {
+			for (final LanguageServer languageServer : languageServers) {
 				languageServer.getTextDocumentService().references(params)
 				.thenAcceptAsync(locations -> {
 					if (locations == null) {
@@ -145,7 +145,7 @@ public class LSSearchQuery extends FileSearchQuery {
 					int endOffset = LSPEclipseUtils.toOffset(location.getRange().getEnd(), document);
 
 					IRegion lineInformation = document.getLineInformationOfOffset(startOffset);
-					LineElement lineEntry = new LineElement(resource, document.getLineOfOffset(startOffset),
+					final var lineEntry = new LineElement(resource, document.getLineOfOffset(startOffset),
 							lineInformation.getOffset(),
 							document.get(lineInformation.getOffset(), lineInformation.getLength()));
 					return new FileMatch((IFile) resource, startOffset, endOffset - startOffset, lineEntry);
@@ -154,7 +154,7 @@ public class LSSearchQuery extends FileSearchQuery {
 				}
 			}
 			Position startPosition = location.getRange().getStart();
-			LineElement lineEntry = new LineElement(resource, startPosition.getLine(), 0,
+			final var lineEntry = new LineElement(resource, startPosition.getLine(), 0,
 					String.format("%s:%s", startPosition.getLine(), startPosition.getCharacter())); //$NON-NLS-1$
 			return new FileMatch((IFile) resource, 0, 0, lineEntry);
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameHandler.java
@@ -34,7 +34,6 @@ import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.ltk.core.refactoring.participants.ProcessorBasedRefactoring;
-import org.eclipse.ltk.core.refactoring.participants.RefactoringProcessor;
 import org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
@@ -64,10 +63,10 @@ public class LSPRenameHandler extends AbstractHandler implements IHandler {
 								int offset = textSelection.getOffset();
 								// TODO consider better strategy to pick LS, or iterate over LS until one gives
 								// 	a good result
-								RefactoringProcessor processor = new LSPRenameProcessor(document, languageServers.get(0), offset);
-								ProcessorBasedRefactoring refactoring = new ProcessorBasedRefactoring(processor);
-								LSPRenameRefactoringWizard wizard = new LSPRenameRefactoringWizard(refactoring);
-								RefactoringWizardOpenOperation operation = new RefactoringWizardOpenOperation(wizard);
+								final var processor = new LSPRenameProcessor(document, languageServers.get(0), offset);
+								final var refactoring = new ProcessorBasedRefactoring(processor);
+								final var wizard = new LSPRenameRefactoringWizard(refactoring);
+								final var operation = new RefactoringWizardOpenOperation(wizard);
 								shell.getDisplay().asyncExec(() -> {
 									try {
 										operation.run(shell, Messages.rename_title);
@@ -105,9 +104,9 @@ public class LSPRenameHandler extends AbstractHandler implements IHandler {
 					// in case the language servers take longer to kick in, defer the enablement to
 					// a later time
 					LanguageServiceAccessor.getLanguageServers(document, LSPRenameHandler::isRenameProvider)
-							.thenAccept((languageServer) -> {
+							.thenAccept(languageServer -> {
 								boolean enabled = !languageServer.isEmpty();
-								HandlerEvent handleEvent = new HandlerEvent(this, enabled, false);
+								final var handleEvent = new HandlerEvent(this, enabled, false);
 								fireHandlerChanged(handleEvent);
 							});
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
@@ -97,7 +97,7 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 	@Override
 	public RefactoringStatus checkInitialConditions(IProgressMonitor pm)
 			throws CoreException, OperationCanceledException {
-		RefactoringStatus status = new RefactoringStatus();
+		final var status = new RefactoringStatus();
 
 		if (document == null) {
 			return status;
@@ -107,8 +107,8 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 			for (LanguageServer serverToTry : serverList.get(500, TimeUnit.MILLISECONDS)) {
 				// check if prepareRename is supported by the active LSP
 				if (languageServer.equals(serverToTry)) {
-					TextDocumentIdentifier identifier = new TextDocumentIdentifier(LSPEclipseUtils.toUri(document).toString());
-					PrepareRenameParams params = new PrepareRenameParams();
+					final var identifier = new TextDocumentIdentifier(LSPEclipseUtils.toUri(document).toString());
+					final var params = new PrepareRenameParams();
 					params.setTextDocument(identifier);
 					params.setPosition(LSPEclipseUtils.toPosition(offset, document));
 					prepareRenameResult = languageServer.getTextDocumentService().prepareRename(params).get(1000, TimeUnit.MILLISECONDS);
@@ -159,11 +159,11 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 	@Override
 	public RefactoringStatus checkFinalConditions(IProgressMonitor pm, CheckConditionsContext context)
 			throws CoreException, OperationCanceledException {
-		RefactoringStatus status = new RefactoringStatus();
+		final var status = new RefactoringStatus();
 		try {
-			RenameParams params = new RenameParams();
+			final var params = new RenameParams();
 			params.setPosition(LSPEclipseUtils.toPosition(offset, document));
-			TextDocumentIdentifier identifier = new TextDocumentIdentifier();
+			final var identifier = new TextDocumentIdentifier();
 			identifier.setUri(LSPEclipseUtils.toUri(document).toString());
 			params.setTextDocument(identifier);
 			params.setNewName(newName);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameRefactoringWizard.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameRefactoringWizard.java
@@ -59,12 +59,12 @@ public class LSPRenameRefactoringWizard extends RefactoringWizard {
 
 		@Override
 		public void createControl(Composite parent) {
-			Composite composite = new Composite(parent, SWT.NONE);
+			final var composite = new Composite(parent, SWT.NONE);
 			composite.setLayout(new GridLayout(2, false));
 			composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 			composite.setFont(parent.getFont());
 
-			Label label = new Label(composite, SWT.NONE);
+			final var label = new Label(composite, SWT.NONE);
 			label.setLayoutData(new GridData());
 			label.setText(Messages.rename_label);
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -167,7 +167,7 @@ public class SemanticHighlightReconcilerStrategy
 	private SemanticTokensParams getSemanticTokensParams() {
 		URI uri = LSPEclipseUtils.toUri(document);
 		if (uri != null) {
-			SemanticTokensParams semanticTokensParams = new SemanticTokensParams();
+			final var semanticTokensParams = new SemanticTokensParams();
 			semanticTokensParams.setTextDocument(new TextDocumentIdentifier(uri.toString()));
 			return semanticTokensParams;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticTokensDataStreamProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticTokensDataStreamProcessor.java
@@ -54,7 +54,7 @@ public class SemanticTokensDataStreamProcessor {
 	 */
 	public @NonNull List<StyleRange> getStyleRanges(@NonNull final List<Integer> dataStream,
 			@NonNull final SemanticTokensLegend semanticTokensLegend) {
-		List<StyleRange> styleRanges = new ArrayList<>(dataStream.size() / 5);
+		final var styleRanges = new ArrayList<StyleRange>(dataStream.size() / 5);
 
 		int idx = 0;
 		int prevLine = 0;
@@ -107,8 +107,8 @@ public class SemanticTokensDataStreamProcessor {
 		if (data.intValue() == 0) {
 			return Collections.emptyList();
 		}
-		BitSet bitSet = BitSet.valueOf(new long[] { data });
-		List<String> tokenModifiers = new ArrayList<>();
+		final var bitSet = BitSet.valueOf(new long[] { data });
+		final var tokenModifiers = new ArrayList<String>();
 		for (int i = bitSet.nextSetBit(0); i >= 0; i = bitSet.nextSetBit(i + 1)) {
 			try {
 				tokenModifiers.add(legend.get(i));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/StyleRangeHolder.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/StyleRangeHolder.java
@@ -68,7 +68,7 @@ public class StyleRangeHolder implements ITextListener {
 	}
 
 	private StyleRange clone(final StyleRange styleRange) {
-		StyleRange clonedStyleRange = new StyleRange(styleRange.start, styleRange.length, styleRange.foreground,
+		final var clonedStyleRange = new StyleRange(styleRange.start, styleRange.length, styleRange.foreground,
 				styleRange.background, styleRange.fontStyle);
 		clonedStyleRange.strikeout = styleRange.strikeout;
 		return clonedStyleRange;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
@@ -62,7 +62,7 @@ public class LSPSymbolInFileDialog extends PopupDialog {
 		IFile documentFile = outlineViewerInput.documentFile;
 		getShell().setText(NLS.bind(Messages.symbolsInFile, documentFile == null ? null : documentFile.getName()));
 
-		FilteredTree filteredTree = new FilteredTree(parent, SWT.BORDER, new PatternFilter(), true, false);
+		final var filteredTree = new FilteredTree(parent, SWT.BORDER, new PatternFilter(), true, false);
 		TreeViewer viewer = filteredTree.getViewer();
 		viewer.setData(LSSymbolsContentProvider.VIEWER_PROPERTY_IS_QUICK_OUTLINE, Boolean.TRUE);
 
@@ -71,7 +71,7 @@ public class LSPSymbolInFileDialog extends PopupDialog {
 		final var contentProvider = contentService.createCommonContentProvider();
 		viewer.setContentProvider(contentProvider);
 
-		var sorter = new CommonViewerSorter();
+		final var sorter = new CommonViewerSorter();
 		sorter.setContentService(contentService);
 		viewer.setComparator(sorter);
 
@@ -87,7 +87,7 @@ public class LSPSymbolInFileDialog extends PopupDialog {
 				return;
 			}
 
-			IStructuredSelection selection = (IStructuredSelection) event.getSelection();
+			final var selection = (IStructuredSelection) event.getSelection();
 			if (selection.isEmpty()) {
 				return;
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
@@ -117,7 +117,7 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 
 	@Override
 	protected ItemsFilter createFilter() {
-		InternalItemsFilter itemsFilter = new InternalItemsFilter();
+		final var itemsFilter = new InternalItemsFilter();
 		labelProvider.setPattern(itemsFilter.getPattern());
 		return itemsFilter;
 	}
@@ -134,7 +134,7 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 				return;
 			}
 
-			WorkspaceSymbolParams params = new WorkspaceSymbolParams(itemsFilter.getPattern());
+			final var params = new WorkspaceSymbolParams(itemsFilter.getPattern());
 			try {
 				List<? extends WorkspaceSymbol> items = server.getWorkspaceService() //
 						.symbol(params) //
@@ -197,7 +197,7 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 		if (symbolinformation == null) {
 			return null;
 		}
-		WorkspaceSymbol res = new WorkspaceSymbol();
+		final var res = new WorkspaceSymbol();
 		res.setName(symbolinformation.getName());
 		res.setLocation(Either.forLeft(symbolinformation.getLocation()));
 		res.setKind(symbolinformation.getKind());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
@@ -51,7 +51,7 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 
 	private static final String DIALOG_SETTINGS = LSPSymbolInWorkspaceDialog.class.getName();
 
-	private static class InternalSymbolsLabelProvider extends SymbolsLabelProvider {
+	private static final class InternalSymbolsLabelProvider extends SymbolsLabelProvider {
 
 		private String pattern;
 		private final BoldStylerProvider stylerProvider;
@@ -89,7 +89,7 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 		}
 	}
 
-	private class InternalItemsFilter extends ItemsFilter {
+	private final class InternalItemsFilter extends ItemsFilter {
 
 		@Override
 		public boolean matchItem(Object item) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
@@ -62,11 +62,11 @@ public class LSPSymbolInWorkspaceHandler extends AbstractHandler {
 		if (site == null) {
 			return null;
 		}
-		LSPSymbolInWorkspaceDialog dialog = new LSPSymbolInWorkspaceDialog(site.getShell(), languageServers);
+		final var dialog = new LSPSymbolInWorkspaceDialog(site.getShell(), languageServers);
 		if (dialog.open() != IDialogConstants.OK_ID) {
 			return null;
 		}
-		SymbolInformation symbolInformation = (SymbolInformation) dialog.getFirstResult();
+		final var symbolInformation = (SymbolInformation) dialog.getFirstResult();
 		Location location = symbolInformation.getLocation();
 
 		LSPEclipseUtils.openInEditor(location);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/WorkspaceSymbolsQuickAccessProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/WorkspaceSymbolsQuickAccessProvider.java
@@ -57,8 +57,8 @@ public class WorkspaceSymbolsQuickAccessProvider implements IQuickAccessComputer
 		if (usedLanguageServers.isEmpty()) {
 			return new QuickAccessElement[0];
 		}
-		WorkspaceSymbolParams params = new WorkspaceSymbolParams(query);
-		List<QuickAccessElement> res = Collections.synchronizedList(new ArrayList<>());
+		final var params = new WorkspaceSymbolParams(query);
+		final var res = Collections.synchronizedList(new ArrayList<QuickAccessElement>());
 
 		try {
 			CompletableFuture.allOf(usedLanguageServers.stream()

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
@@ -14,7 +14,6 @@
 package org.eclipse.lsp4e.outline;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -183,13 +182,13 @@ public class CNFOutlinePage implements IContentOutlinePage, ILabelProviderListen
 	private EditorSelectionChangedListener editorSelectionChangedListener;
 
 	public static void refreshTreeSelection(TreeViewer viewer, int offset, IDocument document) {
-		ITreeContentProvider contentProvider = (ITreeContentProvider) viewer.getContentProvider();
+		final var contentProvider = (ITreeContentProvider) viewer.getContentProvider();
 		if (contentProvider == null) {
 			return;
 		}
 
 		Object[] objects = contentProvider.getElements(null);
-		List<Object> path = new ArrayList<>();
+		final var path = new ArrayList<Object>();
 		while (objects != null && objects.length > 0) {
 			boolean found = false;
 			for (final Object object : objects) {
@@ -212,7 +211,7 @@ public class CNFOutlinePage implements IContentOutlinePage, ILabelProviderListen
 				return;
 			}
 			Display.getDefault().asyncExec(() -> {
-				TreePath treePath = new TreePath(path.toArray());
+				final var treePath = new TreePath(path.toArray());
 				viewer.reveal(treePath);
 				viewer.setSelection(new TreeSelection(treePath), true);
 			});

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -303,7 +303,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			symbols.cancel(true);
 		}
 
-		DocumentSymbolParams params = new DocumentSymbolParams(new TextDocumentIdentifier(documentURI.toString()));
+		final var params = new DocumentSymbolParams(new TextDocumentIdentifier(documentURI.toString()));
 		symbols = outlineViewerInput.languageServer.getTextDocumentService().documentSymbol(params);
 		symbols.thenAcceptAsync(response -> {
 			symbolsModel.update(response);
@@ -332,7 +332,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 				if (linkWithEditor) {
 					ITextEditor editor = UI.getActiveTextEditor();
 					if (editor != null) {
-						ITextSelection selection = (ITextSelection) editor.getSelectionProvider().getSelection();
+						final var selection = (ITextSelection) editor.getSelectionProvider().getSelection();
 						CNFOutlinePage.refreshTreeSelection(viewer, selection.getOffset(), outlineViewerInput.document);
 					}
 				}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
@@ -254,7 +254,7 @@ public class SymbolsLabelProvider extends LabelProvider
 		if (element instanceof LSPDocumentInfo info) {
 			return new StyledString(info.getFileUri().getPath());
 		}
-		StyledString res = new StyledString();
+		final var res = new StyledString();
 		if (element == null){
 			return res;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsModel.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsModel.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,8 +71,8 @@ public class SymbolsModel {
 			childrenMap = Collections.emptyMap();
 			rootSymbols = Collections.emptyList();
 		} else {
-			final Map<SymbolInformation, List<SymbolInformation>> newChildrenMap = new HashMap<>();
-			final List<DocumentSymbol> newRootSymbols = new ArrayList<>();
+			final var newChildrenMap = new HashMap<SymbolInformation, List<SymbolInformation>>();
+			final var newRootSymbols = new ArrayList<DocumentSymbol>();
 
 			Collections.sort(response, Comparator.comparing(
 					either -> either.isLeft() ? either.getLeft().getLocation().getRange().getStart()
@@ -82,7 +81,7 @@ public class SymbolsModel {
 					Comparator.comparingInt(pos -> ((Position) pos).getLine())
 							.thenComparingInt(pos -> ((Position) pos).getCharacter())));
 
-			Deque<SymbolInformation> parentStack = new ArrayDeque<>();
+			final var parentStack = new ArrayDeque<SymbolInformation>();
 			parentStack.push(ROOT_SYMBOL_INFORMATION);
 			SymbolInformation previousSymbol = null;
 			for (Either<SymbolInformation, DocumentSymbol> either : response) {
@@ -141,7 +140,7 @@ public class SymbolsModel {
 	}
 
 	public Object[] getElements() {
-		List<Object> res = new ArrayList<>(Arrays.asList(getChildren(ROOT_SYMBOL_INFORMATION)));
+		final var res = new ArrayList<Object>(Arrays.asList(getChildren(ROOT_SYMBOL_INFORMATION)));
 		final IFile current = this.file;
 		Function<DocumentSymbol, Object> mapper = current != null ?
 				symbol -> new DocumentSymbolWithFile(symbol, current) :
@@ -209,7 +208,7 @@ public class SymbolsModel {
 	}
 
 	public TreePath toUpdatedSymbol(TreePath initialSymbol) {
-		List<Object> res = new ArrayList<>(initialSymbol.getSegmentCount());
+		final var res = new ArrayList<Object>(initialSymbol.getSegmentCount());
 		Object currentSymbol = null;
 		for (int i = 0; i < initialSymbol.getSegmentCount(); i++) {
 			String name = getName(initialSymbol.getSegment(i));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/progress/LSPProgressManager.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/progress/LSPProgressManager.java
@@ -64,7 +64,7 @@ public class LSPProgressManager {
 	 * @return the completable future
 	 */
 	public @NonNull CompletableFuture<Void> createProgress(final @NonNull WorkDoneProgressCreateParams params) {
-		LinkedBlockingDeque<ProgressParams> queue = new LinkedBlockingDeque<>();
+		final var queue = new LinkedBlockingDeque<ProgressParams>();
 
 		String jobIdentifier = params.getToken().map(Function.identity(), Object::toString);
 		BlockingQueue<ProgressParams> oldQueue = progressMap.put(jobIdentifier, queue);
@@ -91,7 +91,7 @@ public class LSPProgressManager {
 						progressMap.remove(jobIdentifier);
 						currentPercentageMap.remove(monitor);
 						if (languageServer != null) {
-							WorkDoneProgressCancelParams workDoneProgressCancelParams = new WorkDoneProgressCancelParams();
+							final var workDoneProgressCancelParams = new WorkDoneProgressCancelParams();
 							workDoneProgressCancelParams.setToken(jobIdentifier);
 							languageServer.cancelProgress(workDoneProgressCancelParams);
 						}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/CreateFileChange.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/CreateFileChange.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileInfo;
@@ -88,7 +87,7 @@ public class CreateFileChange extends ResourceChange {
 
 	@Override
 	public RefactoringStatus isValid(IProgressMonitor pm) throws CoreException {
-		RefactoringStatus result= new RefactoringStatus();
+		final var result= new RefactoringStatus();
 
 		IFileInfo jFile = EFS.getStore(this.uri).fetchInfo();
 		if (jFile.exists()) {
@@ -109,7 +108,7 @@ public class CreateFileChange extends ResourceChange {
 			IFile ifile = LSPEclipseUtils.getFileHandle(this.uri);
 
 			if (ifile != null) {
-				List<IFolder> foldersToCreate = new ArrayList<>();
+				final var foldersToCreate = new ArrayList<IFolder>();
 				IContainer parent = ifile.getParent();
 				while (!parent.exists() && parent.getType() == IResource.FOLDER) {
 					foldersToCreate.add((IFolder) parent);
@@ -141,7 +140,7 @@ public class CreateFileChange extends ResourceChange {
 					return undoChange;
 				}
 			} else {
-				File file = new File(this.uri);
+				final var file = new File(this.uri);
 				Files.createDirectories(file.getParentFile().toPath());
 				if (!file.createNewFile()) {
 					throw new IOException(String.format("Failed to create file '%s'",file)); //$NON-NLS-1$

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/ProcessOverSocketStreamConnectionProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/ProcessOverSocketStreamConnectionProvider.java
@@ -46,8 +46,8 @@ public abstract class ProcessOverSocketStreamConnectionProvider extends ProcessS
 
 	@Override
 	public void start() throws IOException {
-		final ServerSocket serverSocket = new ServerSocket(port);
-		Thread socketThread = new Thread(() -> {
+		final var serverSocket = new ServerSocket(port);
+		final var socketThread = new Thread(() -> {
 			try {
 				socket = serverSocket.accept();
 			} catch (IOException e) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/ProcessStreamConnectionProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/ProcessStreamConnectionProvider.java
@@ -59,7 +59,7 @@ public abstract class ProcessStreamConnectionProvider implements StreamConnectio
 	}
 
 	protected ProcessBuilder createProcessBuilder() {
-		ProcessBuilder builder = new ProcessBuilder(getCommands());
+		final var builder = new ProcessBuilder(getCommands());
 		if (getWorkingDirectory() != null) {
 			builder.directory(new File(getWorkingDirectory()));
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/StreamConnectionProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/StreamConnectionProvider.java
@@ -71,7 +71,7 @@ public interface StreamConnectionProvider {
 		if (output == null)
 			return input;
 
-		FilterInputStream filterInput = new FilterInputStream(input) {
+		final var filterInput = new FilterInputStream(input) {
 			@Override
 			public int read() throws IOException {
 				int res = super.read();
@@ -82,7 +82,7 @@ public interface StreamConnectionProvider {
 			@Override
 			public int read(byte[] b, int off, int len) throws IOException {
 				int bytes = super.read(b, off, len);
-				byte[] payload = new byte[bytes];
+				final var payload = new byte[bytes];
 				System.arraycopy(b, off, payload, 0, bytes);
 				output.write(payload, 0, payload.length);
 				return bytes;
@@ -91,7 +91,7 @@ public interface StreamConnectionProvider {
 			@Override
 			public int read(byte[] b) throws IOException {
 				int bytes = super.read(b);
-				byte[] payload = new byte[bytes];
+				final var payload = new byte[bytes];
 				System.arraycopy(b, 0, payload, 0, bytes);
 				output.write(payload, 0, payload.length);
 				return bytes;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
@@ -235,9 +235,9 @@ public final class LSPImages {
 
 		return colorToImageCache.computeIfAbsent(decodedColor, key -> {
 			// TODO most probably some scaling should be done for HIDPI
-			Image image = new Image(Display.getDefault(), 16, 16);
-			GC gc = new GC(image);
-			Color color = new Color(Display.getDefault(), key.getRed(), key.getGreen(),
+			final var image = new Image(Display.getDefault(), 16, 16);
+			final var gc = new GC(image);
+			final var color = new Color(Display.getDefault(), key.getRed(), key.getGreen(),
 					key.getBlue(), key.getAlpha());
 			gc.setBackground(color);
 			gc.fillRectangle(0, 0, 16, 16);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
@@ -32,8 +32,7 @@ import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.osgi.framework.Bundle;
 
-public class LSPImages {
-
+public final class LSPImages {
 
 	private LSPImages() {
 		// this class shouldn't be instantiated
@@ -246,5 +245,4 @@ public class LSPImages {
 			return image;
 		});
 	}
-
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
@@ -83,16 +83,16 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 
 	@Override
 	protected Control createContents(Composite parent) {
-		Composite res = new Composite(parent, SWT.NONE);
+		final var res = new Composite(parent, SWT.NONE);
 		res.setLayout(new GridLayout(2, false));
-		Link intro = new Link(res, SWT.WRAP);
+		final var intro = new Link(res, SWT.WRAP);
 		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).span(2, 1).hint(400, SWT.DEFAULT).applyTo(intro);
 		intro.setText(Messages.PreferencesPage_Intro);
 		intro.addSelectionListener(this.contentTypeLinkListener);
 
 		createStaticServersTable(res);
 
-		Link manualServersIntro = new Link(res, SWT.WRAP);
+		final var manualServersIntro = new Link(res, SWT.WRAP);
 		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).span(2, 1).hint(400, SWT.DEFAULT).applyTo(manualServersIntro);
 		manualServersIntro.setText(Messages.PreferencesPage_manualServers);
 		manualServersIntro.addSelectionListener(this.contentTypeLinkListener);
@@ -101,7 +101,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 		viewer.setContentProvider(new ArrayContentProvider());
 		workingCopy = new ArrayList<>();
 		workingCopy.addAll(LanguageServersRegistry.getInstance().getContentTypeToLSPLaunches());
-		TableViewerColumn contentTypeColumn = new TableViewerColumn(viewer, SWT.NONE);
+		final var contentTypeColumn = new TableViewerColumn(viewer, SWT.NONE);
 		contentTypeColumn.getColumn().setText(Messages.PreferencesPage_contentType);
 		contentTypeColumn.getColumn().setWidth(200);
 		contentTypeColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -110,7 +110,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 				return ((ContentTypeToLanguageServerDefinition)element).getKey().getName();
 			}
 		});
-		TableViewerColumn launchConfigColumn = new TableViewerColumn(viewer, SWT.NONE);
+		final var launchConfigColumn = new TableViewerColumn(viewer, SWT.NONE);
 		launchConfigColumn.getColumn().setText(Messages.PreferencesPage_LaunchConfiguration);
 		launchConfigColumn.getColumn().setWidth(300);
 		launchConfigColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -119,7 +119,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 				return ((ContentTypeToLSPLaunchConfigEntry)element).getLaunchConfiguration().getName();
 			}
 		});
-		TableViewerColumn launchModeColumn = new TableViewerColumn(viewer, SWT.NONE);
+		final var launchModeColumn = new TableViewerColumn(viewer, SWT.NONE);
 		launchModeColumn.getColumn().setText(Messages.PreferencesPage_LaunchMode);
 		launchModeColumn.getColumn().setWidth(100);
 		launchModeColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -138,9 +138,9 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 		});
 		viewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		viewer.getTable().setHeaderVisible(true);
-		Composite buttonComposite = new Composite(res, SWT.NONE);
+		final var buttonComposite = new Composite(res, SWT.NONE);
 		buttonComposite.setLayout(new GridLayout(1, false));
-		Button addButton = new Button(buttonComposite, SWT.PUSH);
+		final var addButton = new Button(buttonComposite, SWT.PUSH);
 		addButton.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false));
 		addButton.setText(Messages.PreferencesPage_Add);
 		addButton.addSelectionListener(new SelectionAdapter() {
@@ -175,7 +175,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 	}
 
 	private void createStaticServersTable(Composite res) {
-		Link staticServersIntro = new Link(res, SWT.WRAP);
+		final var staticServersIntro = new Link(res, SWT.WRAP);
 		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).span(2, 1).hint(400, SWT.DEFAULT).applyTo(staticServersIntro);
 		staticServersIntro.setText(Messages.PreferencesPage_staticServers);
 		staticServersIntro.addSelectionListener(this.contentTypeLinkListener);
@@ -183,7 +183,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 		checkboxViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		checkboxViewer.setContentProvider(new ArrayContentProvider());
 
-		TableViewerColumn enablementColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
+		final var enablementColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
 		enablementColumn.getColumn().setText(Messages.PreferencesPage_Enabled);
 		enablementColumn.getColumn().setWidth(70);
 		enablementColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -193,7 +193,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 			}
 		});
 
-		TableViewerColumn contentTypeColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
+		final var contentTypeColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
 		contentTypeColumn.getColumn().setText(Messages.PreferencesPage_contentType);
 		contentTypeColumn.getColumn().setWidth(200);
 		contentTypeColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -203,7 +203,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 			}
 		});
 
-		TableViewerColumn launchConfigColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
+		final var launchConfigColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
 		launchConfigColumn.getColumn().setText(Messages.PreferencesPage_languageServer);
 		launchConfigColumn.getColumn().setWidth(300);
 		launchConfigColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -218,7 +218,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 		if (contentTypeToLanguageServerDefinitions.stream()
 				.anyMatch(definition -> definition.getEnablementCondition() != null)) {
 
-			TableViewerColumn conditionColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
+			final var conditionColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
 			conditionColumn.getColumn().setText(Messages.PreferencesPage_enablementCondition);
 			conditionColumn.getColumn().setWidth(150);
 			conditionColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -275,7 +275,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 	@Override
 	public boolean performOk() {
 		this.registry.setAssociations(this.workingCopy);
-		EnableDisableLSJob enableDisableLSJob = new EnableDisableLSJob(changedDefinitions, getEditors());
+		final var enableDisableLSJob = new EnableDisableLSJob(changedDefinitions, getEditors());
 		enableDisableLSJob.schedule();
 		return super.performOk();
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
@@ -17,9 +17,7 @@ import static org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -65,7 +63,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 
 		@Override
 		protected void setValue(Object element, Object value) {
-			ContentTypeToLanguageServerDefinition server = (ContentTypeToLanguageServerDefinition)element;
+			final var server = (ContentTypeToLanguageServerDefinition) element;
 			map.put(server.getValue().id, (Boolean)value);
 			hasLoggingBeenChanged = true;
 			getViewer().refresh(element);
@@ -73,7 +71,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 
 		@Override
 		protected Object getValue(Object element) {
-			ContentTypeToLanguageServerDefinition server = (ContentTypeToLanguageServerDefinition)element;
+			final var server = (ContentTypeToLanguageServerDefinition) element;
 			return map.get(server.getValue().id);
 		}
 
@@ -118,7 +116,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 
 	@Override
 	protected Control createContents(Composite parent) {
-		Composite res = new Composite(parent, SWT.NONE);
+		final var res = new Composite(parent, SWT.NONE);
 		res.setLayout(new GridLayout(1, false));
 
 		createStaticServersTable(res);
@@ -133,7 +131,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 		languageServerViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		languageServerViewer.setContentProvider(new ArrayContentProvider());
 
-		TableViewerColumn launchConfigColumn = new TableViewerColumn(languageServerViewer, SWT.NONE);
+		final var launchConfigColumn = new TableViewerColumn(languageServerViewer, SWT.NONE);
 		launchConfigColumn.getColumn().setText(Messages.PreferencesPage_languageServer);
 		launchConfigColumn.getColumn().setWidth(300);
 		launchConfigColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -153,7 +151,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 		launchConfigurationViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		launchConfigurationViewer.setContentProvider(new ArrayContentProvider());
 
-		TableViewerColumn launchConfigColumn = new TableViewerColumn(launchConfigurationViewer, SWT.NONE);
+		final var launchConfigColumn = new TableViewerColumn(launchConfigurationViewer, SWT.NONE);
 		launchConfigColumn.getColumn().setText(Messages.PreferencesPage_LaunchConfiguration);
 		launchConfigColumn.getColumn().setWidth(300);
 		launchConfigColumn.setLabelProvider(new ColumnLabelProvider() {
@@ -169,13 +167,13 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 	}
 
 	private void addLoggingColumnsToViewer(TableViewer viewer) {
-		TableViewerColumn logToFileColumn = new TableViewerColumn(viewer, SWT.NONE);
+		final var logToFileColumn = new TableViewerColumn(viewer, SWT.NONE);
 		logToFileColumn.getColumn().setText(Messages.PreferencesPage_logging_toFile_title);
 		logToFileColumn.getColumn().setWidth(100);
 		logToFileColumn.setLabelProvider(new BooleanMapLabelProvider(serverEnableLoggingToFile));
 		logToFileColumn.setEditingSupport(new BooleanMapEditingSupport(viewer, serverEnableLoggingToFile));
 
-		TableViewerColumn logToConsoleColumn = new TableViewerColumn(viewer, SWT.NONE);
+		final var logToConsoleColumn = new TableViewerColumn(viewer, SWT.NONE);
 		logToConsoleColumn.getColumn().setText(Messages.PreferencesPage_logging_toConsole_title);
 		logToConsoleColumn.getColumn().setWidth(125);
 		logToConsoleColumn.setLabelProvider(new BooleanMapLabelProvider(serverEnableLoggingToConsole));
@@ -183,14 +181,14 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 	}
 
 	private void createLoggingContents(Composite res) {
-		Composite loggingComposite = new Composite(res, SWT.NONE);
+		final var loggingComposite = new Composite(res, SWT.NONE);
 		loggingComposite.setLayout(new GridLayout(3, false));
 		loggingComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1));
 
-		Label infoLabel = new Label(loggingComposite, SWT.NONE);
+		final var infoLabel = new Label(loggingComposite, SWT.NONE);
 		infoLabel.setText(Messages.preferencesPage_logging_info);
 		infoLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 3, 1));
-		Link logFolderLabel = new Link(loggingComposite, SWT.NONE);
+		final var logFolderLabel = new Link(loggingComposite, SWT.NONE);
 		logFolderLabel.setText(NLS.bind(Messages.preferencesPage_logging_fileLogsLocation, LoggingStreamConnectionProviderProxy.getLogDirectory()));
 		logFolderLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 3, 1));
 		logFolderLabel.addSelectionListener(widgetSelectedAdapter(e -> {
@@ -199,7 +197,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 			WizardDialog dialog = new WizardDialog(logFolderLabel.getShell(), importWizard);
 			dialog.open();
 		}));
-		Label fileLoggingLabel = new Label(loggingComposite, SWT.NONE);
+		final var fileLoggingLabel = new Label(loggingComposite, SWT.NONE);
 		fileLoggingLabel.setText(Messages.PreferencesPage_logging_toFile_description);
 		Button disableFileLogging = new Button(loggingComposite, SWT.NONE);
 		disableFileLogging.setText(Messages.PreferencePage_enablementCondition_disableAll);
@@ -209,7 +207,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 			languageServerViewer.refresh();
 			launchConfigurationViewer.refresh();
 		}));
-		Button enableFileLogging = new Button(loggingComposite, SWT.NONE);
+		final var enableFileLogging = new Button(loggingComposite, SWT.NONE);
 		enableFileLogging.setText(Messages.PreferencePage_enablementCondition_enableAll);
 		enableFileLogging.addSelectionListener(widgetSelectedAdapter(e -> {
 			serverEnableLoggingToFile.forEach((s, b) -> serverEnableLoggingToFile.put(s, true));
@@ -218,7 +216,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 			launchConfigurationViewer.refresh();
 		}));
 
-		Label consoleLoggingLabel = new Label(loggingComposite, SWT.NONE);
+		final var consoleLoggingLabel = new Label(loggingComposite, SWT.NONE);
 		consoleLoggingLabel.setText(Messages.PreferencesPage_logging_toConsole_description);
 		Button disableConsoleLogging = new Button(loggingComposite, SWT.NONE);
 		disableConsoleLogging.setText(Messages.PreferencePage_enablementCondition_disableAll);
@@ -228,7 +226,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 			languageServerViewer.refresh();
 			launchConfigurationViewer.refresh();
 		}));
-		Button enableConsoleLogging = new Button(loggingComposite, SWT.NONE);
+		final var enableConsoleLogging = new Button(loggingComposite, SWT.NONE);
 		enableConsoleLogging.setText(Messages.PreferencePage_enablementCondition_enableAll);
 		enableConsoleLogging.addSelectionListener(widgetSelectedAdapter(e -> {
 			serverEnableLoggingToConsole.forEach((s, b) -> serverEnableLoggingToConsole.put(s, true));
@@ -259,7 +257,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 	public boolean performOk() {
 		if (hasLoggingBeenChanged) {
 			applyLoggingEnablment();
-			MessageDialog dialog = new MessageDialog(getShell(), Messages.PreferencesPage_restartWarning_title, null,
+			final var dialog = new MessageDialog(getShell(), Messages.PreferencesPage_restartWarning_title, null,
 					Messages.PreferencesPage_restartWarning_message, MessageDialog.WARNING,
 					new String[] { IDialogConstants.NO_LABEL, Messages.PreferencesPage_restartWarning_restart }, 1);
 			if (dialog.open() == 1) {
@@ -276,8 +274,8 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 	}
 
 	private void updateInputs() {
-		Set<String> languageServerIDs = new HashSet<>();
-		List<ContentTypeToLSPLaunchConfigEntry> contentTypeToLSPLaunchConfigEntries = new ArrayList<>();
+		final var languageServerIDs = new HashSet<String>();
+		final var contentTypeToLSPLaunchConfigEntries = new ArrayList<ContentTypeToLSPLaunchConfigEntry>();
 		LanguageServersRegistry.getInstance().getContentTypeToLSPLaunches().forEach(o -> {
 			String id = o.getValue().id;
 			if (languageServerIDs.add(id)) {
@@ -293,7 +291,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 		launchConfigurationViewer.refresh();
 
 		languageServerIDs.clear();
-		List<ContentTypeToLanguageServerDefinition> contentTypeToLanguageServerDefinitions = new ArrayList<>();
+		final var contentTypeToLanguageServerDefinitions = new ArrayList<ContentTypeToLanguageServerDefinition>();
 		LanguageServersRegistry.getInstance().getContentTypeToLSPExtensions().forEach(o -> {
 			String id = o.getValue().id;
 			if (languageServerIDs.add(id)) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
@@ -15,7 +15,7 @@ package org.eclipse.lsp4e.ui;
 
 import org.eclipse.osgi.util.NLS;
 
-public class Messages extends NLS {
+public final class Messages extends NLS {
 
 	public static String hyperlinkLabel;
 	public static String PreferencesPage_Intro;
@@ -87,5 +87,8 @@ public class Messages extends NLS {
 
 	static {
 		NLS.initializeMessages("org.eclipse.lsp4e.ui.messages", Messages.class); //$NON-NLS-1$
+	}
+
+	private Messages() {
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/NewContentTypeLSPLaunchDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/NewContentTypeLSPLaunchDialog.java
@@ -58,7 +58,7 @@ public class NewContentTypeLSPLaunchDialog extends Dialog {
 	////
 	// copied from ContentTypesPreferencePage
 
-	private static class ContentTypesLabelProvider extends LabelProvider {
+	private static final class ContentTypesLabelProvider extends LabelProvider {
 		@Override
 		public String getText(Object element) {
 			IContentType contentType = (IContentType) element;
@@ -66,7 +66,7 @@ public class NewContentTypeLSPLaunchDialog extends Dialog {
 		}
 	}
 
-	private static class ContentTypesContentProvider implements ITreeContentProvider {
+	private static final class ContentTypesContentProvider implements ITreeContentProvider {
 
 		private IContentTypeManager manager;
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/NewContentTypeLSPLaunchDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/NewContentTypeLSPLaunchDialog.java
@@ -13,7 +13,6 @@ package org.eclipse.lsp4e.ui;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -61,7 +60,7 @@ public class NewContentTypeLSPLaunchDialog extends Dialog {
 	private static final class ContentTypesLabelProvider extends LabelProvider {
 		@Override
 		public String getText(Object element) {
-			IContentType contentType = (IContentType) element;
+			final var contentType = (IContentType) element;
 			return contentType.getName();
 		}
 	}
@@ -72,8 +71,8 @@ public class NewContentTypeLSPLaunchDialog extends Dialog {
 
 		@Override
 		public Object[] getChildren(Object parentElement) {
-			List<IContentType> elements = new ArrayList<>();
-			IContentType baseType = (IContentType) parentElement;
+			final var elements = new ArrayList<IContentType>();
+			final var baseType = (IContentType) parentElement;
 			IContentType[] contentTypes = manager.getAllContentTypes();
 			for (int i = 0; i < contentTypes.length; i++) {
 				IContentType type = contentTypes[i];
@@ -86,7 +85,7 @@ public class NewContentTypeLSPLaunchDialog extends Dialog {
 
 		@Override
 		public Object getParent(Object element) {
-			IContentType contentType = (IContentType) element;
+			final var contentType = (IContentType) element;
 			return contentType.getBaseType();
 		}
 
@@ -119,12 +118,12 @@ public class NewContentTypeLSPLaunchDialog extends Dialog {
 
 	@Override
 	protected Control createDialogArea(Composite parent) {
-		Composite res = (Composite)super.createDialogArea(parent);
+		final var res = (Composite)super.createDialogArea(parent);
 		res.setLayout(new GridLayout(2, false));
 		new Label(res, SWT.NONE).setText(Messages.NewContentTypeLSPLaunchDialog_associateContentType);
 		new Label(res, SWT.NONE).setText(Messages.NewContentTypeLSPLaunchDialog_withLSPLaunch);
 		// copied from ContentTypesPreferencePage
-		FilteredTree contentTypesFilteredTree = new FilteredTree(res, SWT.BORDER, new PatternFilter(), true, false);
+		final var contentTypesFilteredTree = new FilteredTree(res, SWT.BORDER, new PatternFilter(), true, false);
 		TreeViewer contentTypesViewer = contentTypesFilteredTree.getViewer();
 		contentTypesFilteredTree.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		contentTypesViewer.setContentProvider(new ContentTypesContentProvider());
@@ -142,7 +141,7 @@ public class NewContentTypeLSPLaunchDialog extends Dialog {
 			updateButtons();
 		});
 		// copied from LaunchConfigurationDialog : todo use LaunchConfigurationFilteredTree
-		FilteredTree launchersFilteredTree = new FilteredTree(res, SWT.BORDER, new PatternFilter(), true, false);
+		final var launchersFilteredTree = new FilteredTree(res, SWT.BORDER, new PatternFilter(), true, false);
 		TreeViewer launchConfigViewer = launchersFilteredTree.getViewer();
 		launchersFilteredTree.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		launchConfigViewer.setLabelProvider(new DecoratingLabelProvider(DebugUITools.newDebugModelPresentation(), PlatformUI.getWorkbench().getDecoratorManager().getLabelDecorator()));


### PR DESCRIPTION
This PR:
- marks private classes as final
- marks utility classes (containing only static methods) as final and adds private constructors where missing
- uses the var keyword in places where the type still is obvious because of the assignment being an explicit cast or a new instance of a class