### PR TITLE
Limit the key binding Shift+Alt+R for Rename to the Generic Text Editor

### DIFF
--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -330,18 +330,21 @@
       <key
             sequence="M2+M3+R"
             commandId="org.eclipse.ui.edit.rename"
+            contextId="org.eclipse.ui.genericeditor.genericEditorContext"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
       </key>
       <key
             platform="carbon"
             sequence="M2+M3+R"
             commandId=""
+            contextId="org.eclipse.ui.genericeditor.genericEditorContext"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
       </key>
       <key
             platform="carbon"
             sequence="COMMAND+ALT+R"
             commandId="org.eclipse.ui.edit.rename"
+            contextId="org.eclipse.ui.genericeditor.genericEditorContext"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
       </key>
       <key


### PR DESCRIPTION
Limiting the applicability of the key binding for the Rename command with ID `org.eclipse.ui.edit.rename` to the _Generic Text Editor_ reduces conflicts with commands from other plug-ins using the same key combination (e.g. `org.eclipse.jdt.ui.edit.text.java.rename.element` from JDT UI).