### PR TITLE
Fix References Displaying Incorrect Line Number in Search Panel

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/references/FindReferencesTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/references/FindReferencesTest.java
@@ -33,6 +33,7 @@ import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.search.internal.ui.text.FileMatch;
 import org.eclipse.search.ui.IQueryListener;
 import org.eclipse.search.ui.ISearchQuery;
 import org.eclipse.search.ui.ISearchResult;
@@ -194,10 +195,16 @@ public class FindReferencesTest {
 				final var match1 = lsSearchResult.getMatches(file)[0];
 				assertEquals(6, match1.getOffset());
 				assertEquals(5, match1.getLength());
+				if(match1 instanceof FileMatch fileMatch) {
+					assertEquals(1, fileMatch.getLineElement().getLine());
+				}
 
 				final var match2 = lsSearchResult.getMatches(file)[1];
 				assertEquals(18, match2.getOffset());
 				assertEquals(5, match2.getLength());
+				if(match2 instanceof FileMatch fileMatch) {
+					assertEquals(2, fileMatch.getLineElement().getLine());
+				}
 
 				if (searchDuration.get() < 0) {
 					searchDuration.set(now - startAt);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchQuery.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchQuery.java
@@ -128,7 +128,7 @@ public class LSSearchQuery extends FileSearchQuery {
 					int endOffset = LSPEclipseUtils.toOffset(location.getRange().getEnd(), document);
 
 					IRegion lineInformation = document.getLineInformationOfOffset(startOffset);
-					final var lineEntry = new LineElement(resource, document.getLineOfOffset(startOffset),
+					final var lineEntry = new LineElement(resource, document.getLineOfOffset(startOffset) + 1,
 							lineInformation.getOffset(),
 							document.get(lineInformation.getOffset(), lineInformation.getLength()));
 					return new FileMatch((IFile) resource, startOffset, endOffset - startOffset, lineEntry);
@@ -146,7 +146,7 @@ public class LSSearchQuery extends FileSearchQuery {
 			}
 
 			Position startPosition = location.getRange().getStart();
-			final var lineEntry = new LineElement(resource, startPosition.getLine(), 0,
+			final var lineEntry = new LineElement(resource, startPosition.getLine() + 1, 0,
 					String.format("%s:%s", startPosition.getLine(), startPosition.getCharacter())); //$NON-NLS-1$
 			return new FileMatch((IFile) resource, 0, 0, lineEntry);
 		}


### PR DESCRIPTION
Related to [discussion 784](https://github.com/eclipse/lsp4e/discussions/784)

Very small changes to fix the `references` operation not displaying the correct line number in the Search window in eclipse, see the discussion for examples. I've also modified the references test to verify the lines are stored correctly. 