### PR TITLE
Provide a Java process command builder.

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/java/JavaProcessCommandBuilder.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/java/JavaProcessCommandBuilder.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Angelo ZERR (Red Hat Inc.) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.server.java;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.Platform;
+
+/**
+ * A builder to create Java process command.
+ */
+public class JavaProcessCommandBuilder {
+
+    private String javaPath;
+
+    private String debugPort;
+
+    private boolean debugSuspend;
+    private String jar;
+
+    private String cp;
+
+    public JavaProcessCommandBuilder() {
+        setJavaPath(computeJavaPath());
+    }
+
+    public JavaProcessCommandBuilder setJavaPath(String javaPath) {
+        this.javaPath = javaPath;
+        return this;
+    }
+
+    public JavaProcessCommandBuilder setDebugPort(String debugPort) {
+        this.debugPort = debugPort;
+        return this;
+    }
+
+    public JavaProcessCommandBuilder setDebugSuspend(boolean debugSuspend) {
+        this.debugSuspend = debugSuspend;
+        return this;
+    }
+
+    public JavaProcessCommandBuilder setJar(String jar) {
+        this.jar = jar;
+        return this;
+    }
+
+    public JavaProcessCommandBuilder setCp(String cp) {
+        this.cp = cp;
+        return this;
+    }
+
+    public List<String> create() {
+        List<String> commands = new ArrayList<>();
+        commands.add(javaPath);
+        if (debugPort != null && !debugPort.isEmpty()) {
+            String suspend = debugSuspend ? "y" : "n"; //$NON-NLS-1$ //$NON-NLS-2$
+            commands.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=" + suspend + ",address=" + debugPort); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (jar != null) {
+            commands.add("-jar"); //$NON-NLS-1$
+            commands.add(jar);
+        }
+        if (cp != null) {
+            commands.add("-cp"); //$NON-NLS-1$
+            commands.add(cp);
+        }
+        return commands;
+    }
+
+    private static String computeJavaPath() {
+    	return new File(System.getProperty("java.home"), //$NON-NLS-1$
+				"bin/java" + (Platform.getOS().equals(Platform.OS_WIN32) ? ".exe" : "")).getAbsolutePath(); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+}


### PR DESCRIPTION
This PR provides the capability to build a Java process command with a builder to start a language server written in Java. The advantage of this builder is:

 * share same code for any language server which need to start a Java process
 * in the future, LSP4E could provide an UI (for language server written in Java) to fill debug port. In LSP4IJ we provide this feature and debug info are stored in the language server settings (so no need to implement a custom UI for a language server)
 
![image](https://github.com/eclipse/lsp4e/assets/1932211/bfd2edce-70ef-4541-961f-cc2a04940144)

 * in the future LSP4E could provide a JRE combo to choose which JRE to use to start the language server
 * M2E provide an extension point to override the classpath (to add lemminx-maven JAR in XMLLanguageServer). This extension point could be hosted in LSP4E (we have for instance a MicroProfile language server which add extra JARs to provide Quarkus support into MicroProfile LS)

This builder could simplify code:

 * for XML language server https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/blob/92ece9fc35e4e028eb249cacf445512bbafac835/org.eclipse.wildwebdeveloper.xml/src/org/eclipse/wildwebdeveloper/xml/internal/XMLLanguageServer.java#L91
 * for Quarkus language server https://github.com/jbosstools/jbosstools-quarkus/blob/b073d1801df135c37656492481cdeab26fb5cb83/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/QuarkusLanguageServer.java#L42
 * for Qute language server https://github.com/jbosstools/jbosstools-quarkus/blob/b073d1801df135c37656492481cdeab26fb5cb83/plugins/org.jboss.tools.quarkus.lsp4e/src/org/jboss/tools/quarkus/lsp4e/internal/ls/qute/QuteLanguageServer.java#L45

As you can notice the code is the same (ex : computeJavaPath), etc