### PR TITLE
Add .settings to gitignore. The .settings folder is created by eclipse and should be ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 .META-INF_MANIFEST.MF
 dash-licenses/
 *.log
+**/.settings


### PR DESCRIPTION
See title