### PR TITLE
add AbstractTest and AbstractTestWithProject

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/ContentTypeToLanguageServerDefinitionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/ContentTypeToLanguageServerDefinitionTest.java
@@ -19,12 +19,13 @@ import java.util.List;
 import org.eclipse.lsp4e.ContentTypeToLanguageServerDefinition;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServersRegistry;
+import org.eclipse.lsp4e.test.utils.AbstractTest;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class ContentTypeToLanguageServerDefinitionTest {
+public class ContentTypeToLanguageServerDefinitionTest extends AbstractTest {
 
 	public static final String SERVER_TO_DISABLE = "org.eclipse.lsp4e.test.server.disable";
 	public static final String DISABLED_CONTENT_TYPE = "org.eclipse.lsp4e.test.content-type-disabled";

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
@@ -12,6 +12,8 @@
 package org.eclipse.lsp4e.test;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
@@ -27,31 +29,25 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.MockConnectionProviderWithStartException;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.ui.IEditorPart;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class LanguageServerWrapperTest {
+public class LanguageServerWrapperTest extends AbstractTestWithProject {
 
-	private IProject project1;
 	private IProject project2;
 
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-
 	@Before
-	public void setUp() throws CoreException {
-		project1 = TestUtils.createProject("LanguageServerWrapperTestProject1" + System.currentTimeMillis());
+	public void setUp() throws Exception {
 		project2 = TestUtils.createProject("LanguageServerWrapperTestProject2" + System.currentTimeMillis());
 	}
 
 	@Test
 	public void testConnect() throws Exception {
-		IFile testFile1 = TestUtils.createFile(project1, "shouldUseExtension.lsptWithMultiRoot", "");
+		IFile testFile1 = TestUtils.createFile(project, "shouldUseExtension.lsptWithMultiRoot", "");
 		IFile testFile2 = TestUtils.createFile(project2, "shouldUseExtension.lsptWithMultiRoot", "");
 
 		IEditorPart editor1 = TestUtils.openEditor(testFile1);
@@ -64,8 +60,8 @@ public class LanguageServerWrapperTest {
 		LanguageServerWrapper wrapper = wrappers.iterator().next();
 		waitForAndAssertCondition(2_000, () -> wrapper.isActive());
 
-		// e.g. LanguageServerWrapper@69fe8c75 [serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P/LanguageServerWrapperTestProject11691664858710, isActive=true]
-		assertTrue(wrapper.toString().matches("LanguageServerWrapper@[0-9a-f]+ \\[serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P\\/LanguageServerWrapperTestProject1[0-9]+, isActive=true, pid=(null|[0-9])+\\]"));
+		// e.g. LanguageServerWrapper@69fe8c75 [serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P/LanguageServerWrapperTest_testConnect_11691664858710, isActive=true]
+		assertThat(wrapper.toString(), matchesPattern("LanguageServerWrapper@[0-9a-f]+ \\[serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P\\/LanguageServerWrapperTest_testConnect_[0-9]+, isActive=true, pid=(null|[0-9])+\\]"));
 
 		assertTrue(wrapper.isConnectedTo(testFile1.getLocationURI()));
 		assertTrue(wrapper.isConnectedTo(testFile2.getLocationURI()));
@@ -80,7 +76,7 @@ public class LanguageServerWrapperTest {
 	 */
 	@Test
 	public void testStopAndActive() throws CoreException, IOException, AssertionError, InterruptedException, ExecutionException {
-		IFile testFile1 = TestUtils.createFile(project1, "shouldUseExtension.lsptWithMultiRoot", "");
+		IFile testFile1 = TestUtils.createFile(project, "shouldUseExtension.lsptWithMultiRoot", "");
 		IEditorPart editor1 = TestUtils.openEditor(testFile1);
 		@NonNull Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile1, request -> true);
 		assertEquals(1, wrappers.size());
@@ -120,7 +116,7 @@ public class LanguageServerWrapperTest {
 
 	@Test
 	public void testStartExceptionRace() throws Exception {
-		IFile testFile1 = TestUtils.createFile(project1, "shouldUseExtension.lsptStartException", "");
+		IFile testFile1 = TestUtils.createFile(project, "shouldUseExtension.lsptStartException", "");
 
 		IEditorPart editor1 = TestUtils.openEditor(testFile1);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
@@ -34,8 +34,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.IDocument;
@@ -45,7 +43,7 @@ import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.LanguageServers.LanguageServerDocumentExecutor;
 import org.eclipse.lsp4e.internal.Pair;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.MockConnectionProvider;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -65,23 +63,11 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class LanguageServersTest {
-
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-
-	private IProject project;
+public class LanguageServersTest extends AbstractTestWithProject {
 
 	private final Predicate<ServerCapabilities> MATCH_ALL = sc -> true;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("LanguageServersTest" + System.currentTimeMillis());
-	}
 
 	@Test
 	public void testCollectAll() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -19,15 +19,7 @@ import static org.eclipse.lsp4e.LanguageServiceAccessor.getLSPDocumentInfosFor;
 import static org.eclipse.lsp4e.LanguageServiceAccessor.getLSWrapper;
 import static org.eclipse.lsp4e.LanguageServiceAccessor.getLSWrappers;
 import static org.eclipse.lsp4e.LanguageServiceAccessor.hasActiveLanguageServers;
-import static org.eclipse.lsp4e.test.utils.TestUtils.createFile;
-import static org.eclipse.lsp4e.test.utils.TestUtils.createProject;
-import static org.eclipse.lsp4e.test.utils.TestUtils.createTempFile;
-import static org.eclipse.lsp4e.test.utils.TestUtils.createUniqueTestFile;
-import static org.eclipse.lsp4e.test.utils.TestUtils.createUniqueTestFileMultiLS;
-import static org.eclipse.lsp4e.test.utils.TestUtils.openEditor;
-import static org.eclipse.lsp4e.test.utils.TestUtils.openTextViewer;
-import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.eclipse.lsp4e.test.utils.TestUtils.waitForCondition;
+import static org.eclipse.lsp4e.test.utils.TestUtils.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -40,7 +32,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
 import org.eclipse.core.filesystem.EFS;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
@@ -51,7 +42,7 @@ import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.LanguageServersRegistry;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.MappingEnablementTester;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServerMultiRootFolders;
@@ -59,22 +50,11 @@ import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class LanguageServiceAccessorTest {
+public class LanguageServiceAccessorTest extends AbstractTestWithProject {
 
 	private static final Predicate<ServerCapabilities> MATCH_ALL = capabilities -> true;
-
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = createProject("LanguageServiceAccessorTest" + System.currentTimeMillis());
-	}
 
 	@Test
 	public void testGetLSWrapper() throws IOException {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/RunningLanguageServerTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/RunningLanguageServerTest.java
@@ -20,32 +20,20 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.lsp4e.ContentTypeToLanguageServerDefinition;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class RunningLanguageServerTest {
-
-	private IProject project;
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("StartStopServerTest" + System.currentTimeMillis());
-	}
+public class RunningLanguageServerTest extends AbstractTestWithProject {
 
 	/**
 	 * checks if language servers get started and shutdown correctly if opening and

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/VersioningSupportTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/VersioningSupportTest.java
@@ -20,15 +20,13 @@ import java.util.ConcurrentModificationException;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.VersionedEdits;
 import org.eclipse.lsp4e.internal.DocumentUtil;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.DocumentFormattingParams;
@@ -38,20 +36,9 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ui.IEditorPart;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class VersioningSupportTest {
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("VersioningSupportTest" + System.currentTimeMillis());
-	}
+public class VersioningSupportTest extends AbstractTestWithProject {
 
 	@Test
 	public void testVersionSupportSuccess() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/WorkspaceFoldersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/WorkspaceFoldersTest.java
@@ -20,16 +20,13 @@ import java.io.File;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.lsp4e.ConnectDocumentToLanguageServerSetupParticipant;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.test.utils.TestUtils.JobSynchronizer;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -41,18 +38,13 @@ import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
 import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class WorkspaceFoldersTest implements Supplier<ServerCapabilities> {
-
-	@Rule public AllCleanRule clear = new AllCleanRule(this);
-	private IProject project;
+public class WorkspaceFoldersTest extends AbstractTestWithProject {
 
 	@Before
-	public void setUp() throws CoreException {
+	public void setUp() {
 		MockLanguageServer.INSTANCE.getWorkspaceService().getWorkspaceFoldersEvents().clear();
-		project = TestUtils.createProject("WorkspaceFoldersTest" + System.currentTimeMillis());
 	}
 
 	@Test
@@ -193,7 +185,7 @@ public class WorkspaceFoldersTest implements Supplier<ServerCapabilities> {
 	}
 
 	@Override
-	public ServerCapabilities get() {
+	public ServerCapabilities getServerCapabilities() {
 		// Enable workspace folders on the mock server (for this test only)
 		final ServerCapabilities base = MockLanguageServer.defaultServerCapabilities();
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
@@ -23,13 +23,11 @@ import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.lsp4e.operations.diagnostics.LSPDiagnosticsToMarkers;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.NoErrorLoggedRule;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -56,15 +54,13 @@ import org.eclipse.ui.texteditor.TextOperationAction;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class CodeActionTests {
+public class CodeActionTests extends AbstractTestWithProject {
 
-	public final @Rule NoErrorLoggedRule rule = new NoErrorLoggedRule();
-	public final @Rule AllCleanRule clear = new AllCleanRule();
+	public final @Rule NoErrorLoggedRule noErrorLoggedRule = new NoErrorLoggedRule();
 
 	@Test
 	public void testCodeActionsClientCommandForTextEdit() throws CoreException {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createUniqueTestFile(p, "error");
+		IFile f = TestUtils.createUniqueTestFile(project, "error");
 		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forLeft(new Command(
 				"fixme",
 				"edit",
@@ -83,14 +79,12 @@ public class CodeActionTests {
 			assertResolution(editor, m, "fixed");
 		} finally {
 			editor.close(false);
-			p.delete(true, new NullProgressMonitor());
 		}
 	}
 
 	@Test
 	public void testCodeActionsClientCommandForWorkspaceEdit() throws CoreException {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createUniqueTestFile(p, "error");
+		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
 		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
@@ -120,8 +114,7 @@ public class CodeActionTests {
 	@Test
 	public void testCodeActionsQuickAssist() throws CoreException {
 		MockLanguageServer.reset();
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createUniqueTestFile(p, "error");
+		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
 		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
@@ -146,8 +139,7 @@ public class CodeActionTests {
 	@Test
 	public void testSlowCodeActionsQuickAssist() throws CoreException {
 		MockLanguageServer.reset();
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createUniqueTestFile(p, "error");
+		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
 		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
@@ -178,8 +170,7 @@ public class CodeActionTests {
 
 	@Test
 	public void testCodeActionLiteralWorkspaceEdit() throws CoreException {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createUniqueTestFile(p, "error");
+		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
 		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
@@ -195,8 +186,7 @@ public class CodeActionTests {
 
 	@Test
 	public void testNoCodeActionOnReadOnlySource() throws CoreException {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createUniqueTestFile(p, "error");
+		IFile f = TestUtils.createUniqueTestFile(project, "error");
 		f.setResourceAttributes(new ResourceAttributes() {
 			@Override
 			public boolean isReadOnly() {
@@ -217,8 +207,7 @@ public class CodeActionTests {
 
 	@Test
 	public void testCodeActionLiteralWithClientCommand() throws CoreException {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createUniqueTestFile(p, "error");
+		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
 		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
@@ -234,9 +223,8 @@ public class CodeActionTests {
 
 	@Test
 	public void testCodeActionWorkspaceEditlWithDifferentURI() throws CoreException {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile sourceFile = TestUtils.createUniqueTestFile(p, "error");
-		IFile targetFile = TestUtils.createUniqueTestFile(p, "fixme");
+		IFile sourceFile = TestUtils.createUniqueTestFile(project, "error");
+		IFile targetFile = TestUtils.createUniqueTestFile(project, "fixme");
 
 		// create a diagnostic on the sourceFile with a code action
 		// that changes the targetFile

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -36,12 +36,10 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.ide.IDE;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class ColorTest {
+public class ColorTest extends AbstractTestWithProject {
 
-	@Rule public AllCleanRule cleanRule = new AllCleanRule();
 	private RGB color;
 
 	@Before
@@ -52,7 +50,7 @@ public class ColorTest {
 
 	@Test
 	public void testColorProvider() throws Exception {
-		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(TestUtils.createProject("testColorProvider"), "\u2588\u2588\u2588\u2588\u2588"));
+		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "\u2588\u2588\u2588\u2588\u2588"));
 		StyledText widget = viewer.getTextWidget();
 		waitForAndAssertCondition(3_000, widget.getDisplay(), () -> containsColor(widget, color, 10));
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
@@ -24,12 +24,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
@@ -42,23 +41,17 @@ import org.eclipse.lsp4j.WorkspaceFoldersOptions;
 import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import com.google.gson.Gson;
 
-public class DynamicRegistrationTest {
+public class DynamicRegistrationTest extends AbstractTestWithProject {
 
 	private static final String WORKSPACE_EXECUTE_COMMAND = "workspace/executeCommand";
 	private static final String WORKSPACE_DID_CHANGE_FOLDERS = "workspace/didChangeWorkspaceFolders";
 
-	@Rule public AllCleanRule clear = new AllCleanRule();
-
-	private IProject project;
-
 	@Before
 	public void setUp() throws Exception {
-		project = TestUtils.createProject("CommandRegistrationTest" + System.currentTimeMillis());
 		IFile testFile = TestUtils.createFile(project, "shouldUseExtension.lspt", "");
 
 		// Make sure mock language server is created...

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/AbstractCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/AbstractCompletionTest.java
@@ -16,12 +16,11 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.CompletionItem;
@@ -34,17 +33,13 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.ui.PartInitException;
 import org.junit.Before;
-import org.junit.Rule;
 
-public abstract class AbstractCompletionTest {
+public abstract class AbstractCompletionTest extends AbstractTestWithProject {
 
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	protected IProject project;
 	protected LSContentAssistProcessor contentAssistProcessor;
 
 	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("CompletionTest" + System.currentTimeMillis());
+	public void setUp() {
 		contentAssistProcessor = new LSContentAssistProcessor(true, false);
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
@@ -18,30 +18,23 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SignatureInformation;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class ContextInformationTest {
+public class ContextInformationTest extends AbstractCompletionTest {
 
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-	private LSContentAssistProcessor contentAssistProcessor;
-
+	@Override
 	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("ContextInformationTest" + System.currentTimeMillis());
+	public void setUp() {
 		contentAssistProcessor = new LSContentAssistProcessor();
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/debug/DebugTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/debug/DebugTest.java
@@ -17,25 +17,13 @@ import static org.junit.Assert.fail;
 
 import java.util.Map;
 
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.lsp4e.debug.debugmodel.DSPDebugTarget;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
-import org.eclipse.lsp4e.test.utils.TestUtils;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
 import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DebugTest {
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	protected IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("CompletionTest" + System.currentTimeMillis());
-	}
+public class DebugTest extends AbstractTestWithProject {
 
 	/**
 	 * Test for the `IllegalStateException: Duplicate RPC method runInTerminal` issue.

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/debug/debugmodel/JsonParserWithStringSubstitutionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/debug/debugmodel/JsonParserWithStringSubstitutionTest.java
@@ -21,9 +21,10 @@ import org.eclipse.core.variables.IStringVariableManager;
 import org.eclipse.core.variables.IValueVariable;
 import org.eclipse.core.variables.IValueVariableListener;
 import org.eclipse.lsp4e.debug.debugmodel.JsonParserWithStringSubstitution;
+import org.eclipse.lsp4e.test.utils.AbstractTest;
 import org.junit.Test;
 
-public class JsonParserWithStringSubstitutionTest {
+public class JsonParserWithStringSubstitutionTest extends AbstractTest {
 
 	private static final class StringVariableManagerMock implements IStringVariableManager {
 
@@ -218,5 +219,4 @@ public class JsonParserWithStringSubstitutionTest {
 		String resultValue = (String) secondObject.get(key2);
 		assertEquals(variableReplacement, resultValue);
 	}
-
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/declaration/LSBasedHyperlinkTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/declaration/LSBasedHyperlinkTest.java
@@ -19,29 +19,17 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.declaration.LSBasedHyperlink;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class LSBasedHyperlinkTest {
+public class LSBasedHyperlinkTest extends AbstractTestWithProject {
 
 	private static String locationType = "Open Declaration";
-	
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("HyperlinkLabelTest");
-	}
 
 	@Test
 	public void testHyperlinkLabelNoLocation() {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
@@ -23,15 +23,13 @@ import java.util.stream.Collectors;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.declaration.LSBasedHyperlink;
 import org.eclipse.lsp4e.operations.declaration.OpenDeclarationHyperlinkDetector;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -42,21 +40,11 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DefinitionTest {
+public class DefinitionTest extends AbstractTestWithProject {
 
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-	private OpenDeclarationHyperlinkDetector hyperlinkDetector;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("DefinitionTest" + System.currentTimeMillis());
-		hyperlinkDetector = new OpenDeclarationHyperlinkDetector();
-	}
+	private final OpenDeclarationHyperlinkDetector hyperlinkDetector = new OpenDeclarationHyperlinkDetector();
 
 	@Test
 	public void testDefinitionOneLocation() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
@@ -16,9 +16,7 @@ package org.eclipse.lsp4e.test.diagnostics;
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,7 +29,6 @@ import java.util.stream.Stream;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
@@ -46,9 +43,8 @@ import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.operations.diagnostics.LSPDiagnosticsToMarkers;
 import org.eclipse.lsp4e.test.color.ColorTest;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.BlockingWorkspaceJob;
-import org.eclipse.lsp4e.test.utils.NoErrorLoggedRule;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -63,22 +59,11 @@ import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.MarkerUtilities;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DiagnosticsTest {
+public class DiagnosticsTest extends AbstractTestWithProject {
 
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	public final @Rule NoErrorLoggedRule noErrorLoggedRule = new NoErrorLoggedRule();
-	private IProject project;
-	private LSPDiagnosticsToMarkers diagnosticsToMarkers;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("DiagnoticsTest" + System.currentTimeMillis());
-		diagnosticsToMarkers = new LSPDiagnosticsToMarkers("dummy");
-	}
+	private LSPDiagnosticsToMarkers diagnosticsToMarkers = new LSPDiagnosticsToMarkers("dummy");
 
 	@Test
 	public void testDiagnostics() throws CoreException {
@@ -155,7 +140,6 @@ public class DiagnosticsTest {
 		});
 		Job[] allMarkerJobs = Job.getJobManager().find(LanguageServerPlugin.FAMILY_UPDATE_MARKERS);
 		Job markerJob = allMarkerJobs[0];
-		IProject project = file.getProject();
 		project.close(null);
 		waitForAndAssertCondition(1_000, () -> {
 			assertEquals(project.isAccessible(), false);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
@@ -19,14 +19,12 @@ import java.util.List;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.documentLink.DocumentLinkDetector;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -35,21 +33,11 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DocumentLinkTest {
+public class DocumentLinkTest extends AbstractTestWithProject {
 
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-	private DocumentLinkDetector documentLinkDetector;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("DocumentLinkTest" + System.currentTimeMillis());
-		documentLinkDetector = new DocumentLinkDetector();
-	}
+	private final DocumentLinkDetector documentLinkDetector = new DocumentLinkDetector();
 
 	@Test
 	public void testDocumentLinkNoResults() throws Exception {
@@ -102,6 +90,4 @@ public class DocumentLinkTest {
 		IHyperlink[] hyperlinks = documentLinkDetector.detectHyperlinks(viewer, new Region(0, 0), true);
 		assertArrayEquals(null, hyperlinks);
 	}
-
-
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
@@ -22,12 +22,10 @@ import java.util.function.Predicate;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -39,19 +37,9 @@ import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DocumentDidChangeTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("DocumentDidChangeTest" + System.currentTimeMillis());
-	}
+public class DocumentDidChangeTest extends AbstractTestWithProject {
 
 	@Test
 	public void testIncrementalSync() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidCloseTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidCloseTest.java
@@ -20,28 +20,22 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DocumentDidCloseTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
+public class DocumentDidCloseTest extends AbstractTestWithProject {
 
 	@Test
 	public void testClose() throws Exception {
-		IProject project = TestUtils.createProject("DocumentDidCloseTest" + System.currentTimeMillis());
-
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
 		IEditorPart editor = TestUtils.openEditor(testFile);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidOpenTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidOpenTest.java
@@ -20,12 +20,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -33,19 +31,9 @@ import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DocumentDidOpenTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project =  TestUtils.createProject("DocumentDidChangeTest" + System.currentTimeMillis());
-	}
+public class DocumentDidOpenTest extends AbstractTestWithProject {
 
 	@Test
 	public void testOpen() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidSaveTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidSaveTest.java
@@ -22,33 +22,21 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DocumentDidSaveTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project =  TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
-	}
+public class DocumentDidSaveTest extends AbstractTestWithProject {
 
 	@Test
 	public void testSave() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentEditAndUndoTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentEditAndUndoTest.java
@@ -18,14 +18,12 @@ import static org.junit.Assert.*;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextOperationTarget;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.LinkedEditingRanges;
@@ -36,22 +34,11 @@ import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.IEditorPart;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import com.google.common.collect.Iterators;
 
-public class DocumentEditAndUndoTest {
-
-	@Rule
-	public final AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
-	}
+public class DocumentEditAndUndoTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDocumentEditAndUndo() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentRevertAndCloseTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentRevertAndCloseTest.java
@@ -15,30 +15,18 @@ import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
 import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DocumentRevertAndCloseTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project =  TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
-	}
+public class DocumentRevertAndCloseTest extends AbstractTestWithProject {
 
 	@Test
 	public void testShutdownLsp() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
@@ -18,34 +18,22 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ui.IEditorPart;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class DocumentWillSaveWaitUntilTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project =  TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
-	}
+public class DocumentWillSaveWaitUntilTest extends AbstractTestWithProject {
 
 	private List<TextEdit> createSingleTextEditAtFileStart(String newText) {
 		TextEdit textEdit = new TextEdit();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -41,7 +41,7 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.NoErrorLoggedRule;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.ui.UI;
@@ -69,10 +69,9 @@ import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class LSPEclipseUtilsTest {
+public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 
 	public final @Rule NoErrorLoggedRule noErrorLoggedRule = new NoErrorLoggedRule();
-	public final @Rule AllCleanRule clear = new AllCleanRule();
 
 	@Test
 	public void testOpenInEditorExternalFile() throws Exception {
@@ -98,8 +97,7 @@ public class LSPEclipseUtilsTest {
 	}
 
 	private AbstractTextEditor applyWorkspaceTextEdit(TextEdit textEdit) throws CoreException, PartInitException {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createFile(p, "dummy" + new Random().nextInt(), "Here");
+		IFile f = TestUtils.createFile(project, "dummy" + new Random().nextInt(), "Here");
 		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonMap(
 			LSPEclipseUtils.toUri(f).toString(),
@@ -110,8 +108,7 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testWorkspaceEditMultipleChanges() throws Exception {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile f = TestUtils.createFile(p, "dummy", "Here\nHere2");
+		IFile f = TestUtils.createFile(project, "dummy", "Here\nHere2");
 		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		final var edits = new LinkedList<TextEdit>();
 		// order the TextEdits from the top of the document to the bottom
@@ -128,8 +125,7 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testWorkspaceEdit_CreateAndPopulateFile() throws Exception {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile file = p.getFile("test-file.test");
+		IFile file = project.getFile("test-file.test");
 		LinkedList<Either<TextDocumentEdit, ResourceOperation>> edits = new LinkedList<>();
 		// order the TextEdits from the top of the document to the bottom
 		String uri = file.getLocation().toFile().toURI().toString();
@@ -146,30 +142,24 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testURIToResourceMapping() throws CoreException { // bug 508841
-		IProject project1 = null;
-		IProject project2 = null;
-		project1 = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-		IFile file = project1.getFile("res");
+		IFile file = project.getFile("res");
 		file.create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
 		Assert.assertEquals(file, LSPEclipseUtils.findResourceFor(file.getLocationURI().toString()));
 
-		project1.getFile("suffix").create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
-		project2 = TestUtils.createProject(project1.getName() + "suffix");
+		project.getFile("suffix").create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
+		IProject project2 = TestUtils.createProject(project.getName() + "suffix");
 		Assert.assertEquals(project2, LSPEclipseUtils.findResourceFor(project2.getLocationURI().toString()));
 	}
 
 	@Test
 	public void testReturnMostNestedFileRegardlessArrayOrder() throws CoreException { // like maven nested modules
-		IProject project1 = null;
-		project1 = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-
-		IFile mostNestedFile = project1.getFile("res");
+		IFile mostNestedFile = project.getFile("res");
 		mostNestedFile.create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
 
-		IFolder folder = project1.getFolder("folder");
+		IFolder folder = project.getFolder("folder");
 		folder.create(true, true, new NullProgressMonitor());
 
-		IFile someFile = project1.getFile("folder/res");
+		IFile someFile = project.getFile("folder/res");
 		someFile.create(new ByteArrayInputStream(new byte[0]), true, new NullProgressMonitor());
 
 		Assert.assertEquals(mostNestedFile, LSPEclipseUtils.findMostNested(new IFile[] {mostNestedFile, someFile}));
@@ -178,21 +168,15 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testLinkedResourceURIToResourceMapping() throws CoreException, IOException { // bug 577159
-		IProject project1 = null;
-		Path externalFile = null;
-		Path externalFolder = null;
+		Path externalFile = Files.createTempFile("tmp_file-", null);
+		Path externalFolder = Files.createTempDirectory("tmp_dir-");
 
-		externalFile = Files.createTempFile("tmp_file-", null);
-		externalFolder = Files.createTempDirectory("tmp_dir-");
-
-		project1 = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-
-		IFile linkedFile = project1.getFile("linked_file");
+		IFile linkedFile = project.getFile("linked_file");
 		linkedFile.createLink(externalFile.toUri(), 0, new NullProgressMonitor());
 		Assert.assertTrue(linkedFile.isLinked());
 		Assert.assertEquals(linkedFile, LSPEclipseUtils.findResourceFor(linkedFile.getLocationURI().toString()));
 
-		IFolder linkedFolder = project1.getFolder("linked_folder");
+		IFolder linkedFolder = project.getFolder("linked_folder");
 		linkedFolder.createLink(externalFolder.toUri(), 0, new NullProgressMonitor());
 		Assert.assertTrue(linkedFolder.isLinked());
 		Assert.assertEquals(linkedFolder,
@@ -206,16 +190,10 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testVirtualResourceURIToResourceMapping() throws CoreException, IOException { // bug 577159
-		IProject project1 = null;
-		Path externalFile = null;
-		Path externalFolder = null;
+		Path externalFile = Files.createTempFile("tmp_file-", null);
+		Path externalFolder = Files.createTempDirectory("tmp_dir-");
 
-		externalFile = Files.createTempFile("tmp_file-", null);
-		externalFolder = Files.createTempDirectory("tmp_dir-");
-
-		project1 = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
-
-		IFolder virtualFolder = project1.getFolder("virtual_folder");
+		IFolder virtualFolder = project.getFolder("virtual_folder");
 		virtualFolder.create(IResource.VIRTUAL, true, new NullProgressMonitor());
 
 		Assert.assertEquals(virtualFolder.isVirtual(), true);
@@ -244,10 +222,11 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testCustomURIToResourceMapping() throws CoreException { // bug 576425
-		IProject project = null;
-
 		URI uri = URI.create("other://a/res.txt");
-		project = TestUtils.createProject(getClass().getSimpleName() + uri.getScheme());
+
+		// this project name is magic, see UriToResourceAdapterFactory#getAdapter(Object, Class)
+		project = TestUtils.createProject(LSPEclipseUtilsTest.class.getSimpleName() + uri.getScheme());
+
 		IFile file = project.getFile("res.txt");
 		file.createLink(uri, IResource.REPLACE | IResource.ALLOW_MISSING_LOCAL, new NullProgressMonitor());
 		Assert.assertEquals(file, LSPEclipseUtils.findResourceFor(file.getLocationURI().toString()));
@@ -256,10 +235,7 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testCustomResourceToURIMapping() throws CoreException { // bug 576425
-		IProject project = null;
-
 		URI uri = URI.create("other://res.txt");
-		project = TestUtils.createProject(getClass().getSimpleName() + uri.getScheme());
 		IFile file = project.getFile("res.txt");
 		file.createLink(uri, IResource.REPLACE | IResource.ALLOW_MISSING_LOCAL, new NullProgressMonitor());
 		Assert.assertEquals(LSPEclipseUtils.toUri(file).toString(), "other://a/res.txt");
@@ -267,8 +243,6 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testApplyTextEditLongerThanOrigin() throws Exception {
-		IProject project = null;
-		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 		TextEdit textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "InsertHere".length())), "Inserted");
@@ -279,8 +253,6 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testApplyTextEditShorterThanOrigin() throws Exception {
-		IProject project = null;
-		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineHERE");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 		TextEdit textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "HERE".length())), "Inserted");
@@ -291,8 +263,6 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testTextEditInsertSameOffset() throws Exception {
-		IProject project = null;
-		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 		TextEdit[] edits = new TextEdit[] {
@@ -305,8 +275,6 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testTextEditSplittedLineEndings() throws Exception {
-		IProject project = null;
-		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\r\nline2\r\nline3\r\n");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 		// GIVEN a TextEdit which splits the '\r\n' line ending in the third line:
@@ -340,16 +308,13 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testToWorkspaceFolder() throws Exception {
-		IProject project = TestUtils.createProject("testToWorkspaceFolder");
-
 		WorkspaceFolder folder = LSPEclipseUtils.toWorkspaceFolder(project);
-		Assert.assertEquals("testToWorkspaceFolder", folder.getName());
+		Assert.assertEquals(project.getName(), folder.getName());
 		Assert.assertEquals("file://", folder.getUri().substring(0, "file://".length()));
 	}
 
 	@Test
 	public void testResourceOperations() throws Exception {
-		IProject project = TestUtils.createProject("testResourceOperations");
 		IFile targetFile = project.getFile("some/folder/file.txt");
 		LSPEclipseUtils.applyWorkspaceEdit(new WorkspaceEdit(
 				Collections.singletonList(Either.forRight(new CreateFile(targetFile.getLocationURI().toString())))));
@@ -418,7 +383,6 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testTextEditDoesntAutomaticallySaveOpenResourceFiles() throws Exception {
-		IProject project = TestUtils.createProject("testTextEditDoesntAutomaticallySaveOpenFiles");
 		IFile targetFile = project.getFile("blah.txt");
 		targetFile.create(new ByteArrayInputStream("".getBytes()), true, null);
 		IEditorPart editor = IDE.openEditor(UI.getActivePage(),
@@ -464,9 +428,8 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testToCompletionParams_EmptyDocument() throws Exception {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		// Given an empty file/document
-		var file = TestUtils.createFile(p, "dummy" + new Random().nextInt(), "");
+		var file = TestUtils.createFile(project, "dummy" + new Random().nextInt(), "");
 		var triggerChars = new  char[] {':', '>'};
 		// When toCompletionParams get called with offset == 0 and document.getLength() == 0:
 		var param = LSPEclipseUtils.toCompletionParams(file.getLocationURI(), 0, LSPEclipseUtils.getDocument(file), triggerChars);
@@ -476,9 +439,8 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testToCompletionParams_ZeroOffset() throws Exception {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		// Given a non empty file/document containing a non trigger character at position 3:
-		var file = TestUtils.createFile(p, "dummy" + new Random().nextInt(), "std");
+		var file = TestUtils.createFile(project, "dummy" + new Random().nextInt(), "std");
 		var triggerChars = new  char[] {':', '>'};
 		// When toCompletionParams get called with offset == 0 and document.getLength() > 0:
 		var param = LSPEclipseUtils.toCompletionParams(file.getLocationURI(), 0, LSPEclipseUtils.getDocument(file), triggerChars);
@@ -488,9 +450,8 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testToCompletionParams_MatchingTriggerCharacter() throws Exception {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		// Given a non empty file/document containing a trigger character at position 4:
-		var file = TestUtils.createFile(p, "dummy" + new Random().nextInt(), "std:");
+		var file = TestUtils.createFile(project, "dummy" + new Random().nextInt(), "std:");
 		var triggerChars = new  char[] {':', '>'};
 		// When toCompletionParams get called with offset > 0 and document.getLength() > 0:
 		var param = LSPEclipseUtils.toCompletionParams(file.getLocationURI(), 4, LSPEclipseUtils.getDocument(file), triggerChars);
@@ -502,9 +463,8 @@ public class LSPEclipseUtilsTest {
 
 	@Test
 	public void testToCompletionParams_NonMatchingTriggerCharacter() throws Exception {
-		IProject p = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		// Given a non empty file/document containing a non trigger character at position 3:
-		var file = TestUtils.createFile(p, "dummy" + new Random().nextInt(), "std");
+		var file = TestUtils.createFile(project, "dummy" + new Random().nextInt(), "std");
 		var triggerChars = new  char[] {':', '>'};
 		// When toCompletionParams get called with offset > 0 and document.getLength() > 0:
 		var param = LSPEclipseUtils.toCompletionParams(file.getLocationURI(), 3, LSPEclipseUtils.getDocument(file), triggerChars);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/folding/FoldingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/folding/FoldingTest.java
@@ -31,24 +31,31 @@ import org.junit.Test;
 public class FoldingTest extends AbstractTest {
 
 	private static final String CONTENT = """
-		import
-		import
-		import
-		visible
-		""";
+			import
+			import
+			import
+			visible
+			""";
 
 	@Test
 	public void testImportsFoldedByDefaultEnabled() throws CoreException {
 		collapseImports(true);
 		IEditorPart editor = createEditor();
-		DisplayHelper.waitAndAssertCondition(editor.getSite().getShell().getDisplay(), () -> assertEquals("import\nvisible", ((StyledText)editor.getAdapter(Control.class)).getText().trim()));
+
+		// wait for folding to happen
+		DisplayHelper.waitAndAssertCondition(editor.getSite().getShell().getDisplay(),
+				() -> assertEquals("import\nvisible",
+						((StyledText) editor.getAdapter(Control.class)).getText().trim()));
 	}
 
 	@Test
 	public void testImportsFoldedByDefaultDisabled() throws CoreException {
 		collapseImports(false);
 		IEditorPart editor = createEditor();
-		DisplayHelper.waitAndAssertCondition(editor.getSite().getShell().getDisplay(), () -> assertEquals(CONTENT, ((StyledText)editor.getAdapter(Control.class)).getText()));
+
+		// wait a few seconds before testing to ensure no folding happened
+		DisplayHelper.sleep(3000);
+		assertEquals(CONTENT, ((StyledText) editor.getAdapter(Control.class)).getText());
 	}
 
 	private IEditorPart createEditor() throws CoreException, PartInitException {
@@ -59,10 +66,10 @@ public class FoldingTest extends AbstractTest {
 		IEditorPart editor = TestUtils.openEditor(file);
 		return editor;
 	}
-	
+
 	private void collapseImports(boolean collapseImports) {
 		IPreferenceStore store = LanguageServerPlugin.getDefault().getPreferenceStore();
-		store.setValue("foldingReconcilingStrategy.collapseImports", true); //$NON-NLS-1$
+		store.setValue("foldingReconcilingStrategy.collapseImports", collapseImports); //$NON-NLS-1$
 	}
 
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/folding/FoldingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/folding/FoldingTest.java
@@ -16,7 +16,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.lsp4e.LanguageServerPlugin;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTest;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.FoldingRange;
@@ -26,10 +26,9 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class FoldingTest {
+public class FoldingTest extends AbstractTest {
 
 	private static final String CONTENT = """
 		import
@@ -37,9 +36,6 @@ public class FoldingTest {
 		import
 		visible
 		""";
-
-	@Rule
-	public final AllCleanRule clear = new AllCleanRule();
 
 	@Test
 	public void testImportsFoldedByDefaultEnabled() throws CoreException {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
@@ -36,7 +35,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.VersionedEdits;
 import org.eclipse.lsp4e.operations.format.LSPFormatter;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.Position;
@@ -44,19 +43,9 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.texteditor.ITextEditor;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class FormatTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
-	}
+public class FormatTest extends AbstractTestWithProject {
 
 	@Test
 	public void testFormattingInvalidDocument() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/highlight/HighlightTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/highlight/HighlightTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.text.ITextViewer;
@@ -30,7 +29,7 @@ import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.highlight.HighlightReconcilingStrategy;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.DocumentHighlight;
@@ -40,22 +39,11 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.ui.IEditorReference;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
 
-public class HighlightTest {
-
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("HighlightTest" + System.currentTimeMillis());
-	}
+public class HighlightTest extends AbstractTestWithProject{
 
 	@Test
 	public void testHighlight() throws CoreException {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/highlight/HighlightTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/highlight/HighlightTest.java
@@ -78,7 +78,7 @@ public class HighlightTest extends AbstractTestWithProject{
 	@Test
 	public void testCheckIfOtherAnnotationsRemains() throws CoreException {
 		checkGenericEditorVersion();
-		
+
 		MockLanguageServer.INSTANCE.setDocumentHighlights(Map.ofEntries( //
 				Map.entry(new Position(0, 1), List.of( //
 						new DocumentHighlight(new Range(new Position(0, 2), new Position(0, 6)), DocumentHighlightKind.Read)
@@ -107,12 +107,12 @@ public class HighlightTest extends AbstractTestWithProject{
 	}
 
 	@Test
-	public void testHighlightsInMultipleViewersForOneSource() throws CoreException, InterruptedException {
+	public void testHighlightsInMultipleViewersForOneSource() throws CoreException {
 		checkGenericEditorVersion();
 
 		// Create a test file with two sets of highlights
 		final IFile testFile = TestUtils.createUniqueTestFile(project, "ONE\nTWO");
-		
+
 		MockLanguageServer.INSTANCE.setDocumentHighlights(Map.ofEntries( //
 				Map.entry(new Position(0, 1), List.of( //
 						new DocumentHighlight(new Range(new Position(0, 0), new Position(0, 3)), DocumentHighlightKind.Write)
@@ -135,7 +135,7 @@ public class HighlightTest extends AbstractTestWithProject{
 
 		// Split the view in the active editor
 		List<IEditorReference> editorReferences = TestUtils.splitActiveEditor();
-		
+
 		// Keep track of the newly opened editor, so we can close it later
 		ISourceViewer viewer2 = null;
 		IEditorReference editorToClose = null;
@@ -148,7 +148,7 @@ public class HighlightTest extends AbstractTestWithProject{
 			}
 		}
 		Assert.assertNotNull(viewer2);
-		
+
 		final var annotationModel2 = viewer2.getAnnotationModel();
 
 		// Set the caret offset to activate the second set of highlights
@@ -197,7 +197,7 @@ public class HighlightTest extends AbstractTestWithProject{
 					" length=" + posLen + "}. Annotations found: " + annotations);
 		}
 	}
-	
+
 	private void assertAnnotationDoesNotExist(IAnnotationModel annotationModel, String annotationType, int posOffset, int posLen) {
 		final var hasAnnotation = new boolean[] { false };
 		final var annotations = new ArrayList<String>();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
@@ -22,14 +22,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.internal.text.html.BrowserInformationControl;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.hover.LSPTextHover;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -48,19 +47,14 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 @SuppressWarnings("restriction")
-public class HoverTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
+public class HoverTest extends AbstractTestWithProject {
 	private LSPTextHover hover;
 
 	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("HoverTest" + System.currentTimeMillis());
+	public void setUp() {
 		hover = new LSPTextHover();
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/linkedediting/LinkedEditingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/linkedediting/LinkedEditingTest.java
@@ -24,33 +24,22 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.link.LinkedPosition;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.LinkedEditingRanges;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class LinkedEditingTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("LinkedEditingTest" + System.currentTimeMillis());
-	}
+public class LinkedEditingTest extends AbstractTestWithProject {
 
 	@Test
 	public void testLinkedEditing() throws CoreException {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/message/ShowMessageTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/message/ShowMessageTest.java
@@ -16,9 +16,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -28,15 +27,12 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.ide.IDE;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class ShowMessageTest {
-	@Rule public AllCleanRule clear = new AllCleanRule();
+public class ShowMessageTest extends AbstractTestWithProject {
 
 	@Test
 	public void testShowMessage() throws CoreException {
-		IProject project = TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "");
 		IDE.openEditor(UI.getActivePage(), file);
 		String messageContent = "test notification " + System.currentTimeMillis();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/codelens/LSPCodeMiningTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/codelens/LSPCodeMiningTest.java
@@ -21,8 +21,6 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.IHandler;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LanguageServerWrapper;
@@ -31,7 +29,7 @@ import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.command.LSPCommandHandler;
 import org.eclipse.lsp4e.operations.codelens.CodeLensProvider;
 import org.eclipse.lsp4e.operations.codelens.LSPCodeMining;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.CodeLens;
@@ -45,8 +43,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.IHandlerService;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import com.google.gson.JsonObject;
@@ -56,18 +52,9 @@ import com.google.gson.JsonPrimitive;
  * Tests executing actions on server side or client side via registered
  * IHandler.
  */
-public class LSPCodeMiningTest {
+public class LSPCodeMiningTest extends AbstractTestWithProject {
 
 	private static final String MOCK_SERVER_ID = "org.eclipse.lsp4e.test.server";
-
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
-	}
 
 	@Test
 	public void testLSPCodeMiningActionClientSideHandling() throws Exception {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/inlayhint/LSPLineContentCodeMiningTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/inlayhint/LSPLineContentCodeMiningTest.java
@@ -6,7 +6,7 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- * 
+ *
  * Contributors:
  *     Broadcom, Inc. - initial API and implementation
  *******************************************************************************/
@@ -18,8 +18,6 @@ import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.LanguageServerWrapper;
@@ -27,7 +25,7 @@ import org.eclipse.lsp4e.LanguageServersRegistry;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.operations.inlayhint.InlayHintProvider;
 import org.eclipse.lsp4e.operations.inlayhint.LSPLineContentCodeMining;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.Command;
@@ -39,29 +37,17 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 
-public class LSPLineContentCodeMiningTest {
-	
+public class LSPLineContentCodeMiningTest extends AbstractTestWithProject {
+
 	private static final String MOCK_SERVER_ID = "org.eclipse.lsp4e.test.server";
 
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
-	}
-	
 	@Test
-	public void singleLabelPartCommand()
-			throws Exception {
+	public void singleLabelPartCommand() throws Exception {
 		final InlayHint inlay = createMultiLabelInlayHint(createInlayLabelPart("Label-Text", MockLanguageServer.SUPPORTED_COMMAND_ID));
 		Command command = inlay.getLabel().getRight().get(0).getCommand();
 		JsonObject jsonObject = new JsonObject();
@@ -89,14 +75,14 @@ public class LSPLineContentCodeMiningTest {
 		assertEquals(MockLanguageServer.SUPPORTED_COMMAND_ID, executedCommand.getCommand());
 		assertEquals(command.getArguments(), executedCommand.getArguments());
 	}
-	
+
 	private static InlayHintLabelPart createInlayLabelPart(String text, String commandID) {
 		InlayHintLabelPart labelPart = new InlayHintLabelPart(text);
 		Command command = new Command(text, commandID);
 		labelPart.setCommand(command);
 		return labelPart;
 	}
-	
+
 	private static InlayHint createMultiLabelInlayHint(InlayHintLabelPart... parts) {
 		InlayHint inlay = new InlayHint();
 		inlay.setLabel(Arrays.asList(parts));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/EditorToOutlineAdapterFactoryTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/EditorToOutlineAdapterFactoryTest.java
@@ -12,9 +12,8 @@
 package org.eclipse.lsp4e.test.outline;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
@@ -24,15 +23,11 @@ import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.ui.views.contentoutline.ContentOutline;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class EditorToOutlineAdapterFactoryTest {
+public class EditorToOutlineAdapterFactoryTest extends AbstractTestWithProject {
 
 	private static ContentOutline outline;
-
-	@Rule
-	public AllCleanRule rule = new AllCleanRule();
 
 	@BeforeClass
 	public static void setUpBeforeClass() {
@@ -49,7 +44,6 @@ public class EditorToOutlineAdapterFactoryTest {
 
 	@Test
 	public void testGetAdapter() throws CoreException {
-		IProject project = TestUtils.createProject("EditorToOutlineAdapterFactoryTest" + System.currentTimeMillis());
 		IFile testFile = TestUtils.createUniqueTestFile(project, "Hello World !!");
 		outline.partClosed(outline);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -30,7 +29,7 @@ import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.outline.CNFOutlinePage;
 import org.eclipse.lsp4e.outline.EditorToOutlineAdapterFactory;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.DocumentSymbol;
@@ -44,14 +43,10 @@ import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class OutlineContentTest {
+public class OutlineContentTest extends AbstractTestWithProject {
 
-	@Rule
-	public AllCleanRule rule = new AllCleanRule();
-	
 	@Test
 	public void testExternalFile() throws CoreException, IOException {
 		var testFile = TestUtils.createTempFile("test" + System.currentTimeMillis(), ".lspt");
@@ -88,8 +83,6 @@ public class OutlineContentTest {
 
 	@Test
 	public void testOutlineSorting() throws CoreException, IOException {
-		IProject project = TestUtils
-				.createProject("OutlineContentTest_testOutlineSorting" + System.currentTimeMillis());
 		IFile testFile = TestUtils.createUniqueTestFile(project, "content\n does\n not\n matter\n but needs to cover the ranges described below");
 		DocumentSymbol symbolCow = new DocumentSymbol("cow", SymbolKind.Constant,
 				new Range(new Position(0, 0), new Position(0, 2)),
@@ -141,8 +134,6 @@ public class OutlineContentTest {
 
 	@Test
 	public void testNodeRemainExpandedUponSelection() throws CoreException, IOException {
-		IProject project = TestUtils
-				.createProject("OutlineContentTest_testNodeRemainExpandedUponSelection" + System.currentTimeMillis());
 		IFile testFile = TestUtils.createUniqueTestFile(project, "a(b())");
 		MockLanguageServer.INSTANCE.setDocumentSymbols(
 				new DocumentSymbol("a", SymbolKind.Constant, new Range(new Position(0, 0), new Position(0, 6)),
@@ -178,8 +169,6 @@ public class OutlineContentTest {
 
 	@Test
 	public void testNodeRemainExpandedUponModification() throws CoreException, BadLocationException, IOException {
-		IProject project = TestUtils.createProject(
-				"OutlineContentTest_testNodeRemainExpandedUponModification" + System.currentTimeMillis());
 		IFile testFile = TestUtils.createUniqueTestFile(project, "a(b())");
 		MockLanguageServer.INSTANCE.setDocumentSymbols(
 				new DocumentSymbol("a", SymbolKind.Constant, new Range(new Position(0, 0), new Position(0, 6)),

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsLabelProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsLabelProviderTest.java
@@ -15,19 +15,17 @@ import static org.junit.Assert.*;
 
 import org.eclipse.lsp4e.outline.SymbolsLabelProvider;
 import org.eclipse.lsp4e.outline.SymbolsModel;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTest;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class SymbolsLabelProviderTest {
+public class SymbolsLabelProviderTest extends AbstractTest {
 
-	@Rule public AllCleanRule clear = new AllCleanRule();
 	private static final Location LOCATION = new Location("path/to/foo", new Range(new Position(0,0), new Position(1,1)));
 	private static final Location INVALID_LOCATION = new Location("file:://///invalid_location_uri", new Range(new Position(0,0), new Position(1,1)));
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/references/FindReferencesTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/references/FindReferencesTest.java
@@ -13,11 +13,7 @@
 package org.eclipse.lsp4e.test.references;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -26,12 +22,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.lsp4e.internal.Pair;
 import org.eclipse.lsp4e.operations.references.LSFindReferences;
 import org.eclipse.lsp4e.operations.references.LSSearchResult;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.Location;
@@ -50,11 +44,10 @@ import org.eclipse.ui.services.IEvaluationService;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 @SuppressWarnings("restriction")
-public class FindReferencesTest {
+public class FindReferencesTest extends AbstractTestWithProject {
 
 	public static final class UiFreezeEventLogger implements IUiFreezeEventLogger {
 
@@ -73,13 +66,8 @@ public class FindReferencesTest {
 		}
 	}
 
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-	private IProject project;
-
 	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject("CompletionTest" + System.currentTimeMillis());
+	public void setUp() throws Exception {
 		ensureSearchResultViewIsClosed();
 
 		final var testFile = TestUtils.createUniqueTestFile(project, "word1 word2\nword3 word2");

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
@@ -18,28 +18,23 @@ import java.io.File;
 import java.nio.file.Files;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.refactoring.LSPTextChange;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
 import org.eclipse.ltk.core.refactoring.TextChange;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class LSPTextChangeTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
+public class LSPTextChangeTest extends AbstractTestWithProject {
 
 	@Test
 	public void testPerformOperationWorkspaceFile() throws Exception {
-		IProject project = TestUtils.createProject("blah");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		TextEdit edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
 		PerformChangeOperation operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
@@ -51,7 +46,6 @@ public class LSPTextChangeTest {
 
 	@Test
 	public void testRefactoringPreview() throws Exception {
-		IProject project = TestUtils.createProject("blah");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		TextEdit edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
 		TextChange change = new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
@@ -36,14 +36,13 @@ import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.rename.LSPRenameProcessor;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.Position;
@@ -65,16 +64,12 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.texteditor.ITextEditor;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class RenameTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
+public class RenameTest extends AbstractTestWithProject {
 
 	@Test
 	public void testRenameHandlerEnablement() throws Exception {
-		IProject project = TestUtils.createProject("blah");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
 		editor.selectAndReveal(1, 0);
@@ -94,7 +89,6 @@ public class RenameTest {
 		MockLanguageServer.INSTANCE.setTimeToProceedQueries(delay);
 
 		try {
-			IProject project = TestUtils.createProject("blah");
 			IFile file = TestUtils.createUniqueTestFile(project, "old");
 			ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
 			editor.selectAndReveal(1, 0);
@@ -113,7 +107,6 @@ public class RenameTest {
 
 	@Test
 	public void testRenameRefactoring() throws Exception {
-		IProject project = TestUtils.createProject("blah");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
@@ -132,7 +125,6 @@ public class RenameTest {
 
 	@Test
 	public void testPrepareRenameRefactoring() throws Exception {
-		IProject project = TestUtils.createProject("testPrepareRenameRefactoring");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
@@ -151,7 +143,6 @@ public class RenameTest {
 
 	@Test
 	public void testPrepareRenameRefactoringError() throws Exception {
-		IProject project = TestUtils.createProject("testPrepareRenameRefactoring");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		MockLanguageServer.INSTANCE.getTextDocumentService().setPrepareRenameResult(null);
@@ -196,7 +187,6 @@ public class RenameTest {
 
 	@Test
 	public void testRenameChangeAlsoExternalFile() throws Exception {
-		IProject project = TestUtils.createProject("blah");
 		IFile workspaceFile = TestUtils.createUniqueTestFile(project, "old");
 		File externalFile = TestUtils.createTempFile("testRenameChangeAlsoExternalFile", ".lspt");
 		Files.write(externalFile.toPath(), "old".getBytes());
@@ -221,7 +211,6 @@ public class RenameTest {
 
 	@Test
 	public void testRenameHandlerExecution() throws Exception {
-		IProject project = TestUtils.createProject("blah");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
@@ -263,7 +252,6 @@ public class RenameTest {
 
 	@Test
 	public void testPlaceholderUsingPlaceholderFromPrepareRenameResult() throws Exception {
-		IProject project = TestUtils.createProject("blah");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
@@ -280,7 +268,6 @@ public class RenameTest {
 
 	@Test
 	public void testPlaceholderUsingRangeFromPrepareRenameResult() throws Exception {
-		IProject project = TestUtils.createProject("blah");
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		Range range = new Range(new Position(0, 1), new Position(0, 3)); // Two last letters of "old".

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticHighlightReconcilerStrategyTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticHighlightReconcilerStrategyTest.java
@@ -15,10 +15,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.ITextViewer;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.SemanticTokens;
@@ -27,19 +26,14 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class SemanticHighlightReconcilerStrategyTest {
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
+public class SemanticHighlightReconcilerStrategyTest extends AbstractTestWithProject {
 
-	private IProject project;
 	private Shell shell;
 
 	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
+	public void setUp() {
 		shell = new Shell();
 
 		// Setup Server Capabilities

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensDataStreamProcessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensDataStreamProcessorTest.java
@@ -15,15 +15,12 @@ import java.util.List;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.lsp4e.operations.semanticTokens.SemanticTokensDataStreamProcessor;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTest;
 import org.eclipse.lsp4j.SemanticTokensLegend;
 import org.eclipse.swt.custom.StyleRange;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class SemanticTokensDataStreamProcessorTest {
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
+public class SemanticTokensDataStreamProcessorTest extends AbstractTest {
 
 	@Test
 	public void testKeyword() {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensLegendProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensLegendProviderTest.java
@@ -16,29 +16,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.operations.semanticTokens.SemanticHighlightReconcilerStrategy;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4j.SemanticTokensLegend;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class SemanticTokensLegendProviderTest {
-
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
-
-	private IProject project;
-
-	@Before
-	public void setUp() throws CoreException {
-		project = TestUtils.createProject(getClass().getName() + System.currentTimeMillis());
-	}
+public class SemanticTokensLegendProviderTest extends AbstractTestWithProject {
 
 	@Test
 	public void testSemanticTokensLegendProvider() throws CoreException, IOException {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/StyleRangeHolderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/StyleRangeHolderTest.java
@@ -18,15 +18,12 @@ import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.TextEvent;
 import org.eclipse.lsp4e.operations.semanticTokens.StyleRangeHolder;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTest;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.graphics.Color;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class StyleRangeHolderTest {
-	@Rule
-	public AllCleanRule clear = new AllCleanRule();
+public class StyleRangeHolderTest extends AbstractTest {
 
 	private static final Color RED = new Color(255, 0, 0);
 	private List<StyleRange> originalStyleRanges = Arrays.asList(new StyleRange(0, 4, RED, null), new StyleRange(15, 4, RED, null), new StyleRange(24, 7, RED, null));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/symbols/SymbolsModelTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/symbols/SymbolsModelTest.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.lsp4e.outline.SymbolsModel;
-import org.eclipse.lsp4e.test.utils.AllCleanRule;
+import org.eclipse.lsp4e.test.utils.AbstractTest;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -28,12 +28,9 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class SymbolsModelTest {
-
-	@Rule public AllCleanRule clear = new AllCleanRule();
+public class SymbolsModelTest extends AbstractTest {
 
 	@Test
 	public void test() {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AbstractTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AbstractTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Sebastian Thomschke (Vegard IT GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.utils;
+
+import java.io.PrintStream;
+
+import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+
+/**
+ * Test base class that configures a {@link AllCleanRule} and a
+ * {@link TestInfoRule} and works around a surefire-plugin issue which
+ * suppresses output to stderr
+ */
+public abstract class AbstractTest {
+
+	private static PrintStream originalSystemErr;
+
+	private static final boolean isExecutedBySurefirePlugin = System.getProperty("surefire.real.class.path") != null;
+
+	@BeforeClass
+	public static void setUpSystemErrRedirection() throws Exception {
+		if (isExecutedBySurefirePlugin) {
+			// redirect stderr to stdout during test execution as it is otherwise suppressed
+			// by the surefire-plugin
+			originalSystemErr = System.err;
+			System.setErr(System.out);
+		}
+	}
+
+	@AfterClass
+	public static void tearDownSystemErrRedirection() throws Exception {
+		if (isExecutedBySurefirePlugin) {
+			System.setErr(originalSystemErr);
+		}
+	}
+
+	public final @Rule(order = 1) AllCleanRule allCleanRule = new AllCleanRule(this::getServerCapabilities);
+	public final @Rule(order = 0) TestInfoRule testInfo = new TestInfoRule();
+
+	/**
+	 * Override if required, used by {@link #allCleanRule}
+	 */
+	protected ServerCapabilities getServerCapabilities() {
+		return MockLanguageServer.defaultServerCapabilities();
+	}
+}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AbstractTestWithProject.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AbstractTestWithProject.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Sebastian Thomschke (Vegard IT GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.utils;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * Test base class that provides a new unique temporary test project for each @org.junit.Test run
+ */
+public abstract class AbstractTestWithProject extends AbstractTest {
+	protected IProject project;
+
+	@Before
+	public void setUpProject() throws Exception {
+		project = TestUtils.createProject(
+				testInfo.getSimpleClassName() + "_" + testInfo.getMethodName() + "_" + System.currentTimeMillis());
+	}
+
+	@After
+	public void tearDownProject() throws Exception {
+		project.delete(IResource.FORCE, null);
+	}
+}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AllCleanRule.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AllCleanRule.java
@@ -28,9 +28,7 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 public class AllCleanRule extends TestWatcher {
-	
-	private static final boolean LOG_TEST_NAMES = Boolean.getBoolean("lsp4e.log.test.names");
-	
+
 	private final Supplier<ServerCapabilities> serverConfigurer;
 
 	public AllCleanRule() {
@@ -47,9 +45,6 @@ public class AllCleanRule extends TestWatcher {
 		IIntroPart intro = PlatformUI.getWorkbench().getIntroManager().getIntro();
 		if (intro != null) {
 			PlatformUI.getWorkbench().getIntroManager().closeIntro(intro);
-		}
-		if (LOG_TEST_NAMES) {
-			System.out.println("Starting: " + description);
 		}
 		clear();
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestInfoRule.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestInfoRule.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Sebastian Thomschke (Vegard IT GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.utils;
+
+import java.lang.System.Logger.Level;
+
+import org.junit.rules.TestName;
+import org.junit.runner.Description;
+
+public class TestInfoRule extends TestName {
+	private volatile Class<?> testClass;
+	private volatile String displayName;
+
+	@Override
+	protected void starting(Description d) {
+		super.starting(d);
+		testClass = d.getTestClass();
+		System.getLogger(testClass.getName()).log(Level.INFO, "Testing [" + getMethodName() + "()]...");
+	}
+
+	public String getClassName() {
+		return testClass.getName();
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	public String getSimpleClassName() {
+		return testClass.getSimpleName();
+	}
+
+	@Override
+	public String toString() {
+		return getClassName() + "#" + getMethodName();
+	}
+}


### PR DESCRIPTION
Adhering to the DRY principle, this PR introduces two new abstract classes [AbstractTest](https://github.com/sebthom/lsp4e/blob/abstract-test/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AbstractTest.java) and [AbstractTestWithProject](https://github.com/sebthom/lsp4e/blob/abstract-test/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AbstractTestWithProject.java). This saves 300 lines of repetitive boilerplate statements and fixes inconsistencies in test case setup.

One of the main drivers for this PR is, that I am still getting a lot of random test failures when executing the test suite locally on Windows and Ubuntu. This PR is part of an effort to get to the root of it by streamlining the test setup.