### PR TITLE
remove error from the log when the sleep during read is interrupted, as

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LaunchConfigurationStreamProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LaunchConfigurationStreamProvider.java
@@ -82,7 +82,6 @@ public class LaunchConfigurationStreamProvider implements StreamConnectionProvid
 				try {
 					Thread.sleep(5, 0);
 				} catch (InterruptedException e) {
-					LanguageServerPlugin.logError(e);
 					Thread.currentThread().interrupt();
 				}
 			}


### PR DESCRIPTION
the code nicely handles the situation by checking the queue again.