### PR TITLE
Get initialization options from document uri

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -260,7 +260,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 		 * Test whether this server supports the requested <code>ServerCapabilities</code>.
 		 */
 		private @NonNull CompletableFuture<@Nullable LanguageServerWrapper> filter(@NonNull LanguageServerWrapper wrapper) {
-			return wrapper.getInitializedServer()
+			return wrapper.getInitializedServer(LSPEclipseUtils.toUri(document))
 					.thenCompose(server -> CompletableFuture
 							.completedFuture(server != null && getFilter().test(wrapper.getServerCapabilities())))
 					.thenApply(matches -> matches ? wrapper: null);
@@ -316,7 +316,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 			Collection<@NonNull LanguageServerWrapper> startedWrappers = order(LanguageServiceAccessor.getStartedWrappers(project, getFilter(), !restartStopped));
 			List<@NonNull CompletableFuture<LanguageServerWrapper>> wrappers = new ArrayList<>(startedWrappers.size());
 			for (LanguageServerWrapper wrapper :  startedWrappers) {
-				wrappers.add(wrapper.getInitializedServer().thenApply(ls -> wrapper));
+				wrappers.add(wrapper.getInitializedServer(null).thenApply(ls -> wrapper));
 			}
 			return wrappers;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LoggingStreamConnectionProviderProxy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LoggingStreamConnectionProviderProxy.java
@@ -227,6 +227,11 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 	}
 
 	@Override
+	public Object getInitializationOptionsFromUri(@Nullable URI initialUri) {
+		return provider.getInitializationOptionsFromUri(initialUri);
+	}
+
+	@Override
 	public String getTrace(@Nullable URI rootUri) {
 		return provider.getTrace(rootUri);
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
@@ -76,7 +76,7 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 			if (definition != null) {
 				IResource resource = marker.getResource();
 				if (resource != null) {
-					wrapper = LanguageServiceAccessor.getLSWrapper(resource.getProject(), definition);
+					wrapper = LanguageServiceAccessor.getLSWrapper(resource.getProject(), definition, resource.getLocationURI());
 				}
 			}
 			if (wrapper != null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CommandMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CommandMarkerResolution.java
@@ -60,7 +60,7 @@ public class CommandMarkerResolution extends WorkbenchMarkerResolution implement
 		}
 
 		try {
-			LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrapper(resource.getProject(), definition);
+			LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrapper(resource.getProject(), definition, resource.getLocationURI());
 			if (wrapper != null) {
 				ExecuteCommandOptions provider = wrapper.getServerCapabilities().getExecuteCommandProvider();
 				if (provider != null && provider.getCommands().contains(command.getCommand())) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/StreamConnectionProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/StreamConnectionProvider.java
@@ -109,6 +109,14 @@ public interface StreamConnectionProvider {
 	}
 
 	/**
+	 * User provided initialization options from initial uri.
+	 * Will be called when the {@link #getInitializationOptions(URI)} returns null.
+	 */
+	public default Object getInitializationOptionsFromUri(@Nullable URI initialUri){
+		return null;
+	}
+
+	/**
 	 * Returns an object that describes the experimental features supported
 	 * by the client.
 	 * @implNote The returned object gets serialized by LSP4J, which itself uses


### PR DESCRIPTION
For some LS the determination of LS initialization options depends on the first uri to be opened and not on the first project or path. Therefor the
getInitializationOptionsFromUri(URI) method has been added to the StreamConnectionProvider interface. It will be called when getInitializationOptions(URI) returns null.

fixes #683 #684