### PR TITLE
LSPDiagnosticsToMarker: Handle subtypes

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -137,7 +137,7 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 			@Override
 			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
 				final var toDeleteMarkers = new HashSet<IMarker>(
-						Arrays.asList(resource.findMarkers(markerType, false, IResource.DEPTH_ZERO)));
+						Arrays.asList(resource.findMarkers(markerType, true, IResource.DEPTH_ZERO)));
 				toDeleteMarkers
 						.removeIf(marker -> !Objects.equals(marker.getAttribute(LANGUAGE_SERVER_ID, ""), languageServerId)); //$NON-NLS-1$
 				final var newDiagnostics = new ArrayList<Diagnostic>();


### PR DESCRIPTION
Changes LSPDiagnosticsToMarker to consider subtypes of the specified markerType so it is possible to customize the marker type based on diagnostic attributes (e.g. in a workspace change listener).

See issue #645.