### PR TITLE
Only apply TextEdits if they change the document content.

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -435,9 +435,15 @@ public final class LSPEclipseUtils {
 					// Must be a bad location: we bail out to avoid corrupting the document.
 					throw new BadLocationException("Invalid location information found applying edits"); //$NON-NLS-1$
 				}
-				edit.addChild(new ReplaceEdit(offset, length, textEdit.getNewText()));
+
+				// check if that edit would actually change the document
+				if (!document.get(offset, length).equals(textEdit.getNewText()))
+					edit.addChild(new ReplaceEdit(offset, length, textEdit.getNewText()));
 			}
 		}
+
+		if(!edit.hasChildren())
+			return;
 
 		IDocumentUndoManager manager = DocumentUndoManagerRegistry.getDocumentUndoManager(document);
 		if (manager != null) {


### PR DESCRIPTION
There are Language Servers that will send a TextEdit response on format, despite the fact that the formatting did not change.
This results in the open editor being marked dirty.

This PR only applies a TextEdits to a document if it would actually change the text avoiding editors being marked dirty despite no change.