### PR TITLE
re-add DSPLaunchDelegate.createDebugTarget(...) as deprecated method

### DIFF
--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
@@ -384,8 +384,26 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 	 * of {@link DSPDebugTarget}, but does not have to be. The arguments to this
 	 * method are normally just passed to {@link DSPDebugTarget} constructor.
 	 */
-	protected IDebugTarget createDebugTarget(SubMonitor subMonitor, Supplier<TransportStreams> streamsSupplier, ILaunch launch, Map<String, Object> dspParameters) throws CoreException {
-		final var target = new DSPDebugTarget(launch, streamsSupplier, dspParameters);
+	protected IDebugTarget createDebugTarget(SubMonitor subMonitor, Supplier<TransportStreams> streamsSupplier,
+			ILaunch launch, Map<String, Object> dspParameters) throws CoreException {
+		/*
+		 * TODO use the following code when removing createDebugTarget deprecated
+		 * final var target = new DSPDebugTarget(launch, streamsSupplier,
+		 * dspParameters); target.initialize(subMonitor.split(80)); return target;
+		 * return target;
+		 */
+		final var supplier = streamsSupplier.get();
+		return createDebugTarget(subMonitor, supplier::close, supplier.in, supplier.out, launch, dspParameters);
+	}
+
+	/**
+	 * @deprecated use
+	 *             {@link #createDebugTarget(SubMonitor, Supplier, ILaunch, Map)}
+	 */
+	@Deprecated(since = "0.15.2", forRemoval = true)
+	protected IDebugTarget createDebugTarget(SubMonitor subMonitor, Runnable cleanup, InputStream inputStream,
+			OutputStream outputStream, ILaunch launch, Map<String, Object> dspParameters) throws CoreException {
+		final var target = new DSPDebugTarget(launch, cleanup, inputStream, outputStream, dspParameters);
 		target.initialize(subMonitor.split(80));
 		return target;
 	}


### PR DESCRIPTION
The signature of the public API method `DSPLaunchDelegate.createDebugTarget` was changed by 1e5244520850d07c449ca1d5007c2e05196c1cad resulting in compile / linkage errors in our projects where we need to override it.

This PR re-adds the method with the old signature as deprecated to allow graceful API transition phase.
