### PR TITLE
remove deprecated DocumentSymbolWithFile#file field

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
@@ -30,7 +30,7 @@ import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.outline.CNFOutlinePage;
 import org.eclipse.lsp4e.outline.EditorToOutlineAdapterFactory;
-import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4e.test.AllCleanRule;
 import org.eclipse.lsp4e.test.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -80,7 +80,7 @@ public class OutlineContentTest {
 		waitForAndAssertCondition(5_000, tree.getDisplay(), //
 				() -> Arrays.asList(symbolCow) //
 						.equals(Arrays.stream(tree.getItems())
-								.map(e -> ((DocumentSymbolWithFile) e.getData()).symbol)
+								.map(e -> ((DocumentSymbolWithURI) e.getData()).symbol)
 								.toList()) //
 		);
 
@@ -122,7 +122,7 @@ public class OutlineContentTest {
 		waitForAndAssertCondition(5_000, tree.getDisplay(), //
 				() -> Arrays.asList(symbolCow, symbolFox, symbolCat) //
 						.equals(Arrays.stream(tree.getItems())
-								.map(e -> ((DocumentSymbolWithFile) e.getData()).symbol)
+								.map(e -> ((DocumentSymbolWithURI) e.getData()).symbol)
 								.toList()) //
 		);
 
@@ -133,7 +133,7 @@ public class OutlineContentTest {
 		waitForAndAssertCondition(5_000, tree.getDisplay(), //
 				() -> Arrays.asList(symbolCat, symbolCow, symbolFox) //
 						.equals(Arrays.stream(tree.getItems())
-								.map(e -> ((DocumentSymbolWithFile) e.getData()).symbol)
+								.map(e -> ((DocumentSymbolWithURI) e.getData()).symbol)
 								.toList()) //
 		);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsLabelProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsLabelProviderTest.java
@@ -11,8 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.outline;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.eclipse.lsp4e.outline.SymbolsLabelProvider;
 import org.eclipse.lsp4e.outline.SymbolsModel;
@@ -66,7 +65,7 @@ public class SymbolsLabelProviderTest {
 		SymbolInformation info = new SymbolInformation("Foo", SymbolKind.Class, INVALID_LOCATION);
 		assertEquals("Foo", labelProvider.getStyledText(info).getString());
 	}
-	
+
 	@Test
 	public void testDocumentSymbolDetail () {
 		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
@@ -74,7 +73,7 @@ public class SymbolsLabelProviderTest {
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
-		assertEquals("Foo : additional detail", labelProvider.getStyledText(info).getString());		
+		assertEquals("Foo : additional detail", labelProvider.getStyledText(info).getString());
 	}
 
 	@Test
@@ -84,18 +83,18 @@ public class SymbolsLabelProviderTest {
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
-		assertEquals("Foo : additional detail :Class", labelProvider.getStyledText(info).getString());		
+		assertEquals("Foo : additional detail :Class", labelProvider.getStyledText(info).getString());
 	}
 
 	@Test
-	public void testDocumentSymbolWithFileDetail () {
+	public void testDocumentSymbolWithUriDetail () {
 		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
 		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
-		SymbolsModel.DocumentSymbolWithFile infoWithFile = new SymbolsModel.DocumentSymbolWithFile(info, null);
-		assertEquals("Foo : additional detail", labelProvider.getStyledText(infoWithFile).getString());		
+		final var symbolWithURI = new SymbolsModel.DocumentSymbolWithURI(info, null);
+		assertEquals("Foo : additional detail", labelProvider.getStyledText(symbolWithURI).getString());
 	}
 
 	@Test
@@ -105,10 +104,10 @@ public class SymbolsLabelProviderTest {
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
-		SymbolsModel.DocumentSymbolWithFile infoWithFile = new SymbolsModel.DocumentSymbolWithFile(info, null);
-		assertEquals("Foo : additional detail :Class", labelProvider.getStyledText(infoWithFile).getString());		
+		final var symbolWithURI = new SymbolsModel.DocumentSymbolWithURI(info, null);
+		assertEquals("Foo : additional detail :Class", labelProvider.getStyledText(symbolWithURI).getString());
 	}
-	
+
 	@Test
 	public void testDocumentSymbolDetailWithFileWithKindDeprecated () {
 		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, true);
@@ -117,8 +116,8 @@ public class SymbolsLabelProviderTest {
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
 		info.setDeprecated(true);
-		SymbolsModel.DocumentSymbolWithFile infoWithFile = new SymbolsModel.DocumentSymbolWithFile(info, null);
-		assertEquals("Foo : additional detail :Class", labelProvider.getStyledText(infoWithFile).getString());		
-		assertTrue(labelProvider.getStyledText(infoWithFile).getStyleRanges()[0].strikeout);
+		final var symbolWithURI = new SymbolsModel.DocumentSymbolWithURI(info, null);
+		assertEquals("Foo : additional detail :Class", labelProvider.getStyledText(symbolWithURI).getString());
+		assertTrue(labelProvider.getStyledText(symbolWithURI).getStyleRanges()[0].strikeout);
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
@@ -26,7 +26,7 @@ import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.outline.CNFOutlinePage;
 import org.eclipse.lsp4e.outline.LSSymbolsContentProvider;
 import org.eclipse.lsp4e.outline.LSSymbolsContentProvider.OutlineViewerInput;
-import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Range;
@@ -102,7 +102,7 @@ public class LSPSymbolInFileDialog extends PopupDialog {
 				range = symbolInformation.getLocation().getRange();
 			} else if (item instanceof DocumentSymbol documentSymbol) {
 				range = documentSymbol.getSelectionRange();
-			} else if (item instanceof DocumentSymbolWithFile documentSymbolWithFile) {
+			} else if (item instanceof DocumentSymbolWithURI documentSymbolWithFile) {
 				range = documentSymbolWithFile.symbol.getSelectionRange();
 			}
 			if (range != null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
@@ -42,7 +42,7 @@ import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.outline.LSSymbolsContentProvider.OutlineViewerInput;
-import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.swt.SWT;
@@ -134,8 +134,8 @@ public class CNFOutlinePage implements IContentOutlinePage, ILabelProviderListen
 		if (selection instanceof SymbolInformation symbolInformation) {
 			return symbolInformation.getLocation().getRange();
 		}
-		if (selection instanceof DocumentSymbolWithFile symbolWithFile) {
-			return symbolWithFile.symbol.getSelectionRange();
+		if (selection instanceof DocumentSymbolWithURI symbolWithURI) {
+			return symbolWithURI.symbol.getSelectionRange();
 		}
 		return null;
 	}
@@ -228,9 +228,9 @@ public class CNFOutlinePage implements IContentOutlinePage, ILabelProviderListen
 			range = symbol.getLocation().getRange();
 		} else {
 			@Nullable
-			DocumentSymbolWithFile documentSymbol = object instanceof DocumentSymbolWithFile symbolWithFile
-					? symbolWithFile
-					: Adapters.adapt(object, DocumentSymbolWithFile.class);
+			DocumentSymbolWithURI documentSymbol = object instanceof DocumentSymbolWithURI symbolWithURI
+					? symbolWithURI
+					: Adapters.adapt(object, DocumentSymbolWithURI.class);
 			if (documentSymbol != null) {
 				range = documentSymbol.symbol.getRange();
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineSorter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineSorter.java
@@ -16,7 +16,7 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.lsp4e.LanguageServerPlugin;
-import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -46,8 +46,8 @@ public class OutlineSorter extends ViewerComparator {
 		if (element instanceof Either<?, ?> either) {
 			element = either.get();
 		}
-		if (element instanceof DocumentSymbolWithFile symbolWithFile) {
-			return symbolWithFile.symbol.getName();
+		if (element instanceof DocumentSymbolWithURI symbolWithURI) {
+			return symbolWithURI.symbol.getName();
 		}
 		if (element instanceof DocumentSymbol documentSymbol) {
 			return documentSymbol.getName();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
@@ -42,7 +42,7 @@ import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.internal.StyleUtil;
-import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithFile;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4e.ui.LSPImages;
 import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4j.DocumentSymbol;
@@ -135,16 +135,16 @@ public class SymbolsLabelProvider extends LabelProvider
 			res = LSPImages.imageFromSymbolKind(symbol.getKind());
 		} else if (element instanceof DocumentSymbol symbol) {
 			res = LSPImages.imageFromSymbolKind(symbol.getKind());
-		} else if (element instanceof DocumentSymbolWithFile symbolWithFile) {
-			res = LSPImages.imageFromSymbolKind(symbolWithFile.symbol.getKind());
+		} else if (element instanceof DocumentSymbolWithURI symbolWithURI) {
+			res = LSPImages.imageFromSymbolKind(symbolWithURI.symbol.getKind());
 		}
 		IResource file = null;
 		if (element instanceof SymbolInformation symbol) {
 			file = LSPEclipseUtils.findResourceFor(symbol.getLocation().getUri());
 		} else if (element instanceof WorkspaceSymbol symbol) {
 			file = LSPEclipseUtils.findResourceFor(getUri(symbol));
-		} else if (element instanceof DocumentSymbolWithFile symbolWithFile) {
-			file = LSPEclipseUtils.findResourceFor(symbolWithFile.uri);
+		} else if (element instanceof DocumentSymbolWithURI symbolWithURI) {
+			file = LSPEclipseUtils.findResourceFor(symbolWithURI.uri);
 		}
 		/*
 		 * Implementation node: for problem decoration,m aybe consider using a ILabelDecorator/IDelayedLabelDecorator?
@@ -157,8 +157,8 @@ public class SymbolsLabelProvider extends LabelProvider
 				range = symbol.getLocation().getLeft().getRange();
 			} else if (element instanceof DocumentSymbol documentSymbol) {
 				range = documentSymbol.getRange();
-			} else if (element instanceof DocumentSymbolWithFile symbolWithFile) {
-				range = symbolWithFile.symbol.getRange();
+			} else if (element instanceof DocumentSymbolWithURI symbolWithURI) {
+				range = symbolWithURI.symbol.getRange();
 			}
 			if (range != null) {
 				try {
@@ -297,12 +297,12 @@ public class SymbolsLabelProvider extends LabelProvider
 			kind = documentSymbol.getKind();
 			detail = documentSymbol.getDetail();
 			deprecated = isDeprecated(documentSymbol.getTags()) || documentSymbol.getDeprecated() == null ? false: documentSymbol.getDeprecated();
-		} else if (element instanceof DocumentSymbolWithFile symbolWithFile) {
-			name = symbolWithFile.symbol.getName();
-			kind = symbolWithFile.symbol.getKind();
-			detail = symbolWithFile.symbol.getDetail();
-			location = symbolWithFile.uri;
-			deprecated = isDeprecated(symbolWithFile.symbol.getTags()) || symbolWithFile.symbol.getDeprecated() == null ? false: symbolWithFile.symbol.getDeprecated();
+		} else if (element instanceof DocumentSymbolWithURI symbolWithURI) {
+			name = symbolWithURI.symbol.getName();
+			kind = symbolWithURI.symbol.getKind();
+			detail = symbolWithURI.symbol.getDetail();
+			location = symbolWithURI.uri;
+			deprecated = isDeprecated(symbolWithURI.symbol.getTags()) || symbolWithURI.symbol.getDeprecated() == null ? false: symbolWithURI.symbol.getDeprecated();
 		}
 		if (name != null) {
 			if (deprecated) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsModel.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsModel.java
@@ -23,11 +23,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.viewers.TreePath;
-import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -49,16 +46,9 @@ public class SymbolsModel {
 		public final DocumentSymbol symbol;
 		public final @NonNull URI uri;
 
-		/**
-		 * @deprecated use {@link #uri}
-		 */
-		@Deprecated(since = "0.16.1", forRemoval = true)
-		public final @Nullable IFile file;
-
 		public DocumentSymbolWithFile(DocumentSymbol symbol, @NonNull URI uri) {
 			this.symbol = symbol;
 			this.uri = uri;
-			this.file = LSPEclipseUtils.getFileHandle(uri);
 		}
 
 		@Override


### PR DESCRIPTION
This field finally removes the `DocumentSymbolWithFile#file`.

Outline view performance on large files may also improve if the file is removed as I am currently seeing a lot of this in thread dumps when the UI freezes when opening VERY large JSON files.
```python
   java.lang.Thread.State: RUNNABLE
        at java.io.WinNTFileSystem.canonicalize0(java.base@17.0.6/Native Method)
        at java.io.WinNTFileSystem.canonicalize(java.base@17.0.6/WinNTFileSystem.java:462)
        at java.io.File.getCanonicalPath(java.base@17.0.6/File.java:626)
        at org.eclipse.core.internal.utils.FileUtil.canonicalPath(FileUtil.java:66)
        at org.eclipse.core.internal.utils.FileUtil.canonicalURI(FileUtil.java:161)
        at org.eclipse.core.internal.localstore.FileSystemResourceManager.allPathsForLocation(FileSystemResourceManager.java:67)
        at org.eclipse.core.internal.localstore.FileSystemResourceManager.allResourcesFor(FileSystemResourceManager.java:229)
        at org.eclipse.core.internal.resources.WorkspaceRoot.findFilesForLocationURI(WorkspaceRoot.java:98)
        at org.eclipse.core.internal.resources.WorkspaceRoot.findFilesForLocationURI(WorkspaceRoot.java:91)
>>>     at org.eclipse.lsp4e.LSPEclipseUtils.getFileHandle(LSPEclipseUtils.java:370)
>>>     at org.eclipse.lsp4e.outline.SymbolsModel$DocumentSymbolWithFile.<init>(SymbolsModel.java:61)
        at org.eclipse.lsp4e.outline.SymbolsModel.lambda$4(SymbolsModel.java:156)
        at org.eclipse.lsp4e.outline.SymbolsModel$$Lambda$19207/0x00000008016dd0a8.apply(Unknown Source)
        at java.util.stream.ReferencePipeline$3$1.accept(java.base@17.0.6/ReferencePipeline.java:197)
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(java.base@17.0.6/ArrayList.java:1625)
        at java.util.stream.AbstractPipeline.copyInto(java.base@17.0.6/AbstractPipeline.java:509)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(java.base@17.0.6/AbstractPipeline.java:499)
        at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(java.base@17.0.6/ForEachOps.java:150)
        at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(java.base@17.0.6/ForEachOps.java:173)
        at java.util.stream.AbstractPipeline.evaluate(java.base@17.0.6/AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.forEach(java.base@17.0.6/ReferencePipeline.java:596)
        at org.eclipse.lsp4e.outline.SymbolsModel.getElements(SymbolsModel.java:158)
        at org.eclipse.lsp4e.outline.LSSymbolsContentProvider.getElements(LSSymbolsContentProvider.java:286)
        at org.eclipse.ui.internal.navigator.extensions.SafeDelegateTreeContentProvider.getElements(SafeDelegateTreeContentProvider.java:103)
        at org.eclipse.ui.internal.navigator.NavigatorContentServiceContentProvider$1.run(NavigatorContentServiceContentProvider.java:157)
        at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:45)
```