### PR TITLE
Quick Fixes might arrive as empty list

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -156,7 +156,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 		CompletableFuture.allOf(
 				executeOnServers(fn)
 				.map(cf -> cf.thenApply(t -> {
-					if (!isEmpty(t)) { // TODO: Does this need to be a supplied function to handle all cases?
+					if (t != null) { // TODO: Does this need to be a supplied function to handle all cases?
 						result.complete(Optional.of(t));
 					}
 					return t;


### PR DESCRIPTION
Quick fixes for a problem marker shown fine if there are quick fixes available. However, if there are no quick fixes available an empty list of code actions is received on the lsp4e side. However, this result is ignored (this the chunk of code is changed by this PR) and therefore **Computing...** is shown indefnitely under quick fixes for problem that don't have a quick fix.