### PR TITLE
Fix Workspace Symbols Dialog

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
@@ -23,9 +23,8 @@ import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.LanguageServers.LanguageServerProjectExecutor;
 import org.eclipse.lsp4e.ui.UI;
-import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchSite;
@@ -64,10 +63,13 @@ public class LSPSymbolInWorkspaceHandler extends AbstractHandler {
 		if (dialog.open() != IDialogConstants.OK_ID) {
 			return null;
 		}
-		final var symbolInformation = (SymbolInformation) dialog.getFirstResult();
-		Location location = symbolInformation.getLocation();
+		final var symbolInformation = ((WorkspaceSymbol) dialog.getFirstResult()).getLocation();
+		if (symbolInformation.isLeft()) {
+			LSPEclipseUtils.openInEditor(symbolInformation.getLeft());
+		} else if (symbolInformation.isRight()) {
+			LSPEclipseUtils.open(symbolInformation.getRight().getUri(), null);
+		}
 
-		LSPEclipseUtils.openInEditor(location);
 		return null;
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
@@ -46,10 +46,12 @@ import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
 import org.eclipse.lsp4e.ui.LSPImages;
 import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.WorkspaceSymbol;
+import org.eclipse.lsp4j.WorkspaceSymbolLocation;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.IMemento;
@@ -283,10 +285,11 @@ public class SymbolsLabelProvider extends LabelProvider
 		} else if (element instanceof WorkspaceSymbol workspaceSymbol) {
 			name = workspaceSymbol.getName();
 			kind = workspaceSymbol.getKind();
+			String rawUri = getUri(workspaceSymbol);
 			try {
-				location = URI.create(getUri(workspaceSymbol));
+				location = URI.create(rawUri);
 			} catch (IllegalArgumentException e) {
-				LanguageServerPlugin.logError("Invalid URI: " + workspaceSymbol.getLocation(), e); //$NON-NLS-1$
+				LanguageServerPlugin.logError("Invalid URI: " + rawUri, e); //$NON-NLS-1$
 			}
 		} else if (element instanceof DocumentSymbol documentSymbol) {
 			name = documentSymbol.getName();
@@ -351,10 +354,7 @@ public class SymbolsLabelProvider extends LabelProvider
 	}
 
 	private static String getUri(WorkspaceSymbol symbol) {
-		if (symbol.getLocation().isLeft()) {
-			return symbol.getLocation().getLeft().getUri();
-		}
-		return symbol.getLocation().getRight().getUri();
+		return symbol.getLocation().map(Location::getUri, WorkspaceSymbolLocation::getUri);
 	}
 
 }


### PR DESCRIPTION
This was originally submitted as part of porting Workspace symbols to the new API (now submitted standalone).

In the process of doing the port I realised that the Workspace Symbols dialog appears to have been broken some time ago: the code to call the server was upgraded to handle the newer return type, and indeed to convert any legacy `SymbolInformation` instances returned into the newer `WorkspaceSymbol` lsp4j type, but the UI code was still assuming the objects could be downcast to `SymbolInformation`.... the two types are not directly interconvertible.

I've got it working but the unit test could do with upgrading. I was also unsure what else used the old `SymbolInformation` code branches and whether I could get rid of it. Can anyone comment?