### PR TITLE
Rename new api for core document changes

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -783,22 +783,22 @@ public class LanguageServerWrapper {
 	}
 
 	/**
-	 * Dispatches a LS request on a single executor thread tied to this server. Use of this guarantees that the server
+	 * Executes a LS request on a single executor thread tied to this server. Use of this guarantees that the server
 	 * will have seen all previous such requests (and document updates), and will not receive any further updates
 	 * prior to receiving this one.
 	 * @param <T> LS response type
 	 * @param fn LS method to invoke
 	 * @return Async result
 	 */
-	<T> CompletableFuture<T> executeOnLatestVersion(Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+	<T> CompletableFuture<T> execute(@NonNull Function<LanguageServer, ? extends CompletionStage<T>> fn) {
 		return getInitializedServer().thenComposeAsync(fn, this.dispatcher);
 	}
 	/**
-	 * Sends a notification to the LS on a single executor thread tied to this server. Use of this guarantees that the server
+	 * Notify the LS on a single executor thread tied to this server. Use of this guarantees that the server
 	 * will have seen all previous such requests/notifications (and document updates).
 	 * @param fn LS notification to send
 	 */
-	void notifyOnLatestVersion(Consumer<LanguageServer> fn) {
+	void notify(@NonNull Consumer<LanguageServer> fn) {
 		getInitializedServer().thenAcceptAsync(fn, this.dispatcher);
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -673,7 +673,7 @@ public class LanguageServiceAccessor {
 			// Ensure wrappers are started, connected to the document, and filter for capabilities
 			.map(wrapper -> wrapper.connectIf(document, filter)
 				// Call fn on lang servers, excluding null servers (that failed to start/connect or do not have the required capability)
-				.thenCompose(w -> w == null ? CompletableFuture.completedFuture((T)null) : w.executeOnLatestVersion(fn)))
+				.thenCompose(w -> w == null ? CompletableFuture.completedFuture((T)null) : w.execute(fn)))
 
 			// Transform individual async results into a single async with the aggregate result
 			.reduce(init, LanguageServiceAccessor::combine, LanguageServiceAccessor::concatResults)


### PR DESCRIPTION
Tidy API the new API for executing requests and sending notifications by
removing the "onLatestVersion". It is a bit verbose to add this to the
the method names, since we will change all calls to use this two
methods, it is enough to have this feature of the methods as part of the
javadoc.

Also remove some comment which has been left over and removed some
unnecessary 'this'.