### PR TITLE
New API: covariantly return null on failure path

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -257,7 +257,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 						LanguageServerPlugin.logError(e);
 					}
 				}
-				return CompletableFuture.completedFuture(wrapper);
+				return CompletableFuture.completedFuture(null);
 			});
 		}
 


### PR DESCRIPTION
@rubenporras this was a comment I made on #454 that I think arrived too late for you to notice.

If connect fails or returns null, then we should return null also in this method, not wrapper.

It's actually quite hard to provoke this error path when wrapper is not itself null, but for paranoia's sake I think we should still correct the logic here.
