### PR TITLE
Fix "mark occurrences" not working because of NPE

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.16.1.qualifier
+Bundle-Version: 0.16.2.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.16.1-SNAPSHOT</version>
+	<version>0.16.2-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
@@ -26,6 +26,7 @@ import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
 import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
@@ -223,7 +224,10 @@ public class HighlightReconcilingStrategy
 	 * @param annotationModel
 	 *            annotation model to update.
 	 */
-	private void updateAnnotations(List<? extends DocumentHighlight> highlights, IAnnotationModel annotationModel) {
+	private void updateAnnotations(@Nullable List<? extends DocumentHighlight> highlights, IAnnotationModel annotationModel) {
+		if (highlights == null)
+			return;
+
 		final var annotationMap = new HashMap<Annotation, org.eclipse.jface.text.Position>(highlights.size());
 		for (DocumentHighlight h : highlights) {
 			if (h != null) {
@@ -285,7 +289,10 @@ public class HighlightReconcilingStrategy
 		}
 	}
 
-	private String kindToAnnotationType(DocumentHighlightKind kind) {
+	private String kindToAnnotationType(@Nullable DocumentHighlightKind kind) {
+		if (kind == null)
+			return TEXT_ANNOTATION_TYPE;
+
 		return switch (kind) {
 		case Read -> READ_ANNOTATION_TYPE;
 		case Write -> WRITE_ANNOTATION_TYPE;


### PR DESCRIPTION
I realized that "mark occurrences" was not working (at least with the Haxe and Dart Language Servers).

The reason are silently swallowed NPEs in the HighlightReconcilingStrategy. Adding two null guards restored the functionality.