### PR TITLE
Improve thread cleanup/recycling in tests

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/MockConnectionProvider.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/MockConnectionProvider.java
@@ -21,7 +21,10 @@ import java.nio.channels.Pipe;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.Function;
 
 import org.eclipse.lsp4e.server.StreamConnectionProvider;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -37,6 +40,8 @@ public class MockConnectionProvider implements StreamConnectionProvider {
 	private Future<Void> listener;
 	private Collection<Closeable> streams = new ArrayList<>(4);
 	
+	private static ExecutorService testRunner = Executors.newCachedThreadPool();
+	
 	@Override
 	public void start() throws IOException {
 		Pipe serverOutputToClientInput = Pipe.open();
@@ -46,7 +51,7 @@ public class MockConnectionProvider implements StreamConnectionProvider {
 		InputStream serverInputStream = Channels.newInputStream(clientOutputToServerInput.source());
 		OutputStream serverOutputStream = Channels.newOutputStream(serverOutputToClientInput.sink());
 		Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(MockLanguageServer.INSTANCE, serverInputStream,
-				serverOutputStream);
+				serverOutputStream, testRunner, Function.identity());
 		clientInputStream = Channels.newInputStream(serverOutputToClientInput.source());
 		clientOutputStream = Channels.newOutputStream(clientOutputToServerInput.sink());
 		listener = launcher.startListening();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -222,14 +222,14 @@ public class LanguageServerWrapper {
 		this.serverDefinition = serverDefinition;
 		this.connectedDocuments = new HashMap<>();
 		String projectName = (project != null && project.getName() != null) ? ("@" + project.getName()) : "";  //$NON-NLS-1$//$NON-NLS-2$
-		String dispatcherThreadNameFormat = "LS-" + serverDefinition.id + projectName + "-dispatcher-%d"; //$NON-NLS-1$ //$NON-NLS-2$
+		String dispatcherThreadNameFormat = "LS-" + serverDefinition.id + projectName + "#dispatcher"; //$NON-NLS-1$ //$NON-NLS-2$
 		this.dispatcher = Executors
 				.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(dispatcherThreadNameFormat).build());
 
 		// Executor service passed through to the LSP4j layer when we attempt to start the LS. It will be used
 		// to create a listener that sits on the input stream and processes inbound messages (responses, or server-initiated
 		// requests).
-		String listenerThreadNameFormat = "LS-" + serverDefinition.id + projectName + "-listener-%d"; //$NON-NLS-1$ //$NON-NLS-2$
+		String listenerThreadNameFormat = "LS-" + serverDefinition.id + projectName + "#listener-%d"; //$NON-NLS-1$ //$NON-NLS-2$
 		this.listener = Executors
 				.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat(listenerThreadNameFormat).build());
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -221,7 +221,7 @@ public class LanguageServerWrapper {
 		this.initialPath = initialPath;
 		this.serverDefinition = serverDefinition;
 		this.connectedDocuments = new HashMap<>();
-		String projectName = (project != null && project.getName() != null) ? ("@" + project.getName()) : "";  //$NON-NLS-1$//$NON-NLS-2$
+		String projectName = (project != null && project.getName() != null && !serverDefinition.isSingleton) ? ("@" + project.getName()) : "";  //$NON-NLS-1$//$NON-NLS-2$
 		String dispatcherThreadNameFormat = "LS-" + serverDefinition.id + projectName + "#dispatcher"; //$NON-NLS-1$ //$NON-NLS-2$
 		this.dispatcher = Executors
 				.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(dispatcherThreadNameFormat).build());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -221,14 +221,15 @@ public class LanguageServerWrapper {
 		this.initialPath = initialPath;
 		this.serverDefinition = serverDefinition;
 		this.connectedDocuments = new HashMap<>();
-		String dispatcherThreadNameFormat = "LS-" + serverDefinition.id + "-dispatcher-%d"; //$NON-NLS-1$ //$NON-NLS-2$
+		String projectName = (project != null && project.getName() != null) ? ("@" + project.getName()) : "";  //$NON-NLS-1$//$NON-NLS-2$
+		String dispatcherThreadNameFormat = "LS-" + serverDefinition.id + projectName + "-dispatcher-%d"; //$NON-NLS-1$ //$NON-NLS-2$
 		this.dispatcher = Executors
 				.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(dispatcherThreadNameFormat).build());
 
 		// Executor service passed through to the LSP4j layer when we attempt to start the LS. It will be used
 		// to create a listener that sits on the input stream and processes inbound messages (responses, or server-initiated
 		// requests).
-		String listenerThreadNameFormat = "LS-" + serverDefinition.id + "-listener-%d"; //$NON-NLS-1$ //$NON-NLS-2$
+		String listenerThreadNameFormat = "LS-" + serverDefinition.id + projectName + "-listener-%d"; //$NON-NLS-1$ //$NON-NLS-2$
 		this.listener = Executors
 				.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat(listenerThreadNameFormat).build());
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -75,6 +75,7 @@ public class LanguageServiceAccessor {
 	public static void clearStartedServers() {
 		startedServers.removeIf(server -> {
 			server.stop();
+			server.stopDispatcher();
 			return true;
 		});
 	}


### PR DESCRIPTION
This PR attempts to mitigate some of the behaviour noted in https://github.com/eclipse/lsp4e/issues/371

I have picked through the code and checked the documentation on `Executors.newCachedThreadPool()` and established that the behaviour is probably benign as far as production goes: prior to this PR we created a new cached thread pool for each LS every time `LanguageServerWrapper.start()` was called, with no corresponding cleanup code.
However:
1. Only one thread is ever instantiated from each thread pool by the launcher (used for listening for LS responses and incoming server->client requests)
2. As documented [here](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/Executors.html) `Executors.newThreadPoolExecutor()` creates threads on demand and shuts them down after 60 seconds of idleness, so unless LS have been configured with very very short idle timeouts, then these threads will close down shortly after `LanguageServerWrapper.close()` is called in any case.

The behaviour was more of an issue in testing, as each test creates a new `LanguageServerWrapper` and up to three threads (the launcher/listener thread, the recently-added [by me] dispatcher thread, and the thread for the mock language server - implicitly created by `MockConnectionProvider`).

I've tried to tidy this up - if you run the full test suites in the debugger in Eclipse you can see hundreds of threads starting. It's possible that in some environments the scheduler overhead of this might be causing some of our test stability issues.
