### PR TITLE
allow local maven builds with dirty working tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,18 @@
 
 	<profiles>
 		<profile>
+			<!-- This profile prevents local maven builds from failing if uncommitted changes are present -->
+			<id>local-dev</id>
+			<activation>
+				<property>
+					<name>!env.CI</name>
+				</property>
+			</activation>
+			<properties>
+				<jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
+			</properties>
+		</profile>
+		<profile>
 			<id>sign</id>
 			<build>
 				<plugins>


### PR DESCRIPTION
This PR prevents local (i.e. developer workstation) maven builds from failing if uncommitted changes are present.