### PR TITLE
Rename: Fix issue with rename wizard

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPRenameProcessor.java
@@ -169,7 +169,8 @@ public class LSPRenameProcessor extends RefactoringProcessor {
 			if (params.getNewName() != null) {
 				// TODO: how to manage ltk with CompletableFuture? Is 1000 ms is enough?
 				rename = languageServer.getTextDocumentService().rename(params).get(1000, TimeUnit.MILLISECONDS);
-				if (!status.hasError() && (rename == null || rename.getChanges().isEmpty())) {
+				if (!status.hasError() && (rename == null
+						|| (rename.getChanges().isEmpty() && rename.getDocumentChanges().isEmpty()))) {
 					status.addWarning(Messages.rename_empty_message);
 				}
 			}


### PR DESCRIPTION
The LS protocol now allows (and indeed prefers) a WorkspaceEdit to consist of DocumentChanges instead of Changes. Some old code was assuming that if there were no Changes then there was nothing to do. This mean a load of spurious 'no edits' warnings in the UI before the rename succeeded anyway.

Split out of #459 as not strictly related to the API port

@rubenporras FYI