### PR TITLE
Use custom context to scope key bindings for language server

### DIFF
--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -377,11 +377,18 @@
             id="org.eclipse.lsp4e.operations.hover.LSPTextHover">
       </hoverProvider>
    </extension>
+   <extension point="org.eclipse.ui.contexts">
+       <context name="Language Server" 
+            description="Language Server Editor Context" 
+            id="org.eclipse.lsp4e.context" 
+            parentId="org.eclipse.ui.genericeditor.genericEditorContext">
+       </context>
+  </extension>
    <extension
          point="org.eclipse.ui.bindings">
       <key
             commandId="org.eclipse.lsp4e.symbolinfile"
-            contextId="org.eclipse.ui.textEditorScope"
+            contextId="org.eclipse.lsp4e.context"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+O">
       </key>
@@ -393,7 +400,7 @@
       </key>
       <key
             commandId="org.eclipse.lsp4e.format"
-            contextId="org.eclipse.ui.textEditorScope"
+            contextId="org.eclipse.lsp4e.context"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+M2+F">
       </key>
@@ -402,12 +409,12 @@
       <key
             sequence="M2+M3+R"
             commandId="org.eclipse.ui.edit.rename"
-            contextId="org.eclipse.ui.genericeditor.genericEditorContext"
+            contextId="org.eclipse.lsp4e.context"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
       </key>
       <key
             commandId="org.eclipse.lsp4e.openCallHierarchy"
-            contextId="org.eclipse.ui.genericeditor.genericEditorContext"
+            contextId="org.eclipse.lsp4e.context"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="Ctrl+Alt+H">
       </key>
@@ -415,23 +422,23 @@
       <!-- edit -->
       <key
             sequence="M2+M3+ARROW_UP"
-            contextId="org.eclipse.ui.genericeditor.genericEditorContext"
+            contextId="org.eclipse.lsp4e.context"
             commandId="org.eclipse.lsp4e.selectionRange.up"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
       <key
             sequence="M2+M3+ARROW_DOWN"
-            contextId="org.eclipse.ui.genericeditor.genericEditorContext"
+            contextId="org.eclipse.lsp4e.context"
             commandId="org.eclipse.lsp4e.selectionRange.down"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
       <key
             commandId="org.eclipse.lsp4e.typeHierarchy"
-            contextId="org.eclipse.ui.textEditorScope"
+            contextId="org.eclipse.lsp4e.context"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+T">
       </key>
       <key
             commandId="org.eclipse.lsp4e.openTypeHierarchy"
-            contextId="org.eclipse.ui.genericeditor.genericEditorContext"
+            contextId="org.eclipse.lsp4e.context"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="F4">
       </key>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
@@ -11,17 +11,31 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
+
+import java.util.WeakHashMap;
+
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.lsp4e.ui.LSPImages;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IPartService;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.contexts.IContextActivation;
+import org.eclipse.ui.contexts.IContextService;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
 public class LanguageServerPlugin extends AbstractUIPlugin {
 
 	public static final String PLUGIN_ID = "org.eclipse.lsp4e"; //$NON-NLS-1$
+
+	public static final String CONTEXT_ID = "org.eclipse.lsp4e.context"; //$NON-NLS-1$
 
 	public static final boolean DEBUG = Boolean.parseBoolean(Platform.getDebugOption("org.eclipse.lsp4e/debug")); //$NON-NLS-1$
 
@@ -31,10 +45,53 @@ public class LanguageServerPlugin extends AbstractUIPlugin {
 	public LanguageServerPlugin() {
 	}
 
+	public static class WindowListener implements IPartListener2 {
+		private final IContextService service;
+
+		private final WeakHashMap<IWorkbenchPart, IContextActivation> activations = new WeakHashMap<>();
+		public WindowListener(IContextService service) {
+			this.service = service;
+			}
+
+		@Override public void
+		partActivated(IWorkbenchPartReference partRef) {
+			IWorkbenchPart part = partRef.getPart(false);
+			if (part instanceof IEditorPart) {
+				IEditorPart editorPart = (IEditorPart)part;
+				if (LanguageServersRegistry.getInstance().canUseLanguageServer(editorPart.getEditorInput())) {
+					IContextActivation activation = this.service.activateContext(CONTEXT_ID);
+					this.activations.put(editorPart, activation);
+				}
+			}
+
+		}
+
+		@Override public void
+		partDeactivated(IWorkbenchPartReference partRef) {
+			IWorkbenchPart part = partRef.getPart(false);
+
+			if (part instanceof IEditorPart) {
+				IEditorPart editorPart = (IEditorPart)part;
+				IContextActivation activation = this.activations.remove(editorPart);
+				if (activation != null) {
+					this.service.deactivateContext(activation);
+				}
+			}
+		}
+	}
+
 	@Override
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
+		IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		IPartService partService = window.getPartService();
+		IContextService contextService = PlatformUI.getWorkbench()
+				.getService(IContextService.class);
+		IPartListener2 listener = new WindowListener(contextService);
+		partService.addPartListener(listener);
+
+
 	}
 
 	@Override


### PR DESCRIPTION
There are some problems with promiscuously scoped keybindings in the core platform that mean that some keybindings used by LSP4e don't always work or are at odds with the accelerators that show up in the menus, making them less discoverable.

The problems our users observe are Rename (shows up as F2 in the editor context menu, even though we switched to alt-shift-R some time ago when we had trouble with F2 not working, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=525413) and sometimes format (cmd-shift-F on a Mac).

The culprit with F2 seems to be https://github.com/eclipse-platform/eclipse.platform.ui/blob/1dc77e0823e8b8bfb703ac2ea9c53266555a629e/bundles/org.eclipse.ui.workbench.texteditor/plugin.xml#L503 which binds it to 'show information' clashing with https://github.com/eclipse-platform/eclipse.platform.ui/blob/1dc77e0823e8b8bfb703ac2ea9c53266555a629e/bundles/org.eclipse.ui/plugin.xml#L114

The latter causes F2 to show up as the accelerator in menus, the former causes it not to work in the text editor.

Haven't got to the bottom of what's happening with format, but I think it might be a peer plugin as it mysteriously started working again on update to our plugin, so that might indicate order of installation affecting things in the case of a tie.

There are two abstraction/scoping mechanisms for key bindings as I understand it, scheme and context. If I create a custom scheme within the `bindings` extension block in `plugin.xml` and set the key bindings to use that rather than the default `org.eclipse.ui.defaultAcceleratorConfiguration` then both the menu hints and the accelerators themselves work correctly, **provided the user selects that scheme in preferences**. That feels like the wrong approach - the scheme is more a mechanism for users to 'make eclipse like Emacs or IntelliJ'.

So I think the solution that circumvents any promiscuous behaviour by core or other plugins is to have a context that is active when the active editor is LSP-enabled. I've bodged together example code and it seemed to work.

Any thoughts from anyone? I'm not proposing to submit it in this state, I hasten to add! I wondered if anyone has any better ideas and in particular someone more familiar with eclipse extension points can think of a declarative way of activating a context - LSP4e has the nice `hasLanguageServer` property tester but as far as I can see there isn't anything declarative like `activeWhen` for the context service, hence the ugly use of workbench-level events in my example code. My company in fact uses its own `IContext` with our own language server plugin but we actually use an editor subclass, which means we can override the `initializeKeyBindingScopes` method. LSP4e at the moment allows consuming plugins to use the generic editor directly and adds in its custom behaviour entirely through platform extensions, which is the preferred way of doing it, so forcing consumers to use a custom editor subclass isn't really an option.