### PR TITLE
add LanguageServerWrapper#getProcessHandle()

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
-Bundle-Version: 0.15.2.qualifier
+Bundle-Version: 0.15.3.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPProcess.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPProcess.java
@@ -40,7 +40,11 @@ public class DSPProcess implements IProcess {
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter.isInstance(handle)) {
+			return (T) handle.orElse(null);
+		}
 		return target.getAdapter(adapter);
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
@@ -12,8 +12,7 @@
 package org.eclipse.lsp4e.test;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -64,7 +63,7 @@ public class LanguageServerWrapperTest {
 		waitForAndAssertCondition(2_000, () -> wrapper.isActive());
 
 		// e.g. LanguageServerWrapper@69fe8c75 [serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P/LanguageServerWrapperTestProject11691664858710, isActive=true]
-		assertTrue(wrapper.toString().matches("LanguageServerWrapper@[0-9a-f]+ \\[serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P\\/LanguageServerWrapperTestProject1[0-9]+, isActive=true\\]"));
+		assertTrue(wrapper.toString().matches("LanguageServerWrapper@[0-9a-f]+ \\[serverId=org.eclipse.lsp4e.test.server-with-multi-root-support, initialPath=null, initialProject=P\\/LanguageServerWrapperTestProject1[0-9]+, isActive=true, pid=(null|[0-9])+\\]"));
 
 		assertTrue(wrapper.isConnectedTo(testFile1.getLocationURI()));
 		assertTrue(wrapper.isConnectedTo(testFile2.getLocationURI()));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -52,6 +52,7 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -344,6 +345,11 @@ public class LanguageServerWrapper {
 
 		// no then...Async future here as we want this chain of operation to be sequential and "atomic"-ish
 		return languageServer.initialize(initParams);
+	}
+
+	@Nullable
+	public ProcessHandle getProcessHandle() {
+		return Adapters.adapt(lspStreamProvider, ProcessHandle.class);
 	}
 
 	private ClientInfo getClientInfo(String name) {
@@ -1011,11 +1017,13 @@ public class LanguageServerWrapper {
 
 	@Override
 	public String toString() {
+		final var ph = getProcessHandle();
 		return getClass().getSimpleName() + '@' + Integer.toHexString(System.identityHashCode(this)) //
 				+ " [serverId=" + serverDefinition.id //$NON-NLS-1$
 				+ ", initialPath=" + initialPath //$NON-NLS-1$
 				+ ", initialProject=" + initialProject //$NON-NLS-1$
 				+ ", isActive=" + isActive() //$NON-NLS-1$
+				+ ", pid=" + (ph == null ? null : ph.pid()) //$NON-NLS-1$
 				+ ']';
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LaunchConfigurationStreamProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LaunchConfigurationStreamProvider.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.DebugException;
@@ -44,7 +45,7 @@ import org.eclipse.lsp4e.server.StreamConnectionProvider;
  * Access and control IO streams from a Launch Configuration to connect
  * them to language server protocol client.
  */
-public class LaunchConfigurationStreamProvider implements StreamConnectionProvider  {
+public class LaunchConfigurationStreamProvider implements StreamConnectionProvider, IAdaptable {
 
 	private StreamProxyInputStream inputStream;
 	private StreamProxyInputStream errorStream;
@@ -207,6 +208,14 @@ public class LaunchConfigurationStreamProvider implements StreamConnectionProvid
 	}
 
 	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if(adapter == ProcessHandle.class) {
+			return process.getAdapter(adapter);
+		}
+		return null;
+	}
+
+	@Override
 	public InputStream getInputStream() {
 		return this.inputStream;
 	}
@@ -254,5 +263,4 @@ public class LaunchConfigurationStreamProvider implements StreamConnectionProvid
 		this.outputStream = null;
 		this.errorStream = null;
 	}
-
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LoggingStreamConnectionProviderProxy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LoggingStreamConnectionProviderProxy.java
@@ -24,6 +24,8 @@ import java.nio.file.StandardOpenOption;
 import java.time.OffsetDateTime;
 
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.Adapters;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -37,7 +39,7 @@ import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.MessageConsole;
 import org.eclipse.ui.console.MessageConsoleStream;
 
-public class LoggingStreamConnectionProviderProxy implements StreamConnectionProvider {
+public class LoggingStreamConnectionProviderProxy implements StreamConnectionProvider, IAdaptable {
 
 	public static File getLogDirectory() {
 		IPath root = ResourcesPlugin.getWorkspace().getRoot().getLocation();
@@ -157,6 +159,14 @@ public class LoggingStreamConnectionProviderProxy implements StreamConnectionPro
 			};
 		}
 		return inputStream;
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if(adapter == ProcessHandle.class) {
+			return Adapters.adapt(provider, adapter);
+		}
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/ProcessStreamConnectionProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/ProcessStreamConnectionProvider.java
@@ -20,13 +20,14 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Objects;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
  *
  * @since 0.1.0
  */
-public abstract class ProcessStreamConnectionProvider implements StreamConnectionProvider {
+public abstract class ProcessStreamConnectionProvider implements StreamConnectionProvider, IAdaptable {
 
 	private @Nullable Process process;
 	private List<String> commands;
@@ -93,6 +94,20 @@ public abstract class ProcessStreamConnectionProvider implements StreamConnectio
 		}
 	}
 
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T getAdapter(Class<T> adapter) {
+		final var process = this.process;
+		if(adapter == ProcessHandle.class) {
+			try {
+				return process == null ? null : (T) process.toHandle();
+			} catch(UnsupportedOperationException ex) {
+				// ignore
+			}
+		}
+		return null;
+	}
+
 	protected List<String> getCommands() {
 		return commands;
 	}
@@ -129,5 +144,4 @@ public abstract class ProcessStreamConnectionProvider implements StreamConnectio
 		return "ProcessStreamConnectionProvider [commands=" + this.getCommands() + ", workingDir=" //$NON-NLS-1$//$NON-NLS-2$
 				+ this.getWorkingDirectory() + "]"; //$NON-NLS-1$
 	}
-
 }


### PR DESCRIPTION
This PR adds the `LanguageServerWrapper#getProcessHandle()` method and enriches the the `LanguageServerWrapper#toString()` info with the pid of the underlying LS process.

The `LanguageServerWrapper#getProcessHandle()` will also be useful when implementing a LanguageServers UI view to access information such as pid, working directory or command of the underlying LS process.