### PR TITLE
Enable console for vscode-js-debug

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
-Bundle-Version: 0.15.4.qualifier
+Bundle-Version: 0.15.5.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPProcess.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPProcess.java
@@ -36,7 +36,7 @@ public class DSPProcess implements IProcess {
 		this.target = dspDebugTarget;
 		this.proxy = new DSPStreamsProxy(target.getDebugProtocolServer());
 		this.processArgs = args;
-		handle = ProcessHandle.of(args.getSystemProcessId());
+		handle = args != null && args.getSystemProcessId() != null ? ProcessHandle.of(args.getSystemProcessId()) : Optional.empty();
 	}
 
 	@Override

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPStreamMonitor.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPStreamMonitor.java
@@ -17,7 +17,7 @@ public class DSPStreamMonitor implements IFlushableStreamMonitor {
 
 	private final ListenerList<IStreamListener> listeners = new ListenerList<>();
 	private final StringBuilder stream = new StringBuilder();
-	private boolean buffer;
+	private boolean buffer = true; // buffer by default as first output can happen before listeners are in place
 
 	@Override
 	public String getContents() {


### PR DESCRIPTION
* Fix some bugs in case DAP process doesn't exist
* Buffer streams by default so they're not discarded when received before console shows