### PR TITLE
Do not propagate cancellation exceptions to the UI as outline elements

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.resources.IFile;
@@ -50,6 +51,7 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServerWrapper;
+import org.eclipse.lsp4e.internal.CancellationUtil;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
@@ -350,7 +352,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 		});
 
 		symbols.exceptionally(ex -> {
-			lastError = ex;
+			lastError = (ex instanceof CancellationException || CancellationUtil.isRequestCancelledException(ex)) ? null: ex;
 			viewer.getControl().getDisplay().asyncExec(viewer::refresh);
 			return Collections.emptyList();
 		});


### PR DESCRIPTION
Fixes https://github.com/eclipse/lsp4e/issues/278