### PR TITLE
Do not try to refresh threads to compute resume/suspend

### DIFF
--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPThread.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPThread.java
@@ -65,9 +65,11 @@ public class DSPThread extends DSPDebugElement implements IThread {
 	 */
 	public void update(Thread thread) {
 		Assert.isTrue(Objects.equals(this.id, thread.getId()));
-		this.name = thread.getName();
+		if (!Objects.equals(this.name, thread.getName())) {
+			fireChangeEvent(DebugEvent.STATE);
+			this.name = thread.getName();
+		}
 		refreshFrames.set(true);
-		// fireChangeEvent(DebugEvent.STATE);
 	}
 
 	@Override
@@ -101,7 +103,7 @@ public class DSPThread extends DSPDebugElement implements IThread {
 	public void stopped() {
 		isSuspended = true;
 		stepping = false;
-		refreshFrames.set(true);
+		frames.clear();
 	}
 
 	@Override
@@ -226,8 +228,10 @@ public class DSPThread extends DSPDebugElement implements IThread {
 		}
 	}
 
-	@Override
-	public IStackFrame[] getStackFrames() throws DebugException {
+	@Override public IStackFrame[] getStackFrames() throws DebugException {
+		if (!isSuspended()) {
+			return new IStackFrame[0];
+		}
 		if (!refreshFrames.getAndSet(false)) {
 			synchronized (frames) {
 				return frames.toArray(new DSPStackFrame[frames.size()]);


### PR DESCRIPTION
Those operations typically work on the list of *known* threads, there is no need to refresh the threads at that time, and in case DAP's threads() request doesn't run well on non-suspended targets, then the former implementation could lead to bogus states.