### PR TITLE
Disable LSP rename handler for Java file

### DIFF
--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -104,7 +104,24 @@
             class="org.eclipse.lsp4e.operations.rename.LSPRenameHandler"
             commandId="org.eclipse.ui.edit.rename">
          <activeWhen>
-            <reference definitionId="org.eclipse.lsp4e.textSelectionHasLanguageServer" />
+            <and>
+               <!-- LSP rename handler is active when: -->
+               <!-- 1. The file is not a Java file to avoid conlict with JDT UI rename handler -->
+               <not>
+                 <with variable="editorInput">
+                    <or>
+                       <adapt type="org.eclipse.core.resources.IFile">
+                          <test property="org.eclipse.core.resources.contentTypeId" value="org.eclipse.jdt.core.javaSource" />                     
+                       </adapt>
+                       <adapt type="org.eclipse.jdt.core.IClassFile">
+                          <instanceof value="org.eclipse.jdt.core.IClassFile" />
+                       </adapt>
+                    </or>
+                 </with>
+              </not>
+              <!-- 2. The file is mapped with a language server -->
+              <reference definitionId="org.eclipse.lsp4e.textSelectionHasLanguageServer" />
+            </and>
          </activeWhen>
       </handler>
       <handler


### PR DESCRIPTION
This PR disable LSP rename handler for Java file. 

The problem has been reported here https://github.com/jbosstools/jbosstools-quarkus/issues/199

The JBoss Quarkus maps the MicroProfile language server to a Java file. Once the plugin is installed, it is not possible to use `Alt+Shift+R` because I think there is a conflict between LSP4E and JDT which is really annoying.

I have never seen some language server which support rename in Java file, it is the reason why this PR disable rename handler for Java file.