### PR TITLE
fix missing member from types in external file

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -593,7 +593,7 @@ public final class LSPEclipseUtils {
 	}
 
 	@Nullable
-	private static IDocument getDocument(URI uri) {
+	public static IDocument getDocument(URI uri) {
 		if (uri == null) {
 			return null;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyViewContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyViewContentProvider.java
@@ -45,6 +45,7 @@ public class TypeHierarchyViewContentProvider implements ITreeContentProvider {
 	private LanguageServerWrapper languageServerWrapper;
 	private List<TypeHierarchyItem> hierarchyItems = Collections.emptyList();
 	public boolean showSuperTypes = true;
+	public IDocument document;
 
 	@Override
 	public Object[] getElements(Object inputElement) {
@@ -90,7 +91,8 @@ public class TypeHierarchyViewContentProvider implements ITreeContentProvider {
 
 		if (newInput instanceof HierarchyViewInput viewInput) {
 
-			IDocument document = viewInput.getDocument();
+			var document = viewInput.getDocument();
+			this.document = document;
 			if (document != null) {
 				try {
 					initialise(document, viewInput.getOffset(), (TreeViewer) viewer);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeMemberContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeMemberContentProvider.java
@@ -11,41 +11,32 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.typeHierarchy;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.viewers.IStructuredContentProvider;
-import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4j.DocumentSymbol;
 
 public class TypeMemberContentProvider implements IStructuredContentProvider {
 	private static final Object[] NO_CHILDREN = new Object[0];
-	DocumentSymbolWithURI symbolContainer;
-
-	@Override
-	final public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
-		if (newInput instanceof DocumentSymbolWithURI symbolWithURI) {
-			symbolContainer = symbolWithURI;
-		}
-	}
-
-	@Override
-	public void dispose() {
-		symbolContainer = null;
-	}
 
 	@Override
 	public Object[] getElements(Object inputElement) {
-		return Optional.ofNullable(symbolContainer)
-				.map(container -> toContainer(container.symbol.getChildren())).orElse(NO_CHILDREN);
+		if (inputElement instanceof DocumentSymbolWithURI symbolContainer) {
+			return Optional.ofNullable(symbolContainer)
+					.map(container -> toContainer(container.symbol.getChildren(), container.uri)).orElse(NO_CHILDREN);
+		}
+		return NO_CHILDREN;
 	}
 
-	private Object[] toContainer(List<DocumentSymbol> symbols) {
+	private Object[] toContainer(List<DocumentSymbol> symbols, @NonNull URI uri) {
 		if (symbols != null) {
 			var container = new DocumentSymbolWithURI[symbols.size()];
 			for (int i = 0; i < symbols.size(); i++) {
-				container[i] = new DocumentSymbolWithURI(symbols.get(i), symbolContainer.uri);
+				container[i] = new DocumentSymbolWithURI(symbols.get(i), uri);
 			}
 			return container;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
@@ -103,4 +103,4 @@ CH_no_call_hierarchy = No Call Hierarchy for the selected element
 CH_finding_callers = Finding callers ...
 TH_no_type_hierarchy = No Type Hierarchy for the selected element
 TH_diplay_hint = To display the type hierarchy, select a type or a member and select the 'Open Type Hierarchy' menu option.
-TH_cannot_find_file = Cannot find file {0}
+TH_cannot_find_file = Cannot find file


### PR DESCRIPTION
When the type is declared in an external file, then the IDocument object for this file has to be created and opened. Then the symbols can be fetched form this file via LS.

fixes #775