### PR TITLE
Use getLineOffset instead of getLineInformation().getOffset()

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -169,7 +169,7 @@ public final class LSPEclipseUtils {
 	}
 
 	public static int toOffset(Position position, IDocument document) throws BadLocationException {
-		return document.getLineInformation(position.getLine()).getOffset() + position.getCharacter();
+		return document.getLineOffset(position.getLine()) + position.getCharacter();
 	}
 
 	public static boolean isOffsetInRange(int offset, Range range, IDocument document) {
@@ -1053,7 +1053,7 @@ public final class LSPEclipseUtils {
 		if(path != null) {
 			return path.lastSegment();
 		}
-        return null;
+		return null;
 	}
 
 	@NonNull

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -228,10 +228,21 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 		if (document != null) {
 			Range range = diagnostic.getRange();
 			int documentLength = document.getLength();
+			int start;
 			try {
-				int start = Math.min(LSPEclipseUtils.toOffset(range.getStart(), document), documentLength);
-				int end = Math.min(LSPEclipseUtils.toOffset(range.getEnd(), document), documentLength);
+				start = Math.min(LSPEclipseUtils.toOffset(range.getStart(), document), documentLength);
+			} catch (BadLocationException ex) {
+				start = documentLength;
+			}
+			int end;
+			try {
+				end = Math.min(LSPEclipseUtils.toOffset(range.getEnd(), document), documentLength);
+			} catch (BadLocationException ex) {
+				end = documentLength;
+			}
+			try {
 				int lineOfStartOffset = document.getLineOfOffset(start);
+				attributes.put(IMarker.LINE_NUMBER, lineOfStartOffset + 1);
 				if (start == end && documentLength > end) {
 					end++;
 					if (document.getLineOfOffset(end) != lineOfStartOffset) {
@@ -239,12 +250,11 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 						end--;
 					}
 				}
-				attributes.put(IMarker.CHAR_START, start);
-				attributes.put(IMarker.CHAR_END, end);
-				attributes.put(IMarker.LINE_NUMBER, lineOfStartOffset + 1);
 			} catch (BadLocationException ex) {
 				LanguageServerPlugin.logError(ex);
 			}
+			attributes.put(IMarker.CHAR_START, start);
+			attributes.put(IMarker.CHAR_END, end);
 		}
 
 


### PR DESCRIPTION
Use getLineOffset instead of getLineInformation().getOffset() as it returns the same offset without the creation of an intermediate IRegion object.

Since DiagnosticsTest.testDiagnosticsRangeAfterDocument test that diagnostics outside of the document range are published with range start/end equals to the document length, and getLineOffset has an extra consistency check over getLineInformation().getOffset() which throws BadLocationExection, we need to handle this case when computing marker attributes.