### PR TITLE
Test teardown - make sure global object is cleaned out on all paths

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -70,18 +70,25 @@ public class ConnectDocumentToLanguageServerSetupParticipant implements IDocumen
 			protected IStatus run(IProgressMonitor monitor) {
 				ITextFileBuffer buffer = ITextFileBufferManager.DEFAULT.getTextFileBuffer(document);
 				if (buffer == null || buffer.getLocation() == null) { // document no more relevant
+					SUBMITTED_JOBS.remove(this);
 					return Status.OK_STATUS;
 				}
 				if (monitor.isCanceled()) {
+					SUBMITTED_JOBS.remove(this);
 					return Status.CANCEL_STATUS;
 				}
 				// connect to LS so they start receiving notifications and pushing diagnostics
 				LanguageServiceAccessor.getLanguageServers(document, capabilities -> true)
 					.thenRun(() -> {
 						locationMap.remove(location);
-						SUBMITTED_JOBS.remove(this);
 					});
+				SUBMITTED_JOBS.remove(this);
 				return Status.OK_STATUS;
+			}
+
+			@Override
+			protected void canceling() {
+				SUBMITTED_JOBS.remove(this);
 			}
 		};
 		SUBMITTED_JOBS.add(job);


### PR DESCRIPTION
The SUBMITTED_JOBS was introduced to help test teardown so that we can cancel any of these jobs if the test finishes before they have a chance to run. Wasn't clearing out the map on all paths.

Addresses https://github.com/eclipse/lsp4e/issues/377

