### PR TITLE
Ensure that active highlights are removed when a source view is closed

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -25,5 +25,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)",
  org.eclipse.ui.tests.harness,
  org.eclipse.ui.monitoring,
- org.eclipse.core.variables
+ org.eclipse.core.variables,
+ org.eclipse.e4.ui.model.workbench,
+ org.eclipse.e4.ui.workbench
 Automatic-Module-Name: org.eclipse.lsp4e.test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
@@ -31,6 +32,8 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.e4.ui.model.application.ui.basic.MPart;
+import org.eclipse.e4.ui.workbench.IPresentationEngine;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.lsp4e.ContentTypeToLanguageServerDefinition;
 import org.eclipse.lsp4e.LSPEclipseUtils;
@@ -57,323 +60,336 @@ import com.google.common.io.RecursiveDeleteOption;
 
 public class TestUtils {
 
-	@FunctionalInterface
-	public interface Condition {
-		boolean isMet() throws Exception;
-	}
+    @FunctionalInterface
+    public interface Condition {
+        boolean isMet() throws Exception;
+    }
 
-	private static Set<File> tempFiles = new HashSet<>();
+    private static Set<File> tempFiles = new HashSet<>();
 
-	private TestUtils() {
-		// this class shouldn't be instantiated
-	}
+    private TestUtils() {
+        // this class shouldn't be instantiated
+    }
 
-	public static ITextViewer openTextViewer(IFile file) throws PartInitException {
-		IEditorPart editor = openEditor(file);
-		return LSPEclipseUtils.getTextViewer(editor);
-	}
+    public static ITextViewer openTextViewer(IFile file) throws PartInitException {
+        IEditorPart editor = openEditor(file);
+        return LSPEclipseUtils.getTextViewer(editor);
+    }
 
-	public static IEditorPart openEditor(IFile file) throws PartInitException {
-		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
-		IWorkbenchPage page = workbenchWindow.getActivePage();
-		IEditorInput input = new FileEditorInput(file);
+    public static IEditorPart openEditor(IFile file) throws PartInitException {
+        IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
+        IWorkbenchPage page = workbenchWindow.getActivePage();
+        IEditorInput input = new FileEditorInput(file);
 
-		IEditorPart part = page.openEditor(input, "org.eclipse.ui.genericeditor.GenericEditor", false);
-		part.setFocus();
-		return part;
-	}
+        IEditorPart part = page.openEditor(input, "org.eclipse.ui.genericeditor.GenericEditor", false);
+        part.setFocus();
+        return part;
+    }
+    
+    public static List<IEditorReference> splitActiveEditor() {
+    	IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
+        IWorkbenchPage page = workbenchWindow.getActivePage();
+        IEditorPart part = page.getActiveEditor();
+        
+        MPart editorPart = part.getSite().getService(MPart.class);
+        if (editorPart != null) {
+        	editorPart.getTags().add(IPresentationEngine.SPLIT_HORIZONTAL);
+        }
+        
+        return Arrays.asList(page.getEditorReferences());
+    }
+    
+    public static IEditorPart openExternalFileInEditor(File file) throws PartInitException {
+        IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
+        IWorkbenchPage page = workbenchWindow.getActivePage();
+        IEditorPart part = IDE.openEditor(page, file.toURI(), "org.eclipse.ui.genericeditor.GenericEditor", false);
+        part.setFocus();
+        return part;
+    }
 
-	public static IEditorPart openExternalFileInEditor(File file) throws PartInitException {
-		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
-		IWorkbenchPage page = workbenchWindow.getActivePage();
-		IEditorPart part = IDE.openEditor(page, file.toURI(), "org.eclipse.ui.genericeditor.GenericEditor", false);
-		part.setFocus();
-		return part;
-	}
+    public static IEditorPart getEditor(IFile file) {
+        IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
+        IWorkbenchPage page = workbenchWindow.getActivePage();
+        IEditorInput input = new FileEditorInput(file);
 
-	public static IEditorPart getEditor(IFile file) {
-		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
-		IWorkbenchPage page = workbenchWindow.getActivePage();
-		IEditorInput input = new FileEditorInput(file);
+        return Arrays.asList(page.getEditorReferences()).stream().filter(r -> {
+            try {
+                return r.getEditorInput().equals(input);
+            } catch (PartInitException e) {
+                return false;
+            }
+        }).map(r -> r.getEditor(false)).findAny().orElse(null);
+    }
 
-		return Arrays.asList(page.getEditorReferences()).stream().filter(r -> {
-			try {
-				return r.getEditorInput().equals(input);
-			} catch (PartInitException e) {
-				return false;
-			}
-		}).map(r -> r.getEditor(false)).findAny().orElse(null);
-	}
+    public static IEditorPart getActiveEditor() {
+        IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
+        IWorkbenchPage page = workbenchWindow.getActivePage();
+        return page.getActiveEditor();
+    }
 
-	public static IEditorPart getActiveEditor() {
-		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
-		IWorkbenchPage page = workbenchWindow.getActivePage();
-		return page.getActiveEditor();
-	}
+    public static boolean closeEditor(IEditorPart editor, boolean save) {
+        IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
+        IWorkbenchPage page = workbenchWindow.getActivePage();
+        return page.closeEditor(editor, save);
+    }
 
-	public static boolean closeEditor(IEditorPart editor, boolean save) {
-		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
-		IWorkbenchPage page = workbenchWindow.getActivePage();
-		return page.closeEditor(editor, save);
-	}
+    public static IProject createProject(String projectName) throws CoreException {
+        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+        if (project.exists()) {
+            return project;
+        }
+        project.create(null);
+        project.open(null);
+        // configure nature
+        return project;
+    }
 
-	public static IProject createProject(String projectName) throws CoreException {
-		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
-		if (project.exists()) {
-			return project;
-		}
-		project.create(null);
-		project.open(null);
-		// configure nature
-		return project;
-	}
+    public static IProject createNestedProject(IProject parent, String projectName) throws CoreException {
 
-	public static IProject createNestedProject(IProject parent, String projectName) throws CoreException {
+        IFolder nestedFolder = parent.getFolder(projectName);
+        nestedFolder.create(true, true, new NullProgressMonitor());
 
-		IFolder nestedFolder = parent.getFolder(projectName);
-		nestedFolder.create(true, true, new NullProgressMonitor());
+        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+        if (project.exists()) {
+            return project;
+        }
 
-		IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
-		if (project.exists()) {
-			return project;
-		}
+        IProjectDescription desc = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
+        desc.setLocation(nestedFolder.getLocation());
 
-		IProjectDescription desc = ResourcesPlugin.getWorkspace().newProjectDescription(projectName);
-		desc.setLocation(nestedFolder.getLocation());
+        project.create(desc, null);
+        project.open(null);
+        // configure nature
+        return project;
+    }
 
-		project.create(desc, null);
-		project.open(null);
-		// configure nature
-		return project;
-	}
+    public static IFile createUniqueTestFile(IProject p, String content) throws CoreException {
+        return createUniqueTestFile(p, "lspt", content);
+    }
 
-	public static IFile createUniqueTestFile(IProject p, String content) throws CoreException {
-		return createUniqueTestFile(p, "lspt", content);
-	}
+    public static IFile createUniqueTestFileMultiLS(IProject p, String content) throws CoreException {
+        return createUniqueTestFile(p, "lsptmultils", content);
+    }
 
-	public static IFile createUniqueTestFileMultiLS(IProject p, String content) throws CoreException {
-		return createUniqueTestFile(p, "lsptmultils", content);
-	}
+    public static IFile createUniqueTestFileOfUnknownType(IProject p, String content) throws CoreException {
+        return createUniqueTestFile(p, "lsptunknown", content);
+    }
 
-	public static IFile createUniqueTestFileOfUnknownType(IProject p, String content) throws CoreException {
-		return createUniqueTestFile(p, "lsptunknown", content);
-	}
+    public static synchronized IFile createUniqueTestFile(IProject p, String extension, String content)
+            throws CoreException {
+        long fileNameSalt = System.currentTimeMillis();
+        if (p == null) {
+            p = ResourcesPlugin.getWorkspace().getRoot().getProject(Long.toString(fileNameSalt));
+            p.create(null);
+            p.open(null);
+        }
+        while (p.getFile("test" + fileNameSalt + '.' + extension).exists()) {
+            fileNameSalt++;
+        }
+        return createFile(p, "test" + fileNameSalt + '.' + extension, content);
+    }
 
-	public static synchronized IFile createUniqueTestFile(IProject p, String extension, String content)
-			throws CoreException {
-		long fileNameSalt = System.currentTimeMillis();
-		if (p == null) {
-			p = ResourcesPlugin.getWorkspace().getRoot().getProject(Long.toString(fileNameSalt));
-			p.create(null);
-			p.open(null);
-		}
-		while (p.getFile("test" + fileNameSalt + '.' + extension).exists()) {
-			fileNameSalt++;
-		}
-		return createFile(p, "test" + fileNameSalt + '.' + extension, content);
-	}
+    public static IFile createFile(IProject p, String name, String content) throws CoreException {
+        IFile testFile = p.getFile(name);
+        testFile.create(new ByteArrayInputStream(content.getBytes()), true, null);
+        return testFile;
+    }
 
-	public static IFile createFile(IProject p, String name, String content) throws CoreException {
-		IFile testFile = p.getFile(name);
-		testFile.create(new ByteArrayInputStream(content.getBytes()), true, null);
-		return testFile;
-	}
+    public static void delete(IProject project) throws CoreException {
+        if (project != null) {
+            project.delete(true, new NullProgressMonitor());
+        }
+    }
 
-	public static void delete(IProject project) throws CoreException {
-		if (project != null) {
-			project.delete(true, new NullProgressMonitor());
-		}
-	}
+    public static void delete(IProject... projects) throws CoreException {
+        if (projects != null && projects.length > 0) {
+            for (IProject project : projects) {
+                delete(project);
+            }
+        }
+    }
 
-	public static void delete(IProject... projects) throws CoreException {
-		if (projects != null && projects.length > 0) {
-			for (IProject project : projects) {
-				delete(project);
-			}
-		}
-	}
+    public static void delete(Path path) throws IOException {
+        if (path != null && Files.exists(path)) {
+            MoreFiles.deleteRecursively(path, RecursiveDeleteOption.ALLOW_INSECURE);
+        }
+    }
 
-	public static void delete(Path path) throws IOException {
-		if (path != null && Files.exists(path)) {
-			MoreFiles.deleteRecursively(path, RecursiveDeleteOption.ALLOW_INSECURE);
-		}
-	}
+    public static void delete(Path... paths) throws IOException {
+        if (paths != null && paths.length > 0) {
+            for (Path path : paths) {
+                delete(path);
+            }
+        }
+    }
 
-	public static void delete(Path... paths) throws IOException {
-		if (paths != null && paths.length > 0) {
-			for (Path path : paths) {
-				delete(path);
-			}
-		}
-	}
+    public static File createTempFile(String prefix, String suffix) throws IOException {
+        File tmp = File.createTempFile(prefix, suffix);
+        tempFiles.add(tmp);
+        return tmp;
+    }
 
-	public static File createTempFile(String prefix, String suffix) throws IOException {
-		File tmp = File.createTempFile(prefix, suffix);
-		tempFiles.add(tmp);
-		return tmp;
-	}
+    public static void addManagedTempFile(File file) {
+        tempFiles.add(file);
+    }
 
-	public static void addManagedTempFile(File file) {
-		tempFiles.add(file);
-	}
+    public static void tearDown() {
+        tempFiles.forEach(file -> {
+            try {
+                Files.deleteIfExists(file.toPath());
+            } catch (IOException e) {
+                // Trying to have the tests run quieter but I suppose if there's an actual
+                // problem we'd better find out about it
+                e.printStackTrace();
+            }
+        });
+        tempFiles.clear();
+    }
 
-	public static void tearDown() {
-		tempFiles.forEach(file -> {
-			try {
-				Files.deleteIfExists(file.toPath());
-			} catch (IOException e) {
-				// Trying to have the tests run quieter but I suppose if there's an actual
-				// problem we'd better find out about it
-				e.printStackTrace();
-			}
-		});
-		tempFiles.clear();
-	}
+    public static ContentTypeToLanguageServerDefinition getDisabledLS() {
+        return LanguageServersRegistry.getInstance().getContentTypeToLSPExtensions().stream()
+                .filter(definition -> "org.eclipse.lsp4e.test.server.disable".equals(definition.getValue().id)
+                        && "org.eclipse.lsp4e.test.content-type-disabled".equals(definition.getKey().toString()))
+                .findFirst().get();
+    }
 
-	public static ContentTypeToLanguageServerDefinition getDisabledLS() {
-		return LanguageServersRegistry.getInstance().getContentTypeToLSPExtensions().stream()
-				.filter(definition -> "org.eclipse.lsp4e.test.server.disable".equals(definition.getValue().id)
-						&& "org.eclipse.lsp4e.test.content-type-disabled".equals(definition.getKey().toString()))
-				.findFirst().get();
-	}
+    public static Shell findNewShell(Set<Shell> beforeShells, Display display) {
+        Shell[] afterShells = Arrays.stream(display.getShells())
+                .filter(Shell::isVisible)
+                .filter(shell -> !beforeShells.contains(shell))
+                .toArray(Shell[]::new);
+        assertEquals("No new shell found", 1, afterShells.length);
+        return afterShells[0];
+    }
 
-	public static Shell findNewShell(Set<Shell> beforeShells, Display display) {
-		Shell[] afterShells = Arrays.stream(display.getShells())
-				.filter(Shell::isVisible)
-				.filter(shell -> !beforeShells.contains(shell))
-				.toArray(Shell[]::new);
-		assertEquals("No new shell found", 1, afterShells.length);
-		return afterShells[0];
-	}
+    public static Table findCompletionSelectionControl(Widget control) {
+        if (control instanceof Table table) {
+            return table;
+        } else if (control instanceof Composite composite) {
+            for (Widget child : composite.getChildren()) {
+                Table res = findCompletionSelectionControl(child);
+                if (res != null) {
+                    return res;
+                }
+            }
+        }
+        return null;
+    }
 
-	public static Table findCompletionSelectionControl(Widget control) {
-		if (control instanceof Table table) {
-			return table;
-		} else if (control instanceof Composite composite) {
-			for (Widget child : composite.getChildren()) {
-				Table res = findCompletionSelectionControl(child);
-				if (res != null) {
-					return res;
-				}
-			}
-		}
-		return null;
-	}
+    public static IEditorReference[] getEditors() {
+        IWorkbenchWindow wWindow = UI.getActiveWindow();
+        if (wWindow != null) {
+            IWorkbenchPage wPage = wWindow.getActivePage();
+            if (wPage != null) {
+                return wPage.getEditorReferences();
+            }
+        }
+        return null;
+    }
 
-	public static IEditorReference[] getEditors() {
-		IWorkbenchWindow wWindow = UI.getActiveWindow();
-		if (wWindow != null) {
-			IWorkbenchPage wPage = wWindow.getActivePage();
-			if (wPage != null) {
-				return wPage.getEditorReferences();
-			}
-		}
-		return null;
-	}
+    public static void waitForAndAssertCondition(int timeout_ms, Condition condition) {
+        waitForAndAssertCondition("Condition not met within expected time.", timeout_ms, condition);
+    }
 
-	public static void waitForAndAssertCondition(int timeout_ms, Condition condition) {
-		waitForAndAssertCondition("Condition not met within expected time.", timeout_ms, condition);
-	}
+    public static void waitForAndAssertCondition(int timeout_ms, Display display, Condition condition) {
+        waitForAndAssertCondition("Condition not met within expected time.", timeout_ms, display, condition);
+    }
 
-	public static void waitForAndAssertCondition(int timeout_ms, Display display, Condition condition) {
-		waitForAndAssertCondition("Condition not met within expected time.", timeout_ms, display, condition);
-	}
+    public static void waitForAndAssertCondition(String errorMessage, int timeout_ms, Condition condition) {
+        waitForAndAssertCondition(errorMessage, timeout_ms, UI.getDisplay(), condition);
+    }
 
-	public static void waitForAndAssertCondition(String errorMessage, int timeout_ms, Condition condition) {
-		waitForAndAssertCondition(errorMessage, timeout_ms, UI.getDisplay(), condition);
-	}
+    public static void waitForAndAssertCondition(String errorMessage, int timeout_ms, Display display,
+            Condition condition) {
+        var ex = new Throwable[1];
+        var isConditionMet = new DisplayHelper() {
+            @Override
+            protected boolean condition() {
+                try {
+                    var isMet = condition.isMet();
+                    ex[0] = null;
+                    return isMet;
+                } catch (AssertionError | Exception e) {
+                    ex[0] = e;
+                    return false;
+                }
+            }
+        }.waitForCondition(display, timeout_ms, 50);
+        if (ex[0] != null) {
+            // if the condition was not met because of an exception throw it
+            if (ex[0] instanceof AssertionError ae) {
+                throw ae;
+            }
+            if (ex[0] instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new AssertionError(errorMessage, ex[0]);
+        }
+        assertTrue(errorMessage, isConditionMet);
+    }
 
-	public static void waitForAndAssertCondition(String errorMessage, int timeout_ms, Display display,
-			Condition condition) {
-		var ex = new Throwable[1];
-		var isConditionMet = new DisplayHelper() {
-			@Override
-			protected boolean condition() {
-				try {
-					var isMet = condition.isMet();
-					ex[0] = null;
-					return isMet;
-				} catch (AssertionError | Exception e) {
-					ex[0] = e;
-					return false;
-				}
-			}
-		}.waitForCondition(display, timeout_ms, 50);
-		if (ex[0] != null) {
-			// if the condition was not met because of an exception throw it
-			if (ex[0] instanceof AssertionError ae) {
-				throw ae;
-			}
-			if (ex[0] instanceof RuntimeException re) {
-				throw re;
-			}
-			throw new AssertionError(errorMessage, ex[0]);
-		}
-		assertTrue(errorMessage, isConditionMet);
-	}
+    public static boolean waitForCondition(int timeout_ms, Condition condition) {
+        return waitForCondition(timeout_ms, UI.getDisplay(), condition);
+    }
 
-	public static boolean waitForCondition(int timeout_ms, Condition condition) {
-		return waitForCondition(timeout_ms, UI.getDisplay(), condition);
-	}
+    public static boolean waitForCondition(int timeout_ms, Display display, Condition condition) {
+        var ex = new Throwable[1];
+        var isConditionMet = new DisplayHelper() {
+            @Override
+            protected boolean condition() {
+                try {
+                    var isMet = condition.isMet();
+                    ex[0] = null;
+                    return isMet;
+                } catch (AssertionError | Exception e) {
+                    ex[0] = e;
+                    return false;
+                }
+            }
+        }.waitForCondition(display, timeout_ms, 50);
+        if (ex[0] != null) {
+            // if the condition was not met because of an exception log it
+            ex[0].printStackTrace();
+        }
+        return isConditionMet;
+    }
 
-	public static boolean waitForCondition(int timeout_ms, Display display, Condition condition) {
-		var ex = new Throwable[1];
-		var isConditionMet = new DisplayHelper() {
-			@Override
-			protected boolean condition() {
-				try {
-					var isMet = condition.isMet();
-					ex[0] = null;
-					return isMet;
-				} catch (AssertionError | Exception e) {
-					ex[0] = e;
-					return false;
-				}
-			}
-		}.waitForCondition(display, timeout_ms, 50);
-		if (ex[0] != null) {
-			// if the condition was not met because of an exception log it
-			ex[0].printStackTrace();
-		}
-		return isConditionMet;
-	}
+    public void waitForLanguageServerNotRunning(MockLanguageServer server) {
+        assertTrue(new DisplayHelper() {
+            @Override
+            protected boolean condition() {
+                return !server.isRunning();
+            }
+        }.waitForCondition(UI.getDisplay(), 1000));
+    }
 
-	public void waitForLanguageServerNotRunning(MockLanguageServer server) {
-		assertTrue(new DisplayHelper() {
-			@Override
-			protected boolean condition() {
-				return !server.isRunning();
-			}
-		}.waitForCondition(UI.getDisplay(), 1000));
-	}
+    public static class JobSynchronizer extends NullProgressMonitor {
+        private final CountDownLatch latch = new CountDownLatch(1);
 
-	public static class JobSynchronizer extends NullProgressMonitor {
-		private final CountDownLatch latch = new CountDownLatch(1);
+        @Override
+        public void done() {
+            latch.countDown();
+        }
 
-		@Override
-		public void done() {
-			latch.countDown();
-		}
+        @Override
+        public void setCanceled(boolean cancelled) {
+            super.setCanceled(cancelled);
+            if (cancelled) {
+                latch.countDown();
+            }
+        }
 
-		@Override
-		public void setCanceled(boolean cancelled) {
-			super.setCanceled(cancelled);
-			if (cancelled) {
-				latch.countDown();
-			}
-		}
+        public void await() throws InterruptedException {
+            latch.await();
+        }
 
-		public void await() throws InterruptedException {
-			latch.await();
-		}
+        @Override
+        public void worked(int work) {
+            latch.countDown();
+        }
+    }
 
-		@Override
-		public void worked(int work) {
-			latch.countDown();
-		}
-	}
-
-	public static Condition numberOfChangesIs(int changes) {
-		return () -> MockLanguageServer.INSTANCE.getDidChangeEvents().size() == changes;
-	}
+    public static Condition numberOfChangesIs(int changes) {
+        return () -> MockLanguageServer.INSTANCE.getDidChangeEvents().size() == changes;
+    }
 }

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -57,6 +58,7 @@ import org.eclipse.lsp4j.LinkedEditingRangeRegistrationOptions;
 import org.eclipse.lsp4j.LinkedEditingRanges;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.RenameOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SignatureHelp;
@@ -237,7 +239,7 @@ public final class MockLanguageServer implements LanguageServer {
 		this.textDocumentService.setMockFormattingTextEdits(formattingTextEdits);
 	}
 
-	public void setDocumentHighlights(List<? extends DocumentHighlight> documentHighlights) {
+	public void setDocumentHighlights(Map<Position, List<? extends DocumentHighlight>> documentHighlights) {
 		this.textDocumentService.setDocumentHighlights(documentHighlights);
 	}
 

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServerMultiRootFolders.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServerMultiRootFolders.java
@@ -17,6 +17,7 @@ package org.eclipse.lsp4e.tests.mock;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -41,6 +42,7 @@ import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SignatureHelpOptions;
@@ -186,7 +188,7 @@ public final class MockLanguageServerMultiRootFolders implements LanguageServer 
 		this.textDocumentService.setMockFormattingTextEdits(formattingTextEdits);
 	}
 
-	public void setDocumentHighlights(List<? extends DocumentHighlight> documentHighlights) {
+	public void setDocumentHighlights(Map<Position, List<? extends DocumentHighlight>> documentHighlights) {
 		this.textDocumentService.setDocumentHighlights(documentHighlights);
 	}
 

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
@@ -95,7 +96,7 @@ public class MockTextDocumentService implements TextDocumentService {
 	private SignatureHelp mockSignatureHelp;
 	private List<CodeLens> mockCodeLenses;
 	private List<DocumentLink> mockDocumentLinks;
-	private List<? extends DocumentHighlight> mockDocumentHighlights;
+	private Map<Position, List<? extends DocumentHighlight>> mockDocumentHighlights;
 	private LinkedEditingRanges mockLinkedEditingRanges;
 
 	private CompletableFuture<DidOpenTextDocumentParams> didOpenCallback;
@@ -165,8 +166,8 @@ public class MockTextDocumentService implements TextDocumentService {
 	}
 
 	@Override
-	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams position) {
-		return CompletableFuture.completedFuture(mockDocumentHighlights);
+	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(DocumentHighlightParams params) {
+		return CompletableFuture.completedFuture(mockDocumentHighlights.get(params.getPosition()));
 	}
 
 	@Override
@@ -390,7 +391,7 @@ public class MockTextDocumentService implements TextDocumentService {
 		this.mockSignatureHelp = signatureHelp;
 	}
 
-	public void setDocumentHighlights(List<? extends DocumentHighlight> documentHighlights) {
+	public void setDocumentHighlights(Map<Position, List<? extends DocumentHighlight>> documentHighlights) {
 		this.mockDocumentHighlights = documentHighlights;
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
@@ -141,6 +141,7 @@ public class HighlightReconcilingStrategy
 
 	@Override
 	public void uninstall() {
+		removeOccurrenceAnnotations();
 		if (sourceViewer != null) {
 			editorSelectionChangedListener.uninstall(sourceViewer.getSelectionProvider());
 		}


### PR DESCRIPTION
Ensure that active highlights are removed when a source view is closed
This commit resolves a bug related to erroneously persisted highlights
in source files. It includes a unit test that verifies the correctness
of the fix, and a few minor improvements to the testing framework.

---

Bug Description: Before this change, it was possible for highlights to
persist and be shown erroneously after a source view is closed. This
would happen, for example, after the following sequence of steps:

1. Open a source. Ensure that some keyword is highlighted.
2. Activate the option "Toggle Split Editor (Horizontal)".
3. In the newly opened source view, highlight a different keyword.
4. At this point, both sets of highlights (the one from step 1 and the
one from step 3) should be visible in both open source views. This is
correct behavior.
5. Close one of the source views, while keeping the other open. Before
this commit, both sets of highlights would persist. However, only the
set of highlights related to the source view that remains open should be
displayed.

Cause: Each instance of HighlightReconcilingStrategy adds/removes
highlights independently, and keeps track of all the highlights it has
created internally. However, all the highlights associated with the
source file's underlying IFileBuffer are only cleared when the file is
closed. If two source views display the same file, and one of them is
closed, its highlights should no longer be displayed.

Solution: When a source view is closed, all active highlights associated
with its HighlightReconcilingStrategy should be removed. We accomplish
this by calling `removeOccurrenceAnnotations()` during the `uninstall()`
method of `HighlightReconcilingStrategy.java`.

Testing: A unit test was created which approximately follows the
sequence of steps outlined above. To implement this unit test, the
following changes were made to the testing framework:

1. In HighlightTest.java, the function `assertAnnotationDoesNotExist`
was created (for consistency, the existing function
`assertHasAnnotation` was renamed to `assertAnnotationExists`).
2. The `mockDocumentHighlights` returned by the
`MockTextDocumentService` are now Position-dependent. The unit tests in
`HighlightTest.java` were adapted accordingly.
