### PR TITLE
Adding Did Change Configuration feature

### DIFF
--- a/org.eclipse.lsp4e/schema/languageServer.exsd
+++ b/org.eclipse.lsp4e/schema/languageServer.exsd
@@ -151,6 +151,16 @@ If set to a number bigger than zero, the server will run until the timeout is re
                </documentation>
             </annotation>
          </attribute>
+         <attribute name="configurationHandler" type="string">
+            <annotation>
+               <documentation>
+                  An optional configuration handler that enables to send and update the configuration of the language server. The initial configuration is sent after receiving the initialized notification message from the language server.
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.lsp4e.IConfigurationHandler"/>
+               </appinfo>
+            </annotation>
+         </attribute>
       </complexType>
    </element>
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/IConfigurationHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/IConfigurationHandler.java
@@ -1,0 +1,74 @@
+package org.eclipse.lsp4e;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+
+/**
+ * Configuration handler that enables to send and update
+ * the configuration of the language server.
+ * It also contains a default implementation that can be instantiated.
+ */
+public interface IConfigurationHandler {
+
+	/**
+	 * Returns a {@link Map} containing all preference names and their values.
+	 * Usually used during the initialization of the language server to send
+	 * all the configuration at once.
+	 * @return
+	 */
+	@SuppressWarnings("null")
+	default @NonNull Map<String, Object> getConfiguration() {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Returns a {@link Map} containing all preference names and their values.
+	 * Used to send multiple configuration change to the language server at once.
+	 * @return
+	 */
+	@SuppressWarnings("null")
+	default @NonNull Map<String, Object> getConfiguration(final List<String> prefList) {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Returns a {@link Map} containing the requested preference name and its value,
+	 * usually used by a preference change listener.
+	 * The Map will be converted to JSON by LSP4J before the transmission.
+	 * @param preferenceName name of preference
+	 * @return {@link Map} containing the requested preference name and its value
+	 */
+	@SuppressWarnings("null")
+	default @NonNull Map<String, Object> getConfiguration(final String prefName) {
+		return Collections.emptyMap();
+	}
+
+	/**
+	 * Returns the preference store containing the configuration of the language server.
+	 * This must be overridden by the plugin developer, usually with the actual
+	 * {@code Activator.getDefault().getPreferenceStore()}
+	 * @see AbstractUIPlugin#getPreferenceStore()
+	 * @return the preference store
+	 */
+	public @NonNull IPreferenceStore getPreferenceStore();
+
+	/**
+	 * Default implementation that can be instantiated
+	 */
+	final static class DefaultConfigurationHandler implements IConfigurationHandler {
+		public DefaultConfigurationHandler() {
+			// Do nothing
+		}
+
+		@SuppressWarnings("null")
+		@Override
+		public @NonNull IPreferenceStore getPreferenceStore() {
+			return LanguageServerPlugin.getDefault().getPreferenceStore();
+		}
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
@@ -89,6 +89,7 @@ public class LanguageServersRegistry {
 	private static final String LABEL_ATTRIBUTE = "label"; //$NON-NLS-1$
 	private static final String ENABLED_WHEN_ATTRIBUTE = "enabledWhen"; //$NON-NLS-1$
 	private static final String ENABLED_WHEN_DESC = "description"; //$NON-NLS-1$
+	private static final String CONFIGURATION_HANDLER_ATTRIBUTE = "configurationHandler"; //$NON-NLS-1$
 
 	public abstract static class LanguageServerDefinition {
 		public final @NonNull String id;
@@ -121,6 +122,10 @@ public class LanguageServersRegistry {
 
 		public <S extends LanguageServer> Launcher.Builder<S> createLauncherBuilder() {
 			return new Launcher.Builder<>();
+		}
+
+		public IConfigurationHandler getConfigurationHandler() {
+			return new IConfigurationHandler.DefaultConfigurationHandler();
 		}
 
 	}
@@ -222,6 +227,19 @@ public class LanguageServersRegistry {
 				}
 			}
 			return super.createLauncherBuilder();
+		}
+
+		@Override
+		public IConfigurationHandler getConfigurationHandler() {
+			final String configHandler = extension.getAttribute(CONFIGURATION_HANDLER_ATTRIBUTE);
+			if (configHandler != null && !configHandler.isEmpty()) {
+				try {
+					return (IConfigurationHandler) extension.createExecutableExtension(CONFIGURATION_HANDLER_ATTRIBUTE);
+				} catch (CoreException e) {
+					LanguageServerPlugin.logError(e);
+				}
+			}
+			return super.getConfigurationHandler();
 		}
 
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.CompletionItemInsertTextModeSupportCapabilities;
 import org.eclipse.lsp4j.CompletionItemResolveSupportCapabilities;
 import org.eclipse.lsp4j.CompletionListCapabilities;
 import org.eclipse.lsp4j.DefinitionCapabilities;
+import org.eclipse.lsp4j.DidChangeConfigurationCapabilities;
 import org.eclipse.lsp4j.DocumentHighlightCapabilities;
 import org.eclipse.lsp4j.DocumentLinkCapabilities;
 import org.eclipse.lsp4j.DocumentSymbolCapabilities;
@@ -142,6 +143,7 @@ public class SupportedFeatures {
 		workspaceClientCapabilities.setWorkspaceEdit(editCapabilities);
 		CodeLensWorkspaceCapabilities codeLensWorkspaceCapabilities = new CodeLensWorkspaceCapabilities(true);
 		workspaceClientCapabilities.setCodeLens(codeLensWorkspaceCapabilities);
+		workspaceClientCapabilities.setDidChangeConfiguration(new DidChangeConfigurationCapabilities(Boolean.FALSE));
 		return workspaceClientCapabilities;
 	}
 


### PR DESCRIPTION
The intention of this PR is adding the Did Change Configuration feature of the LSP. The initial/last configuration is sent after the initialized notification message is received, similarly to VS Code. Then each preference store change triggers a `didChangeConfiguration` message to the server. This behavior provides that the language server acquires a meaningful configuration before starting analyzing any file/workspace/project coming from the LSP4E client.
The plugin developers can add their own implementation via a new extension point called `configurationHandler` and by implementing the `IConfigurationHandler ` interface. This interface comes with a default implementation that basically sends empty messages that can be easily neglected by the language server.
I think the idea is understandable from the code, I tried to add meaningful comments as well, however, feedbacks are welcome.