### PR TITLE
Enable LSPSymbolInWorkspaceHandler only if LSP4E bundle is active

### DIFF
--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -131,6 +131,11 @@
       <handler
             class="org.eclipse.lsp4e.operations.symbols.LSPSymbolInWorkspaceHandler"
             commandId="org.eclipse.lsp4e.symbolinworkspace">
+         <activeWhen>
+            <reference
+                  definitionId="org.eclipse.lsp4e.textSelectionHasLanguageServer">
+            </reference>
+         </activeWhen>
       </handler>
       <handler
             commandId="org.eclipse.lsp4e.togglelinkwitheditor">


### PR DESCRIPTION
Fixes #38

`LSPSymbolInWorkspaceHandler.setEnabled(Object)` for updating the enable status will only be called by the framework when the bundle org.eclipse.lsp4e is active.

Without the now introduced check for `bundleState=ACTIVE` the conflicting key binding will not be filtered out by method `KeyBindingDispatcher.getExecutableMatches(KeySequence, IEclipseContext)` in bundle `org.eclipse.e4.ui.bindings`.

Before Eclipse Release 2022-12 the conflicting key binding for `Shift+Ctrl+T` didn't show up, because the bundle `org.eclipse.lsp4e` was always activated by a startup extension in `plugin.xml` and that is why conflict resolution in the `KeyBindingDispatcher` has worked. The use of this extension has been removed with a0dd75aeb405986e187c9a2b1325144e2afa9273. (Bundle activation status can easily checked with `ss lsp4e` in the _Host OSGi Console_.)

Note: This fix will not prevent a key binding conflict for `Shift+Ctrl+T` when LSPSymbolInWorkspaceHandler is enabled (e.g. in the Generic Editor for JavaScript). The conflict with `Shift+Alt+R` also needs a different solution.