### PR TITLE
Removal of all APIs that expose the language server object.

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
@@ -26,6 +26,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
@@ -62,8 +63,7 @@ public class DynamicRegistrationTest {
 		// Make sure mock language server is created...
 		IDocument document = LSPEclipseUtils.getDocument(testFile);
 		assertNotNull(document);
-		LanguageServiceAccessor.getLanguageServers(document, null).get(1,
-				TimeUnit.SECONDS);
+		LanguageServers.forDocument(document).anyMatching();
 		getMockClient();
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidCloseTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidCloseTest.java
@@ -23,7 +23,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -48,7 +48,7 @@ public class DocumentDidCloseTest {
 		// Force LS to initialize and open file
 		IDocument document = LSPEclipseUtils.getDocument(testFile);
 		assertNotNull(document);
-		LanguageServiceAccessor.getLanguageServers(document, capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(document).anyMatching();
 
 		final var didCloseExpectation = new CompletableFuture<DidCloseTextDocumentParams>();
 		MockLanguageServer.INSTANCE.setDidCloseCallback(didCloseExpectation);
@@ -65,7 +65,7 @@ public class DocumentDidCloseTest {
 		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(testFile.toURI()));
 
 		// Force LS to initialize and open file
-		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(editor.getEditorInput()), capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(LSPEclipseUtils.getDocument(editor.getEditorInput())).anyMatching();
 
 		final var didCloseExpectation = new CompletableFuture<DidCloseTextDocumentParams>();
 		MockLanguageServer.INSTANCE.setDidCloseCallback(didCloseExpectation);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidOpenTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidOpenTest.java
@@ -24,7 +24,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -59,7 +59,7 @@ public class DocumentDidOpenTest {
 		// Force LS to initialize and open file
 		IDocument document = LSPEclipseUtils.getDocument(testFile);
 		assertNotNull(document);
-		LanguageServiceAccessor.getLanguageServers(document, capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(document).anyMatching();
 
 		DidOpenTextDocumentParams lastOpen = didOpenExpectation.get(1000, TimeUnit.MILLISECONDS);
 		assertNotNull(lastOpen.getTextDocument());
@@ -73,7 +73,7 @@ public class DocumentDidOpenTest {
 		MockLanguageServer.INSTANCE.setDidOpenCallback(didOpenExpectation);
 		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
 		// Force LS to initialize and open file
-		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(editor.getEditorInput()), capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(LSPEclipseUtils.getDocument(editor.getEditorInput())).anyMatching();
 
 		DidOpenTextDocumentParams lastOpen = didOpenExpectation.get(1000, TimeUnit.MILLISECONDS);
 		assertNotNull(lastOpen.getTextDocument());
@@ -92,7 +92,7 @@ public class DocumentDidOpenTest {
 		// Force LS to initialize and open file
 		IDocument document = LSPEclipseUtils.getDocument(testFile);
 		assertNotNull(document);
-		LanguageServiceAccessor.getLanguageServers(document, capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(document).anyMatching();
 
 		DidOpenTextDocumentParams lastOpen = didOpenExpectation.get(1000, TimeUnit.MILLISECONDS);
 		assertNotNull(lastOpen.getTextDocument());

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidSaveTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidSaveTest.java
@@ -28,7 +28,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -62,7 +62,7 @@ public class DocumentDidSaveTest {
 		// Force LS to initialize and open file
 		IDocument document = LSPEclipseUtils.getDocument(testFile);
 		assertNotNull(document);
-		LanguageServiceAccessor.getLanguageServers(document, capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(document).anyMatching();
 		final var didSaveExpectation = new CompletableFuture<DidSaveTextDocumentParams>();
 		MockLanguageServer.INSTANCE.setDidSaveCallback(didSaveExpectation);
 
@@ -88,7 +88,7 @@ public class DocumentDidSaveTest {
 //			testFile.setLocalTimeStamp(0);
 
 		// Force LS to initialize and open file
-		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(editor.getEditorInput()), capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(LSPEclipseUtils.getDocument(editor.getEditorInput())).anyMatching();
 		final var didSaveExpectation = new CompletableFuture<DidSaveTextDocumentParams>();
 		MockLanguageServer.INSTANCE.setDidSaveCallback(didSaveExpectation);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentEditAndUndoTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentEditAndUndoTest.java
@@ -24,7 +24,7 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.TextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -66,7 +66,7 @@ public class DocumentEditAndUndoTest {
 		IEditorPart editor = TestUtils.openEditor(testFile);
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		// Force LS to initialize and open file
-		LanguageServiceAccessor.getLanguageServers(LSPEclipseUtils.getDocument(testFile), capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(LSPEclipseUtils.getDocument(testFile)).anyMatching();
 
 		System.out.println("Document initial:\t[" + viewer.getDocument().get() + "]");
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentRevertAndCloseTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentRevertAndCloseTest.java
@@ -21,7 +21,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -53,7 +53,7 @@ public class DocumentRevertAndCloseTest {
 		// Force LS to initialize and open file
 		IDocument document = LSPEclipseUtils.getDocument(testFile);
 		assertNotNull(document);
-		LanguageServiceAccessor.getLanguageServers(document, capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(document).anyMatching();
 
 		viewer.getDocument().replace(0, 0, "Bye!");
 		((AbstractTextEditor)editor).doRevertToSaved();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
@@ -25,7 +25,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -68,7 +68,7 @@ public class DocumentWillSaveWaitUntilTest {
 		// Force LS to initialize and open file
 		IDocument document = LSPEclipseUtils.getDocument(testFile);
 		assertNotNull(document);
-		LanguageServiceAccessor.getLanguageServers(document, capabilites -> Boolean.TRUE);
+		LanguageServers.forDocument(document).anyMatching();
 
 		// simulate change in file
 		viewer.getDocument().replace(0, 0, oldText);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -975,7 +975,10 @@ public class LanguageServerWrapper {
 		}
 	}
 
-	int getVersion(URI uri) {
+	/**
+	 * return the TextDocument version, suitable to build a TextDocumentIndentifier
+	 */
+	public int getTextDocumentVersion(URI uri) {
 		DocumentContentSynchronizer documentContentSynchronizer = connectedDocuments.get(uri);
 		if (documentContentSynchronizer != null) {
 			return documentContentSynchronizer.getVersion();


### PR DESCRIPTION
Removal of all APIs that expose the language server object.

The test LanguageServiceAccessorTest.testStatusHandlerLSAsRunConfiguration
has been deleted as it cannot be reliably tested, it depends on creation
of the stream provider in LanguageServerWrapper#start, which happens in
a background thread.

The method LanguageServerWrapper#getVersion has been renamed and made public as a
replacement of the marked for removal class `LSPDocumentInfo`, which can be used to
indirectly get access to the until now private method.