### PR TITLE
Make Outline view works for documents with custom URI

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -559,11 +559,7 @@ public final class LSPEclipseUtils {
 		if (resource != null) {
 			return getDocument(resource);
 		}
-		if (!fromUri(uri).isFile()) {
-			return null;
-		}
-
-
+	
 		IDocument document = null;
 		IFileStore store = null;
 		try {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc. and others.
+ * Copyright (c) 2017, 2023 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -14,6 +14,7 @@
 package org.eclipse.lsp4e.outline;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -53,6 +54,7 @@ import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.navigator.ICommonContentExtensionSite;
@@ -82,9 +84,17 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 		public OutlineViewerInput(IDocument document, @NonNull LanguageServerWrapper wrapper, @Nullable ITextEditor textEditor) {
 			this.document = document;
 			IPath path = LSPEclipseUtils.toPath(document);
+			TextDocumentIdentifier docIdentifier = LSPEclipseUtils.toTextDocumentIdentifier(document);
 			if (path == null) {
 				documentFile = null;
-				documentURI = null;
+				URI uri;
+				// Set the documentURI if valid URI for LSs that use custom protocols e.g. jdt://
+				try {
+					uri = new URI(docIdentifier.getUri());
+				} catch (URISyntaxException e) {
+					uri = null;
+				}
+				documentURI = uri;
 			} else {
 				IFile file = LSPEclipseUtils.getFile(path);
 				documentFile = file;


### PR DESCRIPTION
JDT.ls uses custom protocol for sources coming from jvm/jar files (e.g. jdt://contents/java.base/java.lang/Appendable.class?=proba/%5C/usr%5C/lib%5C/jvm%5C/java-17-openjdk-17.0.7.0.7-5.fc38.x86_64%5C/lib%5C/jrt-fs.jar%60java.base=/javadoc_location=/https:%5C/%5C/docs.oracle.com%5C/en%5C/java%5C/javase%5C/17%5C/docs%5C/api%5C/=/%3Cjava.lang(Appendable.class ) which is retrievable from ITextFileBuffer if/when custom EFS for the protocol is provided.
Extra change was required in LSPEclipseUtils.getDocument(URI) which wrongly assumed that every IDocument has to be backed by file.