### PR TITLE
Add URI to the Hyperlink label as default case

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/LSBasedHyperlink.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/LSBasedHyperlink.java
@@ -86,9 +86,7 @@ public class LSBasedHyperlink implements IHyperlink {
 				else if (uri.startsWith(LSPEclipseUtils.INTRO_URL)) {
 					return getIntroUrlBasedLabel(uri);
 				}
-				else if (uri.startsWith(LSPEclipseUtils.HTTP)) {
-					return getHttpBasedLabel(uri);
-				}
+				return getGenericUriBasedLabel(uri);
 			}
 		}
 
@@ -112,7 +110,7 @@ public class LSBasedHyperlink implements IHyperlink {
 		return Messages.hyperlinkLabel;
 	}
 
-	private String getHttpBasedLabel(String uri) {
+	private String getGenericUriBasedLabel(String uri) {
 		return Messages.hyperlinkLabel + " - " + uri; //$NON-NLS-1$
 	}
 


### PR DESCRIPTION
Add URI to the Hyperlink label as default case, since the protocol supports returning several locations for all schemas, we need to be able to present them on the UI in a way which they can be distinguished, in case there is more than one.