### PR TITLE
ask for active editor directly to deal with multipart editors

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/LSPDocumentAbstractHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/LSPDocumentAbstractHandler.java
@@ -94,7 +94,8 @@ public abstract class LSPDocumentAbstractHandler extends AbstractHandler {
 	}
 
 	protected void setEnabled(final @NonNull Predicate<ServerCapabilities> filter, Predicate<ITextEditor> condition) {
-		if (UI.getActivePart() instanceof ITextEditor textEditor && condition.test(textEditor)) {
+		ITextEditor textEditor = UI.getActiveTextEditor();
+		if (textEditor != null && condition.test(textEditor)) {
 			IDocument document = LSPEclipseUtils.getDocument(textEditor);
 			if (document != null) {
 				setBaseEnabled(new LanguageServerDocumentHandlerExecutor(document)


### PR DESCRIPTION
the format action is disabled in the `pom.xml` editor since some refactorings and changes to the action handlers. The underlying reason why the actions are disabled in the `pom.xml` editor is because the new abstract handler doesn't take multipart editors into account.