### PR TITLE
Document content synchronizer

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -97,8 +97,11 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			IFileStore store = EFS.getStore(fileUri);
 			this.openSaveStamp = store.fetchInfo().getLastModified();
 		} catch (CoreException e) {
-			LanguageServerPlugin.logError(e);
-			this.openSaveStamp = new File(fileUri).lastModified();
+			try {
+				this.openSaveStamp = new File(fileUri).lastModified();
+			} catch (IllegalArgumentException iae) {
+				this.openSaveStamp = 0L;
+			}
 		}
 		this.syncKind = syncKind != null ? syncKind : TextDocumentSyncKind.Full;
 


### PR DESCRIPTION
Prevent failure of DocumentContentSynchronizer.<init> if the document
does not have an URI registered in EFS and it is not a file uri.

Also improve the existing log to include the URI that we are failing to
deal with.