### PR TITLE
export format package

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -50,6 +50,7 @@ Export-Package: org.eclipse.lsp4e;x-internal:=true,
  org.eclipse.lsp4e.operations.codeactions;x-internal:=true,
  org.eclipse.lsp4e.command;x-internal:=true,
  org.eclipse.lsp4e.operations.completion;x-internal:=true,
+ org.eclipse.lsp4e.operations.format;x-internal:=true,
  org.eclipse.lsp4e.operations.hover;x-internal:=true,
  org.eclipse.lsp4e.outline;x-internal:=true,
  org.eclipse.lsp4e.server;version="0.1.0"


### PR DESCRIPTION
This package is needed in DocumentProviders of LSP based editors to support the format on file save action. Only needed for servers who do not support willSaveWaitUntil

fixes #761