### PR TITLE
improve error logging for JUnit tests

### DIFF
--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -37,6 +37,7 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<trimStackTrace>false</trimStackTrace>
 					<testClass>org.eclipse.lsp4e.test.AllTests</testClass>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>true</useUIThread>

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/NoErrorLoggedRule.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/NoErrorLoggedRule.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test;
 
+import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,13 +31,23 @@ public class NoErrorLoggedRule extends TestWatcher {
 
 	public NoErrorLoggedRule(ILog log) {
 		this.log = log;
-		listener = (status, message) -> {
-			if (status.getSeverity() == IStatus.ERROR) {
+		final var logger = System.getLogger(log.getBundle().getSymbolicName());
+		listener = (status, unused) -> {
+			switch (status.getSeverity()) {
+			case IStatus.ERROR:
 				loggedErrors.add(status);
+				logger.log(Level.ERROR, status.toString(), status.getException());
+				break;
+			case IStatus.WARNING:
+				logger.log(Level.WARNING, status.toString(), status.getException());
+				break;
+			case IStatus.INFO:
+				logger.log(Level.INFO, status.toString(), status.getException());
+				break;
 			}
 		};
 	}
-	
+
 	@Override
 	protected void starting(Description description) {
 		super.starting(description);


### PR DESCRIPTION
This PR extends logging output for easier root cause analysis of erratic test failures esp. if happening on remote build servers