### PR TITLE
Improved parsing of completions with InsertTextFormat.Snippet

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.15.6.qualifier
+Bundle-Version: 0.15.7.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.15.6-SNAPSHOT</version>
+	<version>0.15.7-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -400,7 +400,9 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		assertEquals(1, proposals.length);
 		((LSCompletionProposal) proposals[0]).apply(viewer, '\n', 0, invokeOffset);
 		assertEquals("foo and foo", viewer.getDocument().get());
-		// TODO check link edit groups
+		// check linked edit groups
+		viewer.getTextWidget().insert("a");
+		assertEquals("a and a", viewer.getDocument().get());
 	}
 
 	@Test

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionSnippetParser.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionSnippetParser.java
@@ -1,0 +1,333 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2023 Red Hat Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Christoph Kaser (ICONPARC GmbH) - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.lsp4e.operations.completion;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.contentassist.CompletionProposal;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.link.LinkedPosition;
+import org.eclipse.jface.text.link.ProposalPosition;
+
+import java.util.*;
+import java.util.function.Function;
+
+
+/**
+ * A parser for the completion insert text in
+ * <a href="https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax">snippet syntax</a>
+ */
+class CompletionSnippetParser {
+	private final IDocument document;
+	private final String snippetText;
+	private final int insertionOffset;
+	private final LinkedHashMap<String, List<LinkedPosition>> linkedPositions = new LinkedHashMap<>();
+	private final Function<String, String> getVariableValue;
+	private int snippetOffset = 0;
+	private int snippetToDocumentOffset = 0;
+	private boolean dontAddLinkedPositions = false;
+
+
+	/**
+	 * Creates a new snippet parser
+	 * @param document the document that this completion will be applied to
+	 * @param snippetText the text to parse
+	 * @param insertionOffset the document offset this completion will be applied to
+	 * @param getVariableValue a function that resolves variable values
+	 */
+	public CompletionSnippetParser(IDocument document, String snippetText, int insertionOffset, Function<String, String> getVariableValue) {
+		this.document = document;
+		this.snippetText = snippetText;
+		this.insertionOffset = insertionOffset;
+		this.getVariableValue = getVariableValue;
+	}
+
+	/**
+	 * Parses the insertText
+	 * @return the text to apply to the editor
+	 */
+	public String parse() {
+		StringBuilder insertTextBuilder = new StringBuilder(snippetText.length());
+		while (hasRemaining()) {
+			char current = readChar();
+			switch (current) {
+				default -> insertTextBuilder.append(current);
+				case '\\' -> {
+					if (!hasRemaining()) {
+						insertTextBuilder.append(current);
+					} else {
+						insertTextBuilder.append(readChar());
+						snippetToDocumentOffset++;
+					}
+				}
+				case '$' -> {
+					int _snippetOffset = snippetOffset;
+					int _snippetToDocumentOffset = snippetToDocumentOffset;
+					try {
+						String value = parseDollarExpression();
+						insertTextBuilder.append(value);
+					} catch (DollarExpressionParseException e) {
+						// unparseable expression is handled 'as-is'
+						snippetOffset = _snippetOffset;
+						snippetToDocumentOffset = _snippetToDocumentOffset;
+						insertTextBuilder.append('$');
+					}
+				}
+			}
+		}
+		return insertTextBuilder.toString();
+	}
+
+	/**
+	 * @return a map of LinkedPositions that were defined by the snippet
+	 */
+	public Map<String, List<LinkedPosition>> getLinkedPositions() {
+		return linkedPositions;
+	}
+
+	private String parseDollarExpression() throws DollarExpressionParseException {
+		if (!hasRemaining()) {
+			throw new DollarExpressionParseException();
+		}
+		char firstChar = peekChar();
+		if (Character.isDigit(firstChar)) {
+			// A tabstop position like $1
+			String key = readNumberKey();
+			snippetToDocumentOffset += key.length() + 1;
+			LinkedPosition position = new LinkedPosition(document, insertionOffset + snippetOffset - snippetToDocumentOffset, 0);
+			addLinkedPosition(key, position);
+			return ""; //$NON-NLS-1$
+		} else if (isCharacterForVariableName(firstChar)) {
+			// A Variable like $TM_LINE_NUMBER
+			String key = readVariableKey();
+			String value = getVariableValue.apply(key);
+			snippetToDocumentOffset += key.length() + 1 - value.length();
+			return value;
+		} else if (firstChar == '{') {
+			return parseDollarExpressionInBrackets();
+		} else {
+			throw new DollarExpressionParseException();
+		}
+	}
+
+	/**
+	 * Parses an expression in brackets like ${1|value} or ${TM_SELECTED_TEXT:default}
+	 */
+	private String parseDollarExpressionInBrackets() throws DollarExpressionParseException {
+		if (readChar() != '{') {
+			// This method must be called on a bracket character
+			throw new IllegalStateException();
+		}
+		if (!hasRemaining()) {
+			throw new DollarExpressionParseException();
+		}
+		char firstKeyChar = peekChar();
+		if (Character.isDigit(firstKeyChar)) {
+			// tabstop, placeholder or choice
+			return parseTabStopInBrackets();
+		} else if (isCharacterForVariableName(firstKeyChar)) {
+			// a variable
+			return parseVariableExpressionInBrackets();
+		} else {
+			throw new DollarExpressionParseException();
+		}
+	}
+
+	private String parseVariableExpressionInBrackets() throws DollarExpressionParseException {
+		int dollarOffset = snippetOffset - 2;
+		String key = readVariableKey();
+		if (!hasRemaining()) {
+			throw new DollarExpressionParseException();
+		}
+		char postKeyChar = readChar();
+		String defaultValue = ""; //$NON-NLS-1$
+
+		switch (postKeyChar) {
+			case '}' -> {
+			}
+			case ':' -> {
+				// default Value
+				defaultValue = readTextValue();
+			}
+			case '/' -> {
+				// TODO: Format strings are unsupported for now, simple read and ignore them
+				readTextValue();
+			}
+			default -> {
+				throw new DollarExpressionParseException();
+			}
+		}
+		String value = getVariableValue.apply(key);
+		if (value.isEmpty()) {
+			value = defaultValue;
+		}
+		snippetToDocumentOffset += snippetOffset - dollarOffset - value.length();
+		return value;
+	}
+
+	private String parseTabStopInBrackets() throws DollarExpressionParseException {
+		int dollarOffset = snippetOffset - 2;
+		String key = readNumberKey();
+		if (!hasRemaining()) {
+			throw new DollarExpressionParseException();
+		}
+		char postKeyChar = readChar();
+		List<String> valueList;
+		switch (postKeyChar) {
+			case '}' -> {
+				valueList = Collections.emptyList();
+			}
+			case ':' -> {
+				valueList = List.of(readTextValue());
+			}
+			case '|' -> {
+				valueList = readChoiceValues();
+			}
+			default -> {
+				throw new DollarExpressionParseException();
+			}
+		}
+		LinkedPosition position;
+		String defaultProposal;
+		if (!valueList.isEmpty()) {
+			defaultProposal = valueList.get(0);
+			int replacementOffset = insertionOffset + dollarOffset - snippetToDocumentOffset;
+			ICompletionProposal[] proposals = valueList.stream().map(string ->
+					new CompletionProposal(string, replacementOffset, defaultProposal.length(), replacementOffset + string.length())
+			).toArray(ICompletionProposal[]::new);
+			position = new ProposalPosition(document, insertionOffset + dollarOffset - snippetToDocumentOffset, defaultProposal.length(), proposals);
+		} else {
+			defaultProposal = ""; //$NON-NLS-1$
+			position = new LinkedPosition(document, insertionOffset + dollarOffset - snippetToDocumentOffset, 0);
+		}
+		addLinkedPosition(key, position);
+		snippetToDocumentOffset += snippetOffset - dollarOffset - defaultProposal.length();
+		return defaultProposal;
+	}
+
+	private List<String> readChoiceValues() throws DollarExpressionParseException {
+		List<String> valueList = new ArrayList<>();
+		StringBuilder valueBuilder = new StringBuilder();
+		while (true) {
+			if (!hasRemaining()) {
+				throw new DollarExpressionParseException();
+			}
+			char c = readChar();
+			switch (c) {
+				default -> valueBuilder.append(c);
+				case ',' -> {
+					valueList.add(valueBuilder.toString());
+					valueBuilder.setLength(0);
+				}
+				case '\\' -> {
+					if (!hasRemaining()) {
+						throw new DollarExpressionParseException();
+					}
+					valueBuilder.append(readChar());
+				}
+				case '}' -> {
+					// a choice needs to end on |}
+					throw new DollarExpressionParseException();
+				}
+				case '|' -> {
+					if (!hasRemaining() || readChar() != '}') {
+						throw new DollarExpressionParseException();
+					}
+					valueList.add(valueBuilder.toString());
+					return valueList;
+				}
+			}
+		}
+	}
+
+	private String readTextValue() throws DollarExpressionParseException {
+		StringBuilder valueBuilder = new StringBuilder();
+		while (true) {
+			if (!hasRemaining()) {
+				throw new DollarExpressionParseException();
+			}
+			char c = readChar();
+			switch (c) {
+				default -> valueBuilder.append(c);
+				case '\\' -> {
+					if (!hasRemaining()) {
+						throw new DollarExpressionParseException();
+					}
+					valueBuilder.append(readChar());
+				}
+				case '$' -> {
+					int _snippetOffset = snippetOffset;
+					int _snippetToDocumentOffset = snippetToDocumentOffset;
+					boolean _dontAddLinkedPositions = dontAddLinkedPositions;
+					// For now, we don't support nested linked positions
+					dontAddLinkedPositions = true;
+					try {
+						String value = parseDollarExpression();
+						valueBuilder.append(value);
+					} catch (DollarExpressionParseException e) {
+						// unparseable expression is handled 'as-is'
+						snippetOffset = _snippetOffset;
+						valueBuilder.append('$');
+					} finally {
+						dontAddLinkedPositions = _dontAddLinkedPositions;
+						snippetToDocumentOffset = _snippetToDocumentOffset; // Reset the snippetToDocumentOffset, since the value was not added to the insertText yet
+					}
+				}
+				case '}' -> {
+					return valueBuilder.toString();
+				}
+			}
+		}
+	}
+
+	private void addLinkedPosition(String key, LinkedPosition position) {
+		if (!dontAddLinkedPositions) {
+			linkedPositions.computeIfAbsent(key, whatever -> new ArrayList<>()).add(position);
+		}
+	}
+
+	private boolean hasRemaining() {
+		return snippetOffset < snippetText.length();
+	}
+
+	private char peekChar() {
+		return snippetText.charAt(snippetOffset);
+	}
+
+	private char readChar() {
+		char retval = peekChar();
+		snippetOffset++;
+		return retval;
+	}
+
+	private String readNumberKey() {
+		StringBuilder keyBuilder = new StringBuilder();
+		while (hasRemaining() && Character.isDigit(peekChar())) {
+			keyBuilder.append(readChar());
+		}
+		return keyBuilder.toString();
+	}
+
+	private String readVariableKey() {
+		StringBuilder keyBuilder = new StringBuilder();
+		while (hasRemaining() && isCharacterForVariableName(peekChar())) {
+			keyBuilder.append(readChar());
+		}
+		return keyBuilder.toString();
+	}
+
+	private boolean isCharacterForVariableName(char c) {
+		return ('0' <= c && c <= '9') || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || c == '_';
+	}
+
+	private static class DollarExpressionParseException extends Exception {	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -17,12 +17,9 @@
 package org.eclipse.lsp4e.operations.completion;
 
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -45,7 +42,6 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.contentassist.BoldStylerProvider;
-import org.eclipse.jface.text.contentassist.CompletionProposal;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.ICompletionProposalExtension;
 import org.eclipse.jface.text.contentassist.ICompletionProposalExtension2;
@@ -115,12 +111,6 @@ public class LSCompletionProposal
 	private static final String TM_DIRECTORY = "TM_DIRECTORY"; //$NON-NLS-1$
 	/** The full file path of the current document */
 	private static final String TM_FILEPATH = "TM_FILEPATH"; //$NON-NLS-1$\
-
-	// This needs to be a sorted set by size because we want to match longest variable first, since some are substrings of others
-	private static SortedSet<String> ALL_VARIABLES = new TreeSet<>(Comparator.comparing(String::length).reversed().thenComparing(Comparator.naturalOrder()));
-	static {
-		ALL_VARIABLES.addAll(Set.of(TM_SELECTED_TEXT, TM_CURRENT_LINE, TM_CURRENT_WORD, TM_LINE_INDEX, TM_LINE_NUMBER, TM_FILENAME, TM_FILENAME_BASE, TM_DIRECTORY, TM_FILEPATH));
-	}
 
 	protected final CompletionItem item;
 	private final int initialOffset;
@@ -480,82 +470,18 @@ public class LSCompletionProposal
 				textEdit.getRange().getEnd().setCharacter(textEdit.getRange().getEnd().getCharacter() + commonSize);
 			}
 			insertText = textEdit.getNewText();
-			final var regions = new LinkedHashMap<String, List<LinkedPosition>>();
+			Map<String, List<LinkedPosition>> regions = Collections.emptyMap();
 			int insertionOffset = LSPEclipseUtils.toOffset(textEdit.getRange().getStart(), document);
 			if (item.getInsertTextMode() == InsertTextMode.AdjustIndentation) {
 				insertText = adjustIndentation(document, insertText, insertionOffset);
 			}
 			insertionOffset = computeNewOffset(item.getAdditionalTextEdits(), insertionOffset, document);
 			if (item.getInsertTextFormat() == InsertTextFormat.Snippet) {
-				insertText = substituteVariables(insertText);
-				// next is for tabstops, placeholders and linked edition
-				int currentSnippetOffsetInInsertText = 0;
-				while ((currentSnippetOffsetInInsertText = insertText.indexOf('$', currentSnippetOffsetInInsertText)) != -1) {
-					final var keyBuilder = new StringBuilder();
-					boolean isChoice = false;
-					final var snippetProposals = new ArrayList<String>();
-					int offsetInSnippet = 1;
-					while (currentSnippetOffsetInInsertText + offsetInSnippet < insertText.length() && Character.isDigit(insertText.charAt(currentSnippetOffsetInInsertText + offsetInSnippet))) {
-						keyBuilder.append(insertText.charAt(currentSnippetOffsetInInsertText + offsetInSnippet));
-						offsetInSnippet++;
-					}
-					if (keyBuilder.length() == 0 && insertText.substring(currentSnippetOffsetInInsertText).startsWith("${")) { //$NON-NLS-1$
-						offsetInSnippet = 2;
-						while (currentSnippetOffsetInInsertText + offsetInSnippet < insertText.length() && Character.isDigit(insertText.charAt(currentSnippetOffsetInInsertText + offsetInSnippet))) {
-							keyBuilder.append(insertText.charAt(currentSnippetOffsetInInsertText + offsetInSnippet));
-							offsetInSnippet++;
-						}
-						if (currentSnippetOffsetInInsertText + offsetInSnippet < insertText.length()) {
-							char currentChar = insertText.charAt(currentSnippetOffsetInInsertText + offsetInSnippet);
-							if (currentChar == ':' || currentChar == '|') {
-								isChoice |= currentChar == '|';
-								offsetInSnippet++;
-							}
-						}
-						boolean close = false;
-						var valueBuilder = new StringBuilder();
-						while (currentSnippetOffsetInInsertText + offsetInSnippet < insertText.length() && !close) {
-							char currentChar = insertText.charAt(currentSnippetOffsetInInsertText + offsetInSnippet);
-							if (valueBuilder.length() > 0 &&
-								((isChoice && (currentChar == ',' || currentChar == '|') || currentChar == '}'))) {
-								String value = valueBuilder.toString();
-								if (value.startsWith("$")) { //$NON-NLS-1$
-									String varValue = getVariableValue(value.substring(1));
-									if (varValue != null) {
-										value = varValue;
-									}
-								}
-								snippetProposals.add(value);
-								valueBuilder = new StringBuilder();
-							} else if (currentChar != '}') {
-								valueBuilder.append(currentChar);
-							}
-							close = currentChar == '}';
-							offsetInSnippet++;
-						}
-					}
-					String defaultProposal = snippetProposals.isEmpty() ? "" : snippetProposals.get(0); //$NON-NLS-1$
-					if (keyBuilder.length() > 0) {
-						String key = keyBuilder.toString();
-						insertText = insertText.substring(0, currentSnippetOffsetInInsertText) + defaultProposal + insertText.substring(currentSnippetOffsetInInsertText + offsetInSnippet);
-						LinkedPosition position = null;
-						if (!snippetProposals.isEmpty()) {
-							int replacementOffset = insertionOffset + currentSnippetOffsetInInsertText;
-							ICompletionProposal[] proposals = snippetProposals.stream().map(string ->
-								new CompletionProposal(string, replacementOffset, defaultProposal.length(), replacementOffset + string.length())
-							).toArray(ICompletionProposal[]::new);
-							position = new ProposalPosition(document, insertionOffset + currentSnippetOffsetInInsertText, defaultProposal.length(), proposals);
-						} else {
-							position = new LinkedPosition(document, insertionOffset + currentSnippetOffsetInInsertText, defaultProposal.length());
-						}
-						if (firstPosition == null) {
-							firstPosition = position;
-						}
-						regions.computeIfAbsent(key, whatever -> new ArrayList<>()).add(position);
-						currentSnippetOffsetInInsertText += defaultProposal.length();
-					} else {
-						currentSnippetOffsetInInsertText++;
-					}
+				var completionSnippetParser = new CompletionSnippetParser(document, insertText, insertionOffset, this::getVariableValue);
+				insertText = completionSnippetParser.parse();
+				regions = completionSnippetParser.getLinkedPositions();
+				if (!regions.isEmpty() && firstPosition == null) {
+					firstPosition = regions.values().iterator().next().get(0);
 				}
 			}
 			textEdit.setNewText(insertText); // insertText now has placeholder removed
@@ -661,15 +587,6 @@ public class LSCompletionProposal
 	}
 
 	private String getVariableValue(String variableName) {
-		if (variableName.startsWith("$")) {//$NON-NLS-1$
-			variableName = variableName.substring(1);
-		}
-		if (variableName.startsWith("{")) {//$NON-NLS-1$
-			variableName = variableName.substring(1);
-		}
-		if (variableName.endsWith("}")) {//$NON-NLS-1$
-			variableName = variableName.substring(0, variableName.length() - 1);
-		}
 		return switch (variableName) {
 		case TM_FILENAME_BASE -> {
 			IPath pathBase = LSPEclipseUtils.toPath(document).removeFileExtension();
@@ -723,20 +640,6 @@ public class LSCompletionProposal
 		default -> variableName;
 		};
 	}
-
-	private String substituteVariables(String insertText) {
-		for (String variable : ALL_VARIABLES) {
-			if (insertText.contains('$' + variable) || insertText.contains("${" + variable + '}')) { //$NON-NLS-1$
-				String value = getVariableValue(variable);
-				if (value != null) {
-					insertText = insertText.replace("${" + variable + '}', value); //$NON-NLS-1$
-					insertText = insertText.replace('$' + variable, value);
-				}
-			}
-		}
-		return insertText;
-	}
-
 
 	private Range getTextEditRange() {
 		return item.getTextEdit().map(TextEdit::getRange, InsertReplaceEdit::getInsert);


### PR DESCRIPTION
Hello everyone,

we are making extensive use of completions with InsertTextFormat.Snippet and had some problems with completions that try to insert keys with $ in them, because `\$` was inserted as is.

So I tried to improve the parsing of snippets to be closer to the spec (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax) and/or closer to what VSCode does.

Since the snippet format is fairly complex, I extracted the parser into its own class, so I could keep the current parser offset in a field.

This PR fixes
- variables with default values (like `${TM_SELECTED_TEXT:defaultval}`}
- escaping of special characters like dollar, brackets and comma with \ (like `special\$key`)

The following complicated parts of the snippet format are not yet implemented:
- Variable transforms (like `${TM_FILENAME/(.*)\..+$/$1/}`)
- Nested tabstops in placeholders (like `${1:Place${2:holder}}`)
- Nested tabstops in default values (like `${TM_SELECTED_TEXT:Place${1:holder}}`)