### PR TITLE
[FOR DISCUSSION] New API: Outline of cancellation support

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/Canceller.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/Canceller.java
@@ -1,0 +1,68 @@
+package org.eclipse.lsp4e;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.eclipse.lsp4j.services.LanguageServer;
+
+public class Canceller {
+
+	private boolean cancelled;
+
+	private List<CompletableFuture<?>> running = new ArrayList<>();
+
+	private final Object lock = new Object();
+
+	public Canceller() {}
+
+
+	public boolean isCancelled() {
+		synchronized (this.lock) {
+			return this.cancelled;
+		}
+	}
+
+	public void cancel() {
+		synchronized(this.lock) {
+			if (!this.cancelled) {
+				this.cancelled = true;
+				this.running.forEach(cf -> cf.cancel(true));
+			}
+		}
+	}
+
+	protected void checkCancelled() {
+		if (this.cancelled) {
+			throw new CancellationException();
+		}
+	}
+
+	public <T> BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> wrap(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> fn) {
+
+		return (w, ls) -> {
+			synchronized (this.lock) {
+				checkCancelled();
+				CompletableFuture<T> pending = fn.apply(w,  ls);
+				this.running.add(pending);
+
+				return pending;
+			}
+		};
+	}
+
+	public <T> Function<LanguageServer, ? extends CompletableFuture<T>> wrap(Function<LanguageServer, ? extends CompletableFuture<T>> fn) {
+		return ls -> {
+			checkCancelled();
+			CompletableFuture<T> pending = fn.apply(ls);
+			this.running.add(pending);
+
+			return pending;
+
+		};
+	}
+
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -413,7 +413,44 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 		return new LanguageServerProjectExecutor(project);
 	}
 
+	/**
+	 *
+	 * @return True if the server call made using this executor has been cancelled
+	 */
+	public boolean isCancelled() {
+		return canceller.isCancelled();
+	}
+
+	/**
+	 * Cancel any running requests that have been wrapped with cancellation support
+	 */
+	public void cancel() {
+		canceller.cancel();
+	}
+
+	/**
+	 * Wrap a call to the LS such that it can be cancelled while running
+	 * @param <T>
+	 * @param fn
+	 * @return
+	 */
+	public <T> BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> wrapCancellable(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> fn) {
+		return canceller.wrap(fn);
+	}
+
+	/**
+	 * Wrap a call to the LS such that it can be cancelled while running
+	 * @param <T>
+	 * @param fn
+	 * @return
+	 */
+	public <T> Function<LanguageServer, ? extends CompletableFuture<T>> wrapCancellable(Function<LanguageServer, ? extends CompletableFuture<T>> fn) {
+		return canceller.wrap(fn);
+	}
+
 	private @NonNull Predicate<ServerCapabilities> filter = s -> true;
