### PR TITLE
Support limiting the number of outline symbols to avoid UI freezes

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -63,6 +63,7 @@ import org.eclipse.ui.navigator.ICommonContentExtensionSite;
 import org.eclipse.ui.navigator.ICommonContentProvider;
 import org.eclipse.ui.progress.PendingUpdateAdapter;
 import org.eclipse.ui.texteditor.ITextEditor;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 
 public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeContentProvider {
 
@@ -256,6 +257,10 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 		}
 
 		this.viewer = (TreeViewer) viewer;
+		
+		// this enables limiting the number of outline entries to mitigate UI freezes
+		WorkbenchViewerSetup.setupViewer(this.viewer);
+
 		isQuickOutline = Boolean.TRUE.equals(viewer.getData(VIEWER_PROPERTY_IS_QUICK_OUTLINE));
 
 		outlineViewerInput = (OutlineViewerInput) newInput;


### PR DESCRIPTION
This PR addresses #703 by limiting the maximum number of elements rendered in the UI to 5000 elements.

On my workstation Eclipse can add/render around 1.000 elements per second to the outline. Since adding elements is done in the UI thread, more elements mean longer freeze on initial population and each update.