### PR TITLE
Fix NPE of CodeAction when resolve from ls return null.

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
@@ -69,7 +69,10 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 			try {
 				LanguageServerWrapper wrapper = definition != null ? LanguageServiceAccessor.getLSWrapper(marker.getResource().getProject(), definition) : null;
 				if (wrapper != null && CodeActionCompletionProposal.isCodeActionResolveSupported(wrapper.getServerCapabilities())) {
-					this.codeAction = wrapper.execute(ls -> ls.getTextDocumentService().resolveCodeAction(codeAction)).get(2, TimeUnit.SECONDS);
+					CodeAction resolvedCodeAction = wrapper.execute(ls -> ls.getTextDocumentService().resolveCodeAction(codeAction)).get(2, TimeUnit.SECONDS);
+					if (resolvedCodeAction != null) {
+						codeAction = resolvedCodeAction;
+					}
 				}
 			} catch (IOException | TimeoutException | ExecutionException | InterruptedException ex) {
 				LanguageServerPlugin.logError(ex);


### PR DESCRIPTION
In LemMinx we have a CodeAction which is used to generate an XSD/DTD/RNG file which returns:

 * a null text edit
 * a custom command which generates the grammar file

When code action is resolved, the LemMinx language server return null, because there are nothing to resolve. After that there is an NPE at https://github.com/eclipse/lsp4e/blob/91e9977a57afe0a6d4bd65fbc499551f3cabbd2f/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java#L78

This PR update the code action only if resolve return a non null code action.