### PR TITLE
Delay document->LS connection

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -54,7 +54,9 @@ public class ConnectDocumentToLanguageServerSetupParticipant implements IDocumen
 			return;
 		}
 		// Force document connect
-		PENDING_CONNECTIONS.put(LanguageServers.forDocument(document).collectAll(ls -> CompletableFuture.completedFuture(null)), null);
+		CompletableFuture.runAsync(
+				() -> PENDING_CONNECTIONS.put(LanguageServers.forDocument(document).collectAll(ls -> CompletableFuture.completedFuture(null)), null),
+				CompletableFuture.delayedExecutor(1, TimeUnit.SECONDS)); // delay to ensure the document is initialized and can be resolved by LSPEclipseUtils.toUri
 	}
 
 	/**


### PR DESCRIPTION
When requested too early during document initialization, resolution of Document to URI is failing. So we add a delay to let document complete initialization.

Fixes https://github.com/eclipse/lsp4e/issues/560