### PR TITLE
fix erratic ConcurrentModificationException during unit tests

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -34,7 +36,7 @@ import org.eclipse.jface.text.IDocument;
  *
  */
 public class ConnectDocumentToLanguageServerSetupParticipant implements IDocumentSetupParticipant, IDocumentSetupParticipantExtension {
-	private static final WeakHashMap<CompletableFuture<?>, Void> PENDING_CONNECTIONS = new WeakHashMap<>();
+	private static final Map<CompletableFuture<?>, Void> PENDING_CONNECTIONS = Collections.synchronizedMap(new WeakHashMap<>());
 
 	public ConnectDocumentToLanguageServerSetupParticipant() {
 	}


### PR DESCRIPTION
This PR fixes an erratic  ConcurrentModificationException that results in random test failures.

```java
java.util.ConcurrentModificationException
  at java.base/java.util.WeakHashMap.forEach(WeakHashMap.java:1031)
  at org.eclipse.lsp4e.ConnectDocumentToLanguageServerSetupParticipant.waitForAll(ConnectDocumentToLanguageServerSetupParticipant.java:67)
  at org.eclipse.lsp4e.test.AllCleanRule.clear(AllCleanRule.java:66)
  at org.eclipse.lsp4e.test.AllCleanRule.finished(AllCleanRule.java:58)
  at org.junit.rules.TestWatcher.finishedQuietly(TestWatcher.java:122)
```