### PR TITLE
[DO NOT MERGE] Diagnostics: Add torture test to provoke handle exhaustion

### DIFF
--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -98,7 +98,7 @@ public class MockTextDocumentService implements TextDocumentService {
 	private ConcurrentLinkedQueue<DidChangeTextDocumentParams> didChangeEvents = new ConcurrentLinkedQueue<>();
 
 	private Function<?, ? extends CompletableFuture<?>> _futureFactory;
-	private List<LanguageClient> remoteProxies;
+	protected List<LanguageClient> remoteProxies;
 	private Location mockReferences;
 	private List<Diagnostic> diagnostics;
 	private List<Either<Command, CodeAction>> mockCodeActions;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -129,6 +129,7 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 	}
 
 	private void updateMarkers(PublishDiagnosticsParams diagnostics, IResource resource) throws CoreException {
+		System.err.println("Publishing markers for " + diagnostics.getUri()); //$NON-NLS-1$
 		final var toDeleteMarkers = new HashSet<IMarker>(
 				Arrays.asList(resource.findMarkers(markerType, false, IResource.DEPTH_ONE)));
 		toDeleteMarkers

--- a/target-platforms/target-platform-latest/target-platform-latest.target
+++ b/target-platforms/target-platform-latest/target-platform-latest.target
@@ -30,6 +30,10 @@
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/tm4e/releases/latest/"/>
 		</location>
+    	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+        	<repository location="https://download.eclipse.org/releases/2022-03"/>
+        	<unit id="org.eclipse.swt.tools.feature.feature.group" version="3.108.400.v20220222-2111"/>
+    	</location>
 	</locations>
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 </target>


### PR DESCRIPTION
Do not merge - will cause hang!

Abused the existing diagnostics UT to show that a large(ish) number of files with diagnostics + 'run in background' disabled + windows = handle exhaustion (max number of OS shells exceeded).
