### PR TITLE
fix maven offline builds

### DIFF
--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -26,7 +26,15 @@
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
 				<artifactId>download-maven-plugin</artifactId>
-				<version>1.7.0</version>
+				<!-- 1.7.0 is broken, see https://github.com/maven-download-plugin/maven-download-plugin/releases/tag/1.7.0 -->
+				<version>1.6.8</version>
+				<configuration>
+					<!-- https://maven-download-plugin.github.io/maven-download-plugin/docsite/1.6.8/wget-mojo.html -->
+					<alwaysVerifyChecksum>true</alwaysVerifyChecksum>
+					<overwrite>true</overwrite>
+					<skipCache>false</skipCache>
+					<readTimeOut>5000</readTimeOut>
+				</configuration>
 				<executions>
 					<execution>
 						<id>fetch-highlight.min.js</id>
@@ -36,10 +44,8 @@
 						</goals>
 						<configuration>
 							<url>https://unpkg.com/@highlightjs/cdn-assets@11.8.0/highlight.min.js</url>
-							<unpack>false</unpack>
-							<overwrite>true</overwrite>
-							<skipCache>true</skipCache>
-							<outputDirectory>${project.basedir}/resources/highlight.min.js</outputDirectory>
+							<sha256>4499ff936d4fd562adca5a5cbe512dc19eb80942eee8618dafbcebc4f7974bdb</sha256>
+							<outputDirectory>resources/highlight.min.js</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -50,10 +56,8 @@
 						</goals>
 						<configuration>
 							<url>https://unpkg.com/@highlightjs/cdn-assets@11.8.0/styles/default.min.css</url>
-							<unpack>false</unpack>
-							<overwrite>true</overwrite>
-							<skipCache>true</skipCache>
-							<outputDirectory>${project.basedir}/resources/highlight.min.js/styles</outputDirectory>
+							<sha256>fbde0ac0921d86c356c41532e7319c887a23bd1b8ff00060cab447249f03c7cf</sha256>
+							<outputDirectory>resources/highlight.min.js/styles</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -64,10 +68,8 @@
 						</goals>
 						<configuration>
 							<url>https://unpkg.com/@highlightjs/cdn-assets@11.8.0/styles/dark.min.css</url>
-							<unpack>false</unpack>
-							<overwrite>true</overwrite>
-							<skipCache>true</skipCache>
-							<outputDirectory>${project.basedir}/resources/highlight.min.js/styles</outputDirectory>
+							<sha256>bf437be81145907d1d081f1b52be1c1d254df00ff309a3a8a4cb92989595ff9c</sha256>
+							<outputDirectory>resources/highlight.min.js/styles</outputDirectory>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
The lsp4e.plugin module was configured to unnecessarily re-download js/css files from a CDN on each build invocation.

This PR changes the logic to only download/overwrite the files locally if they are missing or outdated.

This makes running `mvn --offline verify` possible and generally speeds up local maven builds.
