### PR TITLE
fix: run apply edits in UI thread

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -64,6 +64,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.junit.Assert;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -582,7 +582,7 @@ public final class LSPEclipseUtils {
 		if (resource != null) {
 			return getDocument(resource);
 		}
-	
+
 		IDocument document = null;
 		IFileStore store = null;
 		try {
@@ -960,15 +960,18 @@ public final class LSPEclipseUtils {
 			.map(LSPEclipseUtils::getDocument)
 			.filter(Objects::nonNull)
 			.findFirst();
+
 		doc.ifPresent(document -> {
-			try {
-				LSPEclipseUtils.applyEdits(document, firstDocumentEdits);
-			} catch (BadLocationException ex) {
-				LanguageServerPlugin.logError(ex);
-			}
+			UI.getDisplay().syncExec(() -> {
+				try {
+					LSPEclipseUtils.applyEdits(document, firstDocumentEdits);
+				} catch (BadLocationException ex) {
+					LanguageServerPlugin.logError(ex);
+				}
+			});
 		});
 		return doc.isPresent();
-	} 
+	}
 
 	/**
 	 * Returns a ltk {@link CompositeChange} from a lsp {@link WorkspaceEdit}.

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -120,9 +120,7 @@ public class LanguageClientImpl implements LanguageClient {
 			final var job = new Job(Messages.serverEdit) {
 				@Override
 				public IStatus run(IProgressMonitor monitor) {
-					UI.getDisplay().syncExec(() -> {
-						LSPEclipseUtils.applyWorkspaceEdit(params.getEdit(), params.getLabel());
-					});
+					LSPEclipseUtils.applyWorkspaceEdit(params.getEdit(), params.getLabel());
 					return Status.OK_STATUS;
 				}
 			};

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -120,7 +120,9 @@ public class LanguageClientImpl implements LanguageClient {
 			final var job = new Job(Messages.serverEdit) {
 				@Override
 				public IStatus run(IProgressMonitor monitor) {
-					LSPEclipseUtils.applyWorkspaceEdit(params.getEdit(), params.getLabel());
+					UI.getDisplay().syncExec(() -> {
+						LSPEclipseUtils.applyWorkspaceEdit(params.getEdit(), params.getLabel());
+					});
 					return Status.OK_STATUS;
 				}
 			};


### PR DESCRIPTION
The edits must be applied while running in UI thread, else an `InvalidThreadAccess` exception is thrown.