### PR TITLE
New API: Port workspace symbols

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
@@ -32,6 +32,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.contentassist.BoldStylerProvider;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4e.LanguageServers.LanguageServerProjectExecutor;
 import org.eclipse.lsp4e.outline.CNFOutlinePage;
 import org.eclipse.lsp4e.outline.SymbolsLabelProvider;
 import org.eclipse.lsp4e.ui.Messages;
@@ -41,7 +42,6 @@ import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
@@ -103,12 +103,13 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 		}
 	}
 
-	private final List<@NonNull LanguageServer> languageServers;
 	private final InternalSymbolsLabelProvider labelProvider;
 
-	public LSPSymbolInWorkspaceDialog(Shell shell, List<@NonNull LanguageServer> languageServers) {
+	private final LanguageServerProjectExecutor executor;
+
+	public LSPSymbolInWorkspaceDialog(Shell shell, final LanguageServerProjectExecutor executor) {
 		super(shell);
-		this.languageServers = languageServers;
+		this.executor = executor;
 		this.labelProvider = new InternalSymbolsLabelProvider(new BoldStylerProvider(shell.getFont()));
 		setMessage(Messages.LSPSymbolInWorkspaceDialog_DialogLabel);
 		setTitle(Messages.LSPSymbolInWorkspaceDialog_DialogTitle);
@@ -128,34 +129,31 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 		if (itemsFilter.getPattern().isEmpty()) {
 			return;
 		}
-
-		for (LanguageServer server : this.languageServers) {
-			if (monitor.isCanceled()) {
-				return;
-			}
-
-			final var params = new WorkspaceSymbolParams(itemsFilter.getPattern());
-			try {
-				List<? extends WorkspaceSymbol> items = server.getWorkspaceService() //
-						.symbol(params) //
-						.thenApplyAsync(LSPSymbolInWorkspaceDialog::eitherToWorkspaceSymbols) //
-						.get(1, TimeUnit.SECONDS);
-				if(items != null) {
-					for (Object item : items) {
-						if (item != null) {
-							contentProvider.add(item, itemsFilter);
-						}
-					}
-				}
-			} catch (ExecutionException e) {
-				LanguageServerPlugin.logError(e);
-			} catch (InterruptedException e) {
-				LanguageServerPlugin.logError(e);
-				Thread.currentThread().interrupt();
-			} catch (TimeoutException e) {
-				LanguageServerPlugin.logWarning("Could not get workspace symbols due to timeout after 1 seconds in `workspace/symbol`", e); //$NON-NLS-1$
-			}
-		}
+		final var params = new WorkspaceSymbolParams(itemsFilter.getPattern());
+		this.executor.computeAll((w, ls) -> ls.getWorkspaceService()
+ 				.symbol(params)).stream().map(s -> s.thenApply(LSPSymbolInWorkspaceDialog::eitherToWorkspaceSymbols))
+ 			.forEach(cf -> {
+ 				if (monitor.isCanceled()) {
+ 					return;
+ 				}
+ 				try {
+ 					final List<? extends WorkspaceSymbol> items = cf.get(1, TimeUnit.SECONDS);
+ 					if(items != null) {
+ 						for (Object item : items) {
+ 							if (item != null) {
+ 								contentProvider.add(item, itemsFilter);
+ 							}
+ 						}
+ 					}
+ 				} catch (ExecutionException e) {
+ 					LanguageServerPlugin.logError(e);
+ 				} catch (InterruptedException e) {
+ 					LanguageServerPlugin.logError(e);
+ 					Thread.currentThread().interrupt();
+ 				} catch (TimeoutException e) {
+ 					LanguageServerPlugin.logWarning("Could not get workspace symbols due to timeout after 1 seconds in `workspace/symbol`", e); //$NON-NLS-1$
+ 				}
+ 			});
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
@@ -11,24 +11,21 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.symbols;
 
-import java.util.List;
-
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.LanguageServiceAccessor.LSPDocumentInfo;
+import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4e.LanguageServers.LanguageServerProjectExecutor;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SymbolInformation;
-import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchSite;
@@ -54,15 +51,16 @@ public class LSPSymbolInWorkspaceHandler extends AbstractHandler {
 		}
 
 		IProject project = resource.getProject();
-		List<@NonNull LanguageServer> languageServers = LanguageServiceAccessor.getLanguageServers(project, capabilities -> LSPEclipseUtils.hasCapability(capabilities.getWorkspaceSymbolProvider()));
-		if (languageServers.isEmpty()) {
+		final LanguageServerProjectExecutor executor = LanguageServers.forProject(project).withCapability(ServerCapabilities::getWorkspaceSymbolProvider);
+		if (!executor.anyMatching()) {
 			return null;
 		}
+
 		IWorkbenchSite site = HandlerUtil.getActiveSite(event);
 		if (site == null) {
 			return null;
 		}
-		final var dialog = new LSPSymbolInWorkspaceDialog(site.getShell(), languageServers);
+		final var dialog = new LSPSymbolInWorkspaceDialog(site.getShell(), executor);
 		if (dialog.open() != IDialogConstants.OK_ID) {
 			return null;
 		}
@@ -77,10 +75,9 @@ public class LSPSymbolInWorkspaceHandler extends AbstractHandler {
 	public boolean isEnabled() {
 		IWorkbenchPart part = UI.getActivePart();
 		if (part instanceof ITextEditor textEditor) {
-			List<LSPDocumentInfo> infos = LanguageServiceAccessor.getLSPDocumentInfosFor(
-					LSPEclipseUtils.getDocument(textEditor),
-					capabilities -> LSPEclipseUtils.hasCapability(capabilities.getWorkspaceSymbolProvider()));
-			return !infos.isEmpty();
+			return LanguageServers.forDocument(LSPEclipseUtils.getDocument(textEditor))
+					.withCapability(ServerCapabilities::getWorkspaceSymbolProvider)
+					.anyMatching();
 		}
 		return false;
 	}


### PR DESCRIPTION
This reworks onto the merged version of the new API example code originally submitted in #333 

Note that the Workspace Symbols dialog is currently not rendering and hot-linking correctly because of changes to the LSP spec. Originally attempted to fix this as well in #423 but not strictly related to the new API so have agreed to submit the API port in this PR as a standalone change.

@rubenporras FYI