### PR TITLE
Use only cross-out for obsolete element

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/StyleUtil.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/StyleUtil.java
@@ -12,11 +12,7 @@
 package org.eclipse.lsp4e.internal;
 
 import org.eclipse.jface.viewers.StyledString.Styler;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.TextStyle;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.PlatformUI;
 
 public class StyleUtil {
 
@@ -24,18 +20,10 @@ public class StyleUtil {
 		// this class shouldn't be instantiated
 	}
 
-	private static Color darkGray;
-
-	static {
-		Display display = PlatformUI.getWorkbench().getDisplay();
-		display.asyncExec(() -> darkGray = display.getSystemColor(SWT.COLOR_DARK_GRAY));
-	}
-
 	public static final Styler DEPRECATE = new Styler() {
 		@Override
 		public void applyStyles(TextStyle textStyle) {
 			textStyle.strikeout = true;
-			textStyle.background = darkGray;
 		};
 	};
 }


### PR DESCRIPTION
This class could be running/initialized in non-UI Thread and the asyncExec can be blocked for a longer time.

Besides, colors are usually not the best way to emphasize on some semantics, a cross-out is clear enough.