### PR TITLE
Add link to releases to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## LSP4E Changelog and New and Noteworthy
 
+The [GitHub releases page](https://github.com/eclipse/lsp4e/releases) provides changelog and details on all releases.
+Older releases are listed below.
+
 ### 0.20.2
 
 📅 Release Date: February 3rd, 2022


### PR DESCRIPTION
We are not really using the changelog anymore and most of the valuable information is provided in the github releases page, therefore link to the releases page from the changelog so that people who look at the changelog will find the most recent information

See https://github.com/eclipse/lsp4e/discussions/789