### PR TITLE
add LanguageServerWrapper#toString method

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
@@ -63,15 +63,18 @@ public class LanguageServerWrapperTest {
 		LanguageServerWrapper wrapper = wrappers.iterator().next();
 		waitForAndAssertCondition(2_000, () -> wrapper.isActive());
 
+		// e.g. LanguageServerWrapper@69fe8c75 [serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P/LanguageServerWrapperTestProject11691664858710, isActive=true]
+		assertTrue(wrapper.toString().matches("LanguageServerWrapper@[0-9a-f]+ \\[serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P\\/LanguageServerWrapperTestProject1[0-9]+, isActive=true\\]"));
+
 		assertTrue(wrapper.isConnectedTo(testFile1.getLocationURI()));
 		assertTrue(wrapper.isConnectedTo(testFile2.getLocationURI()));
 
 		TestUtils.closeEditor(editor1, false);
 		TestUtils.closeEditor(editor2, false);
 	}
-	
+
 	/**
-	 * Check if {@code isActive()} is correctly synchronized with  {@code stop()} 
+	 * Check if {@code isActive()} is correctly synchronized with  {@code stop()}
 	 * @see https://github.com/eclipse/lsp4e/pull/688
 	 */
 	@Test
@@ -110,8 +113,7 @@ public class LanguageServerWrapperTest {
 				}
 			}
 		} finally {
-			TestUtils.closeEditor(editor1, false);	
+			TestUtils.closeEditor(editor1, false);
 		}
-		
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -1009,6 +1009,16 @@ public class LanguageServerWrapper {
 		return serverDefinition.isSingleton || supportsWorkspaceFolderCapability();
 	}
 
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + '@' + Integer.toHexString(System.identityHashCode(this)) //
+				+ " [serverId=" + serverDefinition.id //$NON-NLS-1$
+				+ ", initialPath=" + initialPath //$NON-NLS-1$
+				+ ", initialProject=" + initialProject //$NON-NLS-1$
+				+ ", isActive=" + isActive() //$NON-NLS-1$
+				+ ']';
+	}
+
 	/**
 	 * Resource listener that translates Eclipse resource events into LSP workspace folder events
 	 * and dispatches them if the language server is still active


### PR DESCRIPTION
This is especially useful for debugging failing unit tests on remote CIs because of unexpected language server wrappers being returned by `LanguageServiceAccessor.getLSWrappers` in flaky tests.