### PR TITLE
Fix closing quick outline dialog after selection

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.1.qualifier
+Bundle-Version: 0.18.2.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.1-SNAPSHOT</version>
+	<version>0.18.2-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
@@ -113,6 +113,7 @@ public class LSPSymbolInFileDialog extends PopupDialog {
 				} catch (BadLocationException e) {
 					LanguageServerPlugin.logError(e);
 				}
+				close();
 			}
 		});
 


### PR DESCRIPTION
The quick outline view (in my case used with the C/C++ editor based on LSP) behaved odd. It did not close after selecting an element symbol) in an open file. There was also an x button missing.

I fixed that.