### PR TITLE
Fix completion

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -482,10 +482,10 @@ public class LSCompletionProposal
 			insertText = textEdit.getNewText();
 			final var regions = new LinkedHashMap<String, List<LinkedPosition>>();
 			int insertionOffset = LSPEclipseUtils.toOffset(textEdit.getRange().getStart(), document);
-			insertionOffset = computeNewOffset(item.getAdditionalTextEdits(), insertionOffset, document);
 			if (item.getInsertTextMode() == InsertTextMode.AdjustIndentation) {
 				insertText = adjustIndentation(document, insertText, insertionOffset);
 			}
+			insertionOffset = computeNewOffset(item.getAdditionalTextEdits(), insertionOffset, document);
 			if (item.getInsertTextFormat() == InsertTextFormat.Snippet) {
 				insertText = substituteVariables(insertText);
 				// next is for tabstops, placeholders and linked edition


### PR DESCRIPTION
In case where the additionalTextEdits adds longer text then document.length() - offset.

Do not shift offset because of additionalTextEdit until we're done reading interesting bits of this document at the target location (eg indentation information)