### PR TITLE
Make default implementation of configuration conform to specification

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -74,7 +74,11 @@ public class LanguageClientImpl implements LanguageClient {
 	@Override
 	public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
 		// override as needed
-		return CompletableFuture.completedFuture(Collections.emptyList());
+		List<Object> list = new ArrayList<>(configurationParams.getItems().size());
+		for (int i = 0; i < configurationParams.getItems().size(); i++) {
+			list.add(null);
+		}
+		return CompletableFuture.completedFuture(list);
 	}
 
 	@Override


### PR DESCRIPTION
LSP Specification says "The order of the returned configuration settings correspond to the order of the passed ConfigurationItems (e.g. the first item in the response is the result for the first configuration item in the params). [...] If the client can’t provide a configuration setting for a given scope then null needs to be present in the returned array."