### PR TITLE
Limited Functionality of LSP Editors in MultiPart Editors #859

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.0.qualifier
+Bundle-Version: 0.18.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -748,9 +748,14 @@
             <with variable="selection">
                <instanceof value="org.eclipse.jface.text.ITextSelection" />
             </with>
-            <with variable="activeEditorInput">
-               <test property="org.eclipse.lsp4e.hasLanguageServer" />
-            </with>
+            <or>
+	            <with variable="activeEditorInput">
+               		<test property="org.eclipse.lsp4e.hasLanguageServer" />
+            	</with>
+				<with variable="activeEditor">
+               		<test property="org.eclipse.lsp4e.hasLanguageServer"/>
+            	</with>
+            </or>
          </and>
       </definition>
    </extension>

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.0-SNAPSHOT</version>
+	<version>0.18.1-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/HasLanguageServerPropertyTester.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/HasLanguageServerPropertyTester.java
@@ -16,7 +16,9 @@ import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
 
 public class HasLanguageServerPropertyTester extends PropertyTester {
 
@@ -29,6 +31,15 @@ public class HasLanguageServerPropertyTester extends PropertyTester {
 		} else if (receiver instanceof IDocument document) {
 			return LanguageServersRegistry.getInstance().canUseLanguageServer(document);
 		} else if (receiver instanceof ITextViewer viewer) {
+			return test(viewer);
+		} else if (receiver instanceof IEditorPart part) {
+			return test(UI.asTextViewer(part));
+		}
+		return false;
+	}
+
+	private boolean test(ITextViewer viewer) {
+		if (viewer != null) {
 			IDocument document = viewer.getDocument();
 			if (document != null) {
 				return LanguageServersRegistry.getInstance().canUseLanguageServer(document);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyCommandHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyCommandHandler.java
@@ -13,7 +13,6 @@
 package org.eclipse.lsp4e.callhierarchy;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
@@ -24,7 +23,6 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 /**
@@ -33,24 +31,21 @@ import org.eclipse.ui.texteditor.ITextEditor;
 public class CallHierarchyCommandHandler extends LSPDocumentAbstractHandler {
 
 	@Override
-	public Object execute(final ExecutionEvent event) throws ExecutionException {
-		if (HandlerUtil.getActiveEditor(event) instanceof ITextEditor editor) {
-			IDocument document = LSPEclipseUtils.getDocument(editor);
-			if (document == null) {
-				return null;
-			}
-			if (editor.getSelectionProvider().getSelection() instanceof ITextSelection sel) {
-				int offset = sel.getOffset();
+	protected void execute(ExecutionEvent event, ITextEditor editor) {
+		IDocument document = LSPEclipseUtils.getDocument(editor);
+		if (document == null) {
+			return;
+		}
+		if (editor.getSelectionProvider().getSelection() instanceof ITextSelection sel) {
+			int offset = sel.getOffset();
 
-				try {
-					CallHierarchyView theView = (CallHierarchyView) getActivePage().showView(CallHierarchyView.ID);
-					theView.initialize(document, offset);
-				} catch (PartInitException e) {
-					LanguageServerPlugin.logError("Error while opening the Call Hierarchy view", e); //$NON-NLS-1$
-				}
+			try {
+				CallHierarchyView theView = (CallHierarchyView) getActivePage().showView(CallHierarchyView.ID);
+				theView.initialize(document, offset);
+			} catch (PartInitException e) {
+				LanguageServerPlugin.logError("Error while opening the Call Hierarchy view", e); //$NON-NLS-1$
 			}
 		}
-		return null;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/LSPDocumentAbstractHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/LSPDocumentAbstractHandler.java
@@ -13,6 +13,7 @@
 package org.eclipse.lsp4e.internal;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -20,6 +21,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.HandlerEvent;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -34,6 +37,7 @@ import org.eclipse.lsp4e.LanguageServers.LanguageServerDocumentExecutor;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 public abstract class LSPDocumentAbstractHandler extends AbstractHandler {
@@ -81,6 +85,23 @@ public abstract class LSPDocumentAbstractHandler extends AbstractHandler {
 			return Boolean.FALSE;
 		}
 	}
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		Optional.ofNullable(UI.asTextEditor(HandlerUtil.getActiveEditor(event)))
+				.ifPresent(textEditor -> execute(event, textEditor));
+		return null;
+	}
+
+	/**
+	 * Intended to be implemented by sub-classes which work on the text editor. This
+	 * method is only called if an {@link ITextEditor} can be obtained. Sub-classes
+	 * may still override {@link #execute(ExecutionEvent)} for custom behavior.
+	 *
+	 * @param event
+	 * @param textEditor
+	 */
+	protected abstract void execute(ExecutionEvent event, ITextEditor textEditor);
 
 	protected boolean hasSelection(ITextEditor textEditor) {
 		ISelectionProvider provider = textEditor.getSelectionProvider();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatHandler.java
@@ -16,7 +16,6 @@ package org.eclipse.lsp4e.operations.format;
 import java.util.ConcurrentModificationException;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextSelection;
@@ -37,17 +36,13 @@ public class LSPFormatHandler extends LSPDocumentAbstractHandler {
 	private final LSPFormatter formatter = new LSPFormatter();
 
 	@Override
-	public Object execute(final ExecutionEvent event) throws ExecutionException {
-		final ITextEditor textEditor = UI.getActiveTextEditor();
-		if (textEditor == null)
-			return null;
-
+	protected void execute(ExecutionEvent event, ITextEditor textEditor) {
 		final ISelection selection = HandlerUtil.getCurrentSelection(event);
 		if (selection instanceof final ITextSelection textSelection && !textSelection.isEmpty()) {
 
 			final IDocument doc = LSPEclipseUtils.getDocument(textEditor);
 			if (doc == null)
-				return null;
+				return;
 
 			try {
 				formatter.requestFormatting(doc, textSelection)
@@ -68,7 +63,6 @@ public class LSPFormatHandler extends LSPDocumentAbstractHandler {
 				LanguageServerPlugin.logError(e);
 			}
 		}
-		return null;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSFindReferences.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSFindReferences.java
@@ -14,7 +14,6 @@
 package org.eclipse.lsp4e.operations.references;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.IHandler;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -35,22 +34,19 @@ import org.eclipse.ui.texteditor.ITextEditor;
 public class LSFindReferences extends LSPDocumentAbstractHandler implements IHandler {
 
 	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
-		if (HandlerUtil.getActiveEditor(event) instanceof ITextEditor editor) {
-			ISelection sel = editor.getSelectionProvider().getSelection();
-			if (sel instanceof ITextSelection textSelection) {
-				IDocument document = LSPEclipseUtils.getDocument(editor);
-				if (document != null) {
-					try {
-						final var query = new LSSearchQuery(textSelection.getOffset(), document);
-						HandlerUtil.getActiveShell(event).getDisplay().asyncExec(() -> NewSearchUI.runQueryInBackground(query));
-					} catch (BadLocationException e) {
-						LanguageServerPlugin.logError(e);
-					}
+	protected void execute(ExecutionEvent event, ITextEditor textEditor) {
+		ISelection sel = textEditor.getSelectionProvider().getSelection();
+		if (sel instanceof ITextSelection textSelection) {
+			IDocument document = LSPEclipseUtils.getDocument(textEditor);
+			if (document != null) {
+				try {
+					final var query = new LSSearchQuery(textSelection.getOffset(), document);
+					HandlerUtil.getActiveShell(event).getDisplay().asyncExec(() -> NewSearchUI.runQueryInBackground(query));
+				} catch (BadLocationException e) {
+					LanguageServerPlugin.logError(e);
 				}
 			}
 		}
-		return null;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileHandler.java
@@ -15,45 +15,39 @@ package org.eclipse.lsp4e.operations.symbols;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.internal.LSPDocumentAbstractHandler;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 public class LSPSymbolInFileHandler extends LSPDocumentAbstractHandler {
 
 	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
-		IEditorPart part = HandlerUtil.getActiveEditor(event);
-		if (part instanceof ITextEditor textEditor) {
-			final IDocument document = LSPEclipseUtils.getDocument(textEditor);
-			if (document == null) {
-				return null;
-			}
-
-			final Shell shell = HandlerUtil.getActiveShell(event);
-
-			if (shell == null) {
-				return null;
-			}
-
-			// TODO maybe consider better strategy such as iterating on all LS until we have
-			// a good result
-			LanguageServers.forDocument(document).withCapability(ServerCapabilities::getDocumentSymbolProvider)
-					.computeFirst((w, ls) -> CompletableFuture.completedFuture(w))
-					.thenAcceptAsync(oW -> oW.ifPresent(w -> {
-						if (w != null) {
-							new LSPSymbolInFileDialog(shell, textEditor, document, w).open();
-						}
-					}), shell.getDisplay());
+	protected void execute(ExecutionEvent event, ITextEditor textEditor) {
+		final IDocument document = LSPEclipseUtils.getDocument(textEditor);
+		if (document == null) {
+			return;
 		}
-		return null;
+
+		final Shell shell = HandlerUtil.getActiveShell(event);
+
+		if (shell == null) {
+			return;
+		}
+
+		// TODO maybe consider better strategy such as iterating on all LS until we have
+		// a good result
+		LanguageServers.forDocument(document).withCapability(ServerCapabilities::getDocumentSymbolProvider)
+				.computeFirst((w, ls) -> CompletableFuture.completedFuture(w))
+				.thenAcceptAsync(oW -> oW.ifPresent(w -> {
+					if (w != null) {
+						new LSPSymbolInFileDialog(shell, textEditor, document, w).open();
+					}
+				}), shell.getDisplay());
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchSite;
 import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.texteditor.ITextEditor;
 
 public class LSPSymbolInWorkspaceHandler extends LSPDocumentAbstractHandler {
 
@@ -72,6 +73,11 @@ public class LSPSymbolInWorkspaceHandler extends LSPDocumentAbstractHandler {
 		}
 
 		return null;
+	}
+
+	@Override
+	protected void execute(ExecutionEvent event, ITextEditor textEditor) {
+		// not required here, see implementation above
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyHandler.java
@@ -11,34 +11,28 @@ package org.eclipse.lsp4e.operations.typeHierarchy;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.internal.LSPDocumentAbstractHandler;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 public class TypeHierarchyHandler extends LSPDocumentAbstractHandler {
 
 	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {
-		IEditorPart editor = HandlerUtil.getActiveEditor(event);
-		if (editor instanceof ITextEditor textEditor) {
-			IDocument document = LSPEclipseUtils.getDocument(textEditor);
-			LanguageServers.forDocument(document)
-				.withCapability(ServerCapabilities::getTypeHierarchyProvider)
-				.computeFirst((wrapper, ls) -> CompletableFuture.completedFuture(wrapper.serverDefinition))
-				.thenAcceptAsync(definition -> definition.ifPresent(def -> new TypeHierarchyDialog(editor.getSite().getShell(), (ITextSelection)textEditor.getSelectionProvider().getSelection(), document, def).open()), editor.getSite().getShell().getDisplay());
-		}
-		return null;
+	protected void execute(ExecutionEvent event, ITextEditor editor) {
+		IDocument document = LSPEclipseUtils.getDocument(editor);
+		LanguageServers.forDocument(document)
+			.withCapability(ServerCapabilities::getTypeHierarchyProvider)
+			.computeFirst((wrapper, ls) -> CompletableFuture.completedFuture(wrapper.serverDefinition))
+			.thenAcceptAsync(definition -> definition.ifPresent(def -> new TypeHierarchyDialog(editor.getSite().getShell(), (ITextSelection)editor.getSelectionProvider().getSelection(), document, def).open()), editor.getSite().getShell().getDisplay());
 	}
 
 	@Override
 	public void setEnabled(Object evaluationContext) {
 		setEnabled(ServerCapabilities::getTypeDefinitionProvider, editor -> true);
 	}
+
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyViewHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyViewHandler.java
@@ -14,7 +14,6 @@ package org.eclipse.lsp4e.operations.typeHierarchy;
 import java.util.Optional;
 
 import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.lsp4e.LSPEclipseUtils;
@@ -22,7 +21,6 @@ import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.callhierarchy.CallHierarchyCommandHandler;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.texteditor.ITextEditor;
 
 /**
@@ -31,25 +29,22 @@ import org.eclipse.ui.texteditor.ITextEditor;
 public class TypeHierarchyViewHandler extends CallHierarchyCommandHandler {
 
 	@Override
-	public Object execute(final ExecutionEvent event) throws ExecutionException {
-		if (HandlerUtil.getActiveEditor(event) instanceof ITextEditor editor) {
-			IDocument document = LSPEclipseUtils.getDocument(editor);
-			if (document == null) {
-				return null;
-			}
-			if (editor.getSelectionProvider().getSelection() instanceof ITextSelection sel) {
-				int offset = sel.getOffset();
-				Optional.ofNullable(getActivePage()).map(p -> {
-					try {
-						return p.showView(TypeHierarchyView.ID);
-					} catch (PartInitException e) {
-						LanguageServerPlugin.logError("Error while opening the Type Hierarchy view", e); //$NON-NLS-1$
-					}
-					return Optional.empty();
-				}).filter(view -> view instanceof TypeHierarchyView).ifPresent(thv -> ((TypeHierarchyView) thv).initialize(document, offset));
-			}
+	protected void execute(ExecutionEvent event, ITextEditor editor) {
+		IDocument document = LSPEclipseUtils.getDocument(editor);
+		if (document == null) {
+			return;
 		}
-		return null;
+		if (editor.getSelectionProvider().getSelection() instanceof ITextSelection sel) {
+			int offset = sel.getOffset();
+			Optional.ofNullable(getActivePage()).map(p -> {
+				try {
+					return p.showView(TypeHierarchyView.ID);
+				} catch (PartInitException e) {
+					LanguageServerPlugin.logError("Error while opening the Type Hierarchy view", e); //$NON-NLS-1$
+				}
+				return Optional.empty();
+			}).filter(view -> view instanceof TypeHierarchyView).ifPresent(thv -> ((TypeHierarchyView) thv).initialize(document, offset));
+		}
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/EditorToOutlineAdapterFactory.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/EditorToOutlineAdapterFactory.java
@@ -35,7 +35,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IViewPart;
-import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.views.contentoutline.ContentOutline;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 
@@ -88,11 +87,7 @@ public class EditorToOutlineAdapterFactory implements IAdapterFactory {
 	}
 
 	private static CNFOutlinePage createOutlinePage(IEditorPart editorPart, @NonNull LanguageServerWrapper wrapper) {
-		ITextEditor textEditor = null;
-		if (editorPart instanceof ITextEditor thisTextEditor) {
-			textEditor = thisTextEditor;
-		}
-		return new CNFOutlinePage(wrapper, textEditor);
+		return new CNFOutlinePage(wrapper, UI.asTextEditor(editorPart));
 	}
 
 	private static void refreshContentOutlineAsync(CompletableFuture<Optional<LanguageServerWrapper>> wrapper,

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/UI.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/UI.java
@@ -15,6 +15,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -51,25 +52,33 @@ public final class UI {
 		if (activePage == null) {
 			return null;
 		}
-		var editorPart = activePage.getActiveEditor();
+		return asTextEditor(activePage.getActiveEditor());
+	}
+
+	@Nullable
+	public static ITextEditor asTextEditor(@Nullable IEditorPart editorPart) {
 		if (editorPart instanceof ITextEditor textEditor) {
 			return textEditor;
-		} else if (editorPart instanceof MultiPageEditorPart multiPageEditorPart) {
-			Object page = multiPageEditorPart.getSelectedPage();
-			if (page instanceof ITextEditor textEditor) {
-				return textEditor;
-			}
+		} else if (editorPart instanceof MultiPageEditorPart multiPageEditorPart
+				&& multiPageEditorPart.getSelectedPage() instanceof ITextEditor textEditor) {
+			return textEditor;
+		}
+		return null;
+//		TODO consider returning Adapters.adapt(editorPart, ITextEditor.class) instead
+	}
+
+	@Nullable
+	public static ITextViewer asTextViewer(@Nullable IEditorPart editorPart) {
+		if (editorPart != null) {
+			return editorPart.getAdapter(ITextViewer.class);
+//			TODO consider returning Adapters.adapt(asTextEditor(editorPart), ITextViewer.class)
 		}
 		return null;
 	}
 
 	@Nullable
 	public static ITextViewer getActiveTextViewer() {
-		ITextEditor editor = getActiveTextEditor();
-		if (editor != null) {
-			return editor.getAdapter(ITextViewer.class);
-		}
-		return null;
+		return asTextViewer(getActiveTextEditor());
 	}
 
 	@Nullable


### PR DESCRIPTION
Fix for #859.

There are multiple occasions in the code where editor parts are casted to ITextEditor. As a result, lsp editors embedded in MultiPage editors don't have the full functionality.
Additionally many handlers use UI::getActiveTextEditor, IMHO getting the editor from ExecutionEvent would be cleaner.

As most handlers (except one) work with ITextEditor, I added a convenience execution method to `LSPDocumentAbstractHandler` for this use case. I refactored the existing handlers to use this method, which was basically removing the casts.

I created a new method UI::asTextEditor as central place for obtaining ITextEditor from an IEditorPart. This method could additionally try to adapt to ITextEditor, which would enable more use cases, but I didn't want to introduce this for this PR.