+
+	private Canceller canceller = new Canceller();
 
 	private boolean isRequestCancelledException(final Throwable throwable) {
 		if (throwable instanceof final CompletionException completionException) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -56,7 +56,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * @return Async result
 	 */
 	@NonNull
-	public <T> CompletableFuture<@NonNull List<@NonNull T>> collectAll(Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+	public <T> CompletableFuture<@NonNull List<@NonNull T>> collectAll(Function<LanguageServer, ? extends CompletableFuture<T>> fn) {
 		return collectAll((w, ls) -> fn.apply(ls));
 	}
 
@@ -73,7 +73,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * @return Async result
 	 */
 	@NonNull
-	public <T> CompletableFuture<@NonNull List<@NonNull T>> collectAll(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+	public <T> CompletableFuture<@NonNull List<@NonNull T>> collectAll(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> fn) {
 		computeVersion();
 		final CompletableFuture<@NonNull List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
 		return executeOnServers(fn).reduce(init, LanguageServers::add, LanguageServers::addAll)
@@ -93,7 +93,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * @return A list of pending results (note that these may be null or empty)
 	 */
 	@NonNull
-	public <T> List<@NonNull CompletableFuture<@Nullable T>> computeAll(Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+	public <T> List<@NonNull CompletableFuture<@Nullable T>> computeAll(Function<LanguageServer, ? extends CompletableFuture<T>> fn) {
 		return computeAll((w, ls) -> fn.apply(ls));
 	}
 
@@ -111,7 +111,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * @return A list of pending results (note that these may be null or empty)
 	 */
 	@NonNull
-	public <T> List<@NonNull CompletableFuture<@Nullable T>> computeAll(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+	public <T> List<@NonNull CompletableFuture<@Nullable T>> computeAll(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> fn) {
 		computeVersion();
 		return getServers().stream()
 				.map(cf -> cf
@@ -129,7 +129,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * @return An asynchronous result that will complete with a populated <code>Optional&lt;T&gt;</code> from the first
 	 * non-empty response, and with an empty <code>Optional</code> if none of the servers returned a non-empty result.
 	 */
-	public <T> CompletableFuture<Optional<T>> computeFirst(Function<LanguageServer, ? extends CompletionStage<T>> fn) {
+	public <T> CompletableFuture<Optional<T>> computeFirst(Function<LanguageServer, ? extends CompletableFuture<T>> fn) {
 		return computeFirst((w, ls) -> fn.apply(ls));
 	}
 
@@ -145,7 +145,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * @return An asynchronous result that will complete with a populated <code>Optional&lt;T&gt;</code> from the first
 	 * non-empty response, and with an empty <code>Optional</code> if none of the servers returned a non-empty result.
 	 */
-	public <T> CompletableFuture<Optional<T>> computeFirst(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletionStage<T>> fn) {
+	public <T> CompletableFuture<Optional<T>> computeFirst(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> fn) {
 		computeVersion();
 		final CompletableFuture<Optional<T>> result = new CompletableFuture<>();
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -206,11 +206,11 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 			if (this.lastExecutor != null) {
 				this.lastExecutor.cancel();
 			}
-			this.lastExecutor = LanguageServers.forDocument(document)
+			LanguageServerDocumentExecutor ex = this.lastExecutor = LanguageServers.forDocument(document)
 					.withCapability(ServerCapabilities::getHoverProvider);
 
 			this.request =
-					this.lastExecutor.collectAll(this.lastExecutor.wrapCancellable(server -> server.getTextDocumentService().hover(params)));
+					ex.collectAll(server -> ex.cancellable(server.getTextDocumentService().hover(params)));
 		} catch (BadLocationException e) {
 			LanguageServerPlugin.logError(e);
 		}


### PR DESCRIPTION
Hi all, this is a sketch of how cancellation support can be added to the new API.

According to the LSP spec, cancellation works by sending a special notification `cancel` message containing the request ID of the pending request you want to cancel.

This is supported by LSP4j - according to https://github.com/eclipse/lsp4j/blob/main/documentation/jsonrpc.md if you have made a request to the language server, e.g.

```
CompletableFuture<Hover> pending = ls.hover(params);
```

then you can just call `pending.cancel(true)` to cancel it. The LSP4j remoting layer constructs CompletableFuture objects with an overridden cancel method that knows the id it is associated with.

The slightly complicating factor is that this only applies to the initial response objects constructed directly by lsp4j. The fluent API provided by `CompletableFuture` for chaining further actions will construct further `CompletableFuture` objects that LSP4j knows nothing about, and cancellation flows down not up.

E.g. if you have, say:

```
CompletableFuture<A> a = doRequest();
CompletableFuture<B> b = a.thenApply({ do stuff to a});
CompletableFuture<C> c = b.thenApply({do more stuff});
```

If you call `b.cancel(true)` then `b` will be cancelled (if yet to return), as will `c`, but `a` will be unaffected and run to completion.

For us this has the effect that
```
CompletableFuture<Hover> pending1 = ls.hover(params);
CompletableFuture<TransformedHover> pending2 = ls.hover(params).thenApply(h -> new TransformedHover(h));
pending1.cancel(true);
pending2.cancel(true);
```
the first request will have a cancel message sent to the server, the second will not. `pending2` will still be cancelled, i.e. it will throw a `CancellationException` if you call `get()` on it, but the server will not be informed it can stop processing.

The extension to the new API I outline here works by wrapping the lambda function you would otherwise have passed directly to the API in a new 'do around' block that stores the completable future prior to returning it. For this to work, the wrapped function *must return the LSP4j-constructed objects directly without any chained post processing*.

So
```
var result = LanguageServers.forDocument(doc).collectAll(canceller.wrap(ls -> ls.hover(params)).thenApply(xform)));
```
will work.
```
var result = LanguageServers.forDocument(doc).collectAll(canceller.wrap(ls -> ls.hover(params).thenApply(xform)));
```
won't. 
