### PR TITLE
[#638] Fix outline view for external files

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/TestUtils.java
@@ -49,6 +49,7 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 
@@ -79,6 +80,14 @@ public class TestUtils {
 		IEditorInput input = new FileEditorInput(file);
 
 		IEditorPart part = page.openEditor(input, "org.eclipse.ui.genericeditor.GenericEditor", false);
+		part.setFocus();
+		return part;
+	}
+	
+	public static IEditorPart openExternalFileInEditor(File file) throws PartInitException {
+		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
+		IWorkbenchPage page = workbenchWindow.getActivePage();	
+		IEditorPart part = IDE.openEditor(page, file.toURI(), "org.eclipse.ui.genericeditor.GenericEditor", false);
 		part.setFocus();
 		return part;
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -88,7 +88,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			} else {
 				IFile file = LSPEclipseUtils.getFile(path);
 				documentFile = file;
-				documentURI = file == null ? null : LSPEclipseUtils.toUri(file);
+				documentURI = file == null ? path.toFile().toURI() : LSPEclipseUtils.toUri(file);
 			}
 			this.wrapper = wrapper;
 			this.textEditor = textEditor;
@@ -244,7 +244,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 		isQuickOutline = Boolean.TRUE.equals(viewer.getData(VIEWER_PROPERTY_IS_QUICK_OUTLINE));
 
 		outlineViewerInput = (OutlineViewerInput) newInput;
-		symbolsModel.setFile(outlineViewerInput.documentFile);
+		symbolsModel.setDocument(outlineViewerInput.document);
 
 		// eagerly refresh the content tree, esp. important for the Quick Outline
 		// because otherwise the outline will be blank for 1-2 seconds initially

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeListener;
@@ -142,7 +141,7 @@ public class SymbolsLabelProvider extends LabelProvider
 		} else if (element instanceof WorkspaceSymbol symbol) {
 			file = LSPEclipseUtils.findResourceFor(getUri(symbol));
 		} else if (element instanceof DocumentSymbolWithFile symbolWithFile) {
-			file = symbolWithFile.file;
+			file = LSPEclipseUtils.getFile(symbolWithFile.document);
 		}
 		/*
 		 * Implementation node: for problem decoration,m aybe consider using a ILabelDecorator/IDelayedLabelDecorator?
@@ -295,10 +294,7 @@ public class SymbolsLabelProvider extends LabelProvider
 			name = symbolWithFile.symbol.getName();
 			kind = symbolWithFile.symbol.getKind();
 			detail = symbolWithFile.symbol.getDetail();
-			IFile file = symbolWithFile.file;
-			if (file != null) {
-				location = file.getLocationURI();
-			}
+			location = LSPEclipseUtils.toUri(symbolWithFile.document);
 		}
 		if (name != null) {
 			res.append(name, null);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsModel.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsModel.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Location;
@@ -40,27 +40,27 @@ public class SymbolsModel {
 	private volatile List<DocumentSymbol> rootSymbols = Collections.emptyList();
 	private final Map<DocumentSymbol, DocumentSymbol> parent = new HashMap<>();
 
-	private IFile file;
+	private IDocument document;
 
 	public static class DocumentSymbolWithFile {
 		public final DocumentSymbol symbol;
-		public final @NonNull IFile file;
+		public final @NonNull IDocument document;
 
-		public DocumentSymbolWithFile(DocumentSymbol symbol, @NonNull IFile file) {
+		public DocumentSymbolWithFile(DocumentSymbol symbol, @NonNull IDocument document) {
 			this.symbol = symbol;
-			this.file = file;
+			this.document = document;
 		}
 
 		@Override
 		public boolean equals(Object obj) {
 			return obj instanceof DocumentSymbolWithFile other && //
 					Objects.equals(this.symbol, other.symbol) && //
-					Objects.equals(this.file, other.file);
+					Objects.equals(this.document, other.document);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(this.file, this.symbol);
+			return Objects.hash(this.document, this.symbol);
 		}
 	}
 
@@ -141,7 +141,7 @@ public class SymbolsModel {
 
 	public Object[] getElements() {
 		final var res = new ArrayList<Object>(Arrays.asList(getChildren(ROOT_SYMBOL_INFORMATION)));
-		final IFile current = this.file;
+		final IDocument current = this.document;
 		Function<DocumentSymbol, Object> mapper = current != null ?
 				symbol -> new DocumentSymbolWithFile(symbol, current) :
 				symbol -> symbol;
@@ -160,7 +160,7 @@ public class SymbolsModel {
 				List<DocumentSymbol> children = element.symbol.getChildren();
 				if (children != null && !children.isEmpty()) {
 					return element.symbol.getChildren().stream()
-						.map(symbol -> new DocumentSymbolWithFile(symbol, element.file)).toArray();
+						.map(symbol -> new DocumentSymbolWithFile(symbol, element.document)).toArray();
 				}
 			}
 		}
@@ -195,16 +195,16 @@ public class SymbolsModel {
 			return parent.get(element);
 		} else if (element instanceof DocumentSymbolWithFile) {
 			DocumentSymbol parentSymbol = parent.get(element);
-			final IFile theFile = this.file;
-			if (parentSymbol != null && theFile != null) {
-				return new DocumentSymbolWithFile(parentSymbol, theFile);
+			final IDocument theDocument = this.document;
+			if (parentSymbol != null && theDocument != null) {
+				return new DocumentSymbolWithFile(parentSymbol, theDocument);
 			}
 		}
 		return null;
 	}
 
-	public void setFile(IFile file) {
-		this.file = file;
+	public void setDocument(IDocument document) {
+		this.document = document;
 	}
 
 	public TreePath toUpdatedSymbol(TreePath initialSymbol) {


### PR DESCRIPTION
Fixes #638
Since there is no IFile object for a file outside the workspace, replaced
IFile by IDocument in DocumentSymbolWithFile. Maybe rename DocumentSymbolWithFile into DocumentSymbolWithDocument?