### PR TITLE
New Rename command to resolve a key binding conflict for Shift+Alt+R

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
@@ -79,7 +79,7 @@ public class TestUtils {
 		IEditorInput input = new FileEditorInput(file);
 
 		IEditorPart part = page.openEditor(input, "org.eclipse.ui.genericeditor.GenericEditor", false);
-		part.setFocus();
+		page.activate(part);
 		return part;
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
@@ -60,7 +60,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.IWorkbenchCommandConstants;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
@@ -72,6 +71,8 @@ public class RenameTest {
 
 	@Rule public AllCleanRule clear = new AllCleanRule();
 
+	private static final String RENAME_COMMAND = "org.eclipse.lsp4e.rename";
+
 	@Test
 	public void testRenameHandlerEnablement() throws Exception {
 		IProject project = TestUtils.createProject("blah");
@@ -79,7 +80,7 @@ public class RenameTest {
 		ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
 		editor.selectAndReveal(1, 0);
 		ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
-		Command command = commandService.getCommand(IWorkbenchCommandConstants.FILE_RENAME);
+		Command command = commandService.getCommand(RENAME_COMMAND);
 		assertTrue(command.isEnabled());
 		assertTrue(command.isHandled());
 	}
@@ -98,7 +99,7 @@ public class RenameTest {
 		ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
 		editor.selectAndReveal(1, 0);
 		ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
-		Command command = commandService.getCommand(IWorkbenchCommandConstants.FILE_RENAME);
+		Command command = commandService.getCommand(RENAME_COMMAND);
 		assertFalse(command.isEnabled() && command.isHandled());
 
 		Thread.sleep(delay * 3);
@@ -225,7 +226,7 @@ public class RenameTest {
 		editor.selectAndReveal(1, 0);
 		ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
 		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
-		Command command = commandService.getCommand(IWorkbenchCommandConstants.FILE_RENAME);
+		Command command = commandService.getCommand(RENAME_COMMAND);
 		assertTrue(command.isEnabled() && command.isHandled());
 		Event e = new Event();
 		e.widget = editor.getAdapter(Control.class);

--- a/org.eclipse.lsp4e/plugin.properties
+++ b/org.eclipse.lsp4e/plugin.properties
@@ -29,5 +29,7 @@ command.toggle.outline.sort.name = Sort
 command.toggle.outline.sort.label = Sort
 command.open.call.hierarchy.name = Open Call Hierarchy
 command.open.call.hierarchy.description = Open Call Hierarchy for the selected item
+command.rename.name = Rename Symbol
+command.rename.description = Rename the selected symbol
 markers.name = Language Servers
 

--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -96,6 +96,12 @@
             id="org.eclipse.lsp4e.openCallHierarchy"
             name="%command.open.call.hierarchy.name">
       </command>
+      <command
+            categoryId="org.eclipse.lsp4e.category"
+            description="%command.rename.description"
+            id="org.eclipse.lsp4e.rename"
+            name="%command.rename.name">
+      </command>
    </extension>
    <extension
          point="org.eclipse.ui.handlers">
@@ -108,7 +114,7 @@
       </handler>
       <handler
             class="org.eclipse.lsp4e.operations.rename.LSPRenameHandler"
-            commandId="org.eclipse.ui.edit.rename">
+            commandId="org.eclipse.lsp4e.rename">
          <activeWhen>
             <reference definitionId="org.eclipse.lsp4e.textSelectionHasLanguageServer" />
          </activeWhen>
@@ -187,7 +193,7 @@
          <menu
                label="%refactorings.menu.label">
             <command
-                  commandId="org.eclipse.ui.edit.rename"
+                  commandId="org.eclipse.lsp4e.rename"
                   style="push">
             </command>
             <separator
@@ -329,7 +335,7 @@
       <!-- refactoring -->
       <key
             sequence="M2+M3+R"
-            commandId="org.eclipse.ui.edit.rename"
+            commandId="org.eclipse.lsp4e.rename"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
       </key>
       <key
@@ -341,7 +347,7 @@
       <key
             platform="carbon"
             sequence="COMMAND+ALT+R"
-            commandId="org.eclipse.ui.edit.rename"
+            commandId="org.eclipse.lsp4e.rename"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
       </key>
       <key


### PR DESCRIPTION
From the discussion of: eclipse-jdt/eclipse.jdt.ui/pull/443

The key binding `Shift+Alt+R` should not be added to the existing command `org.eclipse.ui.edit.rename` (with existing key binding `F2`), because this leads to an ambiguity when using `Shift+Alt+R` in the **Package Explorer** from JDT UI. `Shift+Alt+R` would be associated with two commands:

  * `org.eclipse.ui.edit.rename` (Rename)
  * `org.eclipse.jdt.ui.edit.text.java.rename.element` (Rename - Refactoring)

Introducing an own command ID for rename in LSP4E and adding the key binding `Shift+Alt+R` only to this new command resolves this ambiguity. The new command is only available in the LSP4E Editor because its handler already has an appropriate activeWhen condition.