### PR TITLE
New api: port rename

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
@@ -42,9 +42,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServers;
-import org.eclipse.lsp4e.LanguageServers.LanguageServerDocumentExecutor;
-import org.eclipse.lsp4e.operations.rename.LSPRenameHandler;
 import org.eclipse.lsp4e.operations.rename.LSPRenameProcessor;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -118,8 +115,7 @@ public class RenameTest {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(LSPRenameHandler::isRenameProvider);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, executor, 0);
+		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
 		processor.setNewName("new");
 		try {
 			ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
@@ -138,8 +134,7 @@ public class RenameTest {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(LSPRenameHandler::isRenameProvider);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, executor, 0);
+		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
 		processor.setNewName("new");
 		try {
 			ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
@@ -159,8 +154,7 @@ public class RenameTest {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setPrepareRenameResult(null);
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(LSPRenameHandler::isRenameProvider);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, executor, 0);
+		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
 		processor.setNewName("new");
 
 		try {
@@ -182,8 +176,7 @@ public class RenameTest {
 			manager.connectFileStore(store, new NullProgressMonitor());
 			IDocument document = ((ITextFileBuffer)manager.getFileStoreFileBuffer(store)).getDocument();
 			document.set("old");
-			LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(LSPRenameHandler::isRenameProvider);
-			LSPRenameProcessor processor = new LSPRenameProcessor(document, executor, 0);
+			LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
 			processor.setNewName("new");
 			try {
 				ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
@@ -210,8 +203,7 @@ public class RenameTest {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(new WorkspaceEdit(edits));
 		IDocument document = LSPEclipseUtils.getDocument(workspaceFile);
 		assertNotNull(document);
-		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(LSPRenameHandler::isRenameProvider);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, executor, 0);
+		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
 		processor.setNewName("new");
 		try {
 			ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
@@ -273,8 +265,7 @@ public class RenameTest {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(LSPRenameHandler::isRenameProvider);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, executor, 0);
+		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
 		
 		try {
 			processor.checkInitialConditions(new NullProgressMonitor());
@@ -293,8 +284,7 @@ public class RenameTest {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setPrepareRenameResult(Either.forLeft(range));
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(LSPRenameHandler::isRenameProvider);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, executor, 0);
+		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
 		
 		try {
 			processor.checkInitialConditions(new NullProgressMonitor());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameHandler.java
@@ -61,7 +61,7 @@ public class LSPRenameHandler extends AbstractHandler implements IHandler {
 					if (executor.anyMatching()) {
 						int offset = textSelection.getOffset();
 
-						final var processor = new LSPRenameProcessor(document, executor, offset);
+						final var processor = new LSPRenameProcessor(document, offset);
 						final var refactoring = new ProcessorBasedRefactoring(processor);
 						final var wizard = new LSPRenameRefactoringWizard(refactoring);
 						final var operation = new RefactoringWizardOpenOperation(wizard);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameHandler.java
@@ -97,7 +97,7 @@ public class LSPRenameHandler extends AbstractHandler implements IHandler {
 				try {
 					isEnable = !LanguageServiceAccessor.getLanguageServers(document, LSPRenameHandler::isRenameProvider)
 							.get(50, TimeUnit.MILLISECONDS).isEmpty();
-				} catch (java.util.concurrent.ExecutionException | TimeoutException e) {
+				} catch (TimeoutException e) {
 
 					// in case the language servers take longer to kick in, defer the enablement to
 					// a later time
@@ -107,12 +107,14 @@ public class LSPRenameHandler extends AbstractHandler implements IHandler {
 								final var handleEvent = new HandlerEvent(this, enabled, false);
 								fireHandlerChanged(handleEvent);
 							});
-
 					isEnable = false;
 
 				} catch (InterruptedException e) {
 					LanguageServerPlugin.logError(e);
 					Thread.currentThread().interrupt();
+					isEnable = false;
+				} catch (java.util.concurrent.ExecutionException e) {
+					LanguageServerPlugin.logError(e);
 					isEnable = false;
 				}
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
@@ -28,7 +28,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServerWrapper;
-import org.eclipse.lsp4e.LanguageServers.LanguageServerDocumentExecutor;
+import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.internal.Pair;
 import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4j.PrepareRenameDefaultBehavior;
@@ -61,8 +61,6 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 	private final IDocument document;
 	private final int offset;
 
-	private final LanguageServerDocumentExecutor initialExecutor;
-
 	private LanguageServerWrapper refactoringServer;
 
 	private String newName;
@@ -70,9 +68,8 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 	private WorkspaceEdit rename;
 	private Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> prepareRenameResult;
 
-	public LSPRenameProcessor(@NonNull IDocument document, LanguageServerDocumentExecutor executor, int offset) {
+	public LSPRenameProcessor(@NonNull IDocument document, int offset) {
 		this.document = document;
-		this.initialExecutor = executor;
 		this.offset = offset;
 	}
 
@@ -111,7 +108,7 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 			params.setPosition(LSPEclipseUtils.toPosition(offset, document));
 
 
-			Optional<Pair<LanguageServerWrapper, Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>>> tmp = initialExecutor.withFilter(LSPRenameProcessor::isPrepareRenameProvider)
+			Optional<Pair<LanguageServerWrapper, Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior>>> tmp = LanguageServers.forDocument(document).withFilter(LSPRenameProcessor::isPrepareRenameProvider)
 				.computeFirst((w, ls) -> ls.getTextDocumentService().prepareRename(params).thenApply(result -> new Pair<>(w, result))).get(500, TimeUnit.MILLISECONDS);
 
 			if (tmp.isEmpty() || tmp.get().getSecond() == null) {


### PR DESCRIPTION
Ported rename to the new API. We need to make a slightly arbitrary choice of LS in the (fairly unlikely, in practice) case where more than one LS could do the rename. The old logic just picked the first LS that supported rename; I've changed this  slightly to pick the first LS that responds to the prepareRename phase and stick with that one.

I ran into some logic that had not been updated to account for the fact that `WorkspaceEdit`s can now consist of `DocumentEdit`s rather than `Edit`s, so have fixed that.

