### PR TITLE
InsertTextMode.AdjustIndentation when cursor (and completion) is not at the start of the line

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -518,6 +518,19 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
+	public void testAdjustIndentationWithPrefixInLine() throws Exception {
+		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "a\n\tb\n\tprefix\nc"));
+		CompletionItem item = new CompletionItem("line1\n\tline2\nline3");
+		item.setInsertTextMode(InsertTextMode.AdjustIndentation);
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(item)));
+		int invokeOffset = 12;
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
+		assertEquals(1, proposals.length);
+		((LSCompletionProposal) proposals[0]).apply(viewer, '\n', 0, invokeOffset);
+		assertEquals("a\n\tb\n\tprefixline1\n\t\tline2\n\tline3\nc", viewer.getDocument().get());
+	}
+
+	@Test
 	public void testCancellation() throws Exception {
 		MockConnectionProvider.cancellations.clear();
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "a\n\tb\n\t\nc"));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -626,14 +626,14 @@ public class LSCompletionProposal
 	}
 
 	private String adjustIndentation(IDocument document, String insertText, int insertionOffset) throws BadLocationException {
+		int line = document.getLineOfOffset(insertionOffset);
+		int whitespaceOffset = document.getLineOffset(line);
 		final var whitespacesBeforeInsertion = new StringBuilder();
-		int whitespaceOffset = insertionOffset - 1;
-		while (whitespaceOffset >= 0 && document.getChar(whitespaceOffset) != '\n' && Character.isWhitespace(document.getChar(whitespaceOffset))) {
-			whitespacesBeforeInsertion.append(document.getChar(whitespaceOffset));
-			whitespaceOffset--;
-		}
 		whitespacesBeforeInsertion.append('\n');
-		whitespacesBeforeInsertion.reverse();
+		while (whitespaceOffset < insertionOffset && Character.isWhitespace(document.getChar(whitespaceOffset))) {
+			whitespacesBeforeInsertion.append(document.getChar(whitespaceOffset));
+			whitespaceOffset++;
+		}
 		return insertText.replace("\n", whitespacesBeforeInsertion); //$NON-NLS-1$
 	}
 


### PR DESCRIPTION
Assuming I have a file with the following content:
```html
<p>
   foo<di|
```
(| is the position of the cursor)
and I invoke content assist, which provides a completion `"<div>\n</div>"` with InsertTextMode.AdjustIndentation  .

I would expect the applied completion to look like this:

```html
<p>
   foo<div>
   </div>|
```
But atm I get this:

```html
<p>
   foo<div>
</div>|
```

VSCode on the other hand applies the completion with correct indentation.

This PR fixes the indentation calculation and adds a unit test for it.