### PR TITLE
Set a job family on the update markers from diagnostics job

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
@@ -21,6 +21,12 @@ import org.osgi.framework.BundleContext;
 
 public class LanguageServerPlugin extends AbstractUIPlugin {
 
+	/**
+	 * Constant identifying the job family identifier for the background update markers from diagnostics job.
+	 *
+	 */
+	public static final Object FAMILY_UPDATE_MARKERS = new Object();
+
 	public static final String PLUGIN_ID = "org.eclipse.lsp4e"; //$NON-NLS-1$
 
 	public static final boolean DEBUG = Boolean.parseBoolean(Platform.getDebugOption("org.eclipse.lsp4e/debug")); //$NON-NLS-1$

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -133,6 +133,10 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 
 	private WorkspaceJob updateMarkers(PublishDiagnosticsParams diagnostics, IResource resource) throws CoreException {
 		WorkspaceJob job = new WorkspaceJob("Update markers from diagnostics") { //$NON-NLS-1$
+			@Override
+			public boolean belongsTo(Object family) {
+				return LanguageServerPlugin.FAMILY_UPDATE_MARKERS == family;
+			}
 
 			@Override
 			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {


### PR DESCRIPTION
so that it can be waited for all these jobs to finish.