### PR TITLE
Semantic Highlighting: Merge rather than replace styles

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -285,7 +285,7 @@ public class SemanticHighlightReconcilerStrategy
 		documentTimestampAtLastAppliedTextPresentation = DocumentUtil.getDocumentModificationStamp(document);
 		IRegion extent = textPresentation.getExtent();
 		if (extent != null) {
-			textPresentation.replaceStyleRanges(styleRangeHolder.overlappingRanges(extent));
+			textPresentation.mergeStyleRanges(styleRangeHolder.overlappingRanges(extent));
 		}
 	}
 }


### PR DESCRIPTION
@rubenporras what do you think of this?

Semantic highlighting is causing problems with Coco's eclipse plugin. We don't use TM4e on the eclipse side, we have our own editor subclass and implement the various highlighting and bracket-matching hooks directly. Semantic highlighting assumes text mate highlighting is active (not unreasonably, since there needs to be some kind of assumed presentation for the server's tokenisation!) and clobbers everything else.

However, I've also observed similar behaviour with Corrosion (the Rust plugin, which I use in my lsp4e dev workspace as a de facto test harness). When you open a document you initially get colors from the TM highlighting, but when the semantic highlighting kicks in after a second or so, almost all of the colours get replaced as black.

Before:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/6334768/222769466-eace7cb8-117b-4e75-bd3a-b5ca9737c95e.png">

After short delay:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/6334768/222769529-8bfc8fc7-3822-46a2-8b40-480736e56754.png">


If I make the change in this PR then the result looks like this:

<img width="385" alt="image" src="https://user-images.githubusercontent.com/6334768/222769689-bfbd97fc-ff29-4668-b55d-cfd530933962.png">

 