### PR TITLE
fix Maven Warning "Parameter 'comparator' is read-only, must not be used in configuration"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,6 @@
 							<baselines>
 								<url>http://download.eclipse.org/lsp4e/releases/latest</url>
 							</baselines>
-							<comparator>zip</comparator>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
See https://github.com/eclipse-tycho/tycho/blob/61925ee127cecfe13efff467817aedbb50e24168/tycho-extras/tycho-p2-extras-plugin/src/main/java/org/eclipse/tycho/plugins/p2/extras/CompareWithBaselineMojo.java#L118-L122
