### PR TITLE
New api - port hover

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
@@ -148,7 +148,7 @@ public class LanguageServersTest {
 		List<String> hovers = result.join();
 		
 		assertTrue(hovers.contains("HoverContent1"));
-		assertFalse(hovers.contains("HoverContent2"));
+		assertFalse(hovers.contains(null));
 	}
 	
 	@Test

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageServer;
 
 /**
@@ -179,6 +180,16 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 */
 	public E withFilter(final @NonNull Predicate<ServerCapabilities> filter) {
 		this.filter = filter;
+		return (E)this;
+	}
+
+	/**
+	 * Specifies the capabilities that a server must have to process this request
+	 * @param serverCapabilities
+	 * @return
+	 */
+	public E withCapability(final @NonNull Function<ServerCapabilities, Either<Boolean, ? extends Object>> serverCapabilities) {
+		this.filter = f -> LSPEclipseUtils.hasCapability(serverCapabilities.apply(f));
 		return (E)this;
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -72,7 +72,6 @@ public class LanguageServiceAccessor {
 	 */
 	public static void clearStartedServers() {
 		startedServers.removeIf(server -> {
-			server.stopDispatcher();
 			server.stop();
 			server.stopDispatcher();
 			return true;


### PR DESCRIPTION
Based on code originally submitted in #333  - this ports `LSPHover` to use the new API. Note that there is no timeout code in the revised logic, because there is no intermediate future exposed [the call to getLanguageServer is now rolled up into internal logic], but this should be fine as the consuming code in `getHoverRegion()` incorporates the timeout.

The API already excludes any nulls from the returned list, so that post-processing step is no longer needed here either.

Have tested it manually using the Corrosion plugin as well.