### PR TITLE
Prevent error logging for RequestCancelledExceptions

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -66,6 +66,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
+import org.eclipse.lsp4e.internal.CancellationUtil;
 import org.eclipse.lsp4e.internal.FileBufferListenerAdapter;
 import org.eclipse.lsp4e.internal.SupportedFeatures;
 import org.eclipse.lsp4e.server.StreamConnectionProvider;
@@ -836,7 +837,9 @@ public class LanguageServerWrapper {
 		} catch (TimeoutException e) {
 			LanguageServerPlugin.logError("LanguageServer not initialized within 10s", e); //$NON-NLS-1$
 		} catch (ExecutionException | CancellationException e) {
-			LanguageServerPlugin.logError(e);
+			if (!CancellationUtil.isRequestCancelledException(e)) { // do not report error if the server has cancelled the request
+				LanguageServerPlugin.logError(e);
+			}
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			LanguageServerPlugin.logError(e);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/CancellationUtil.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/CancellationUtil.java
@@ -26,7 +26,7 @@ public final class CancellationUtil {
 	}
 
 	public static boolean isRequestCancelledException(Throwable throwable) {
-		if (throwable instanceof CompletionException | throwable instanceof  ExecutionException) {
+		if (throwable instanceof CompletionException | throwable instanceof ExecutionException) {
 			throwable = throwable.getCause();
 		}
 		if (throwable instanceof ResponseErrorException responseErrorException) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
@@ -43,6 +43,7 @@ import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4e.internal.CancellationUtil;
 import org.eclipse.lsp4j.LinkedEditingRanges;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.swt.custom.StyledText;
@@ -165,7 +166,9 @@ public class LSPLinkedEditingReconcilingStrategy extends LSPLinkedEditingBase
 			collectLinkedEditingRanges(fDocument, offset).thenAcceptAsync(optional -> {
 				optional.ifPresent(this::applyLinkedEdit);
 			}).exceptionally(e -> {
-				LanguageServerPlugin.logError(e);
+				if (!CancellationUtil.isRequestCancelledException(e)) { // do not report error if the server has cancelled the request
+					LanguageServerPlugin.logError(e);
+				}
 				return null;
 			});
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -93,7 +93,7 @@ public class SemanticHighlightReconcilerStrategy
 	private SemanticTokensDataStreamProcessor semanticTokensDataStreamProcessor;
 
 	private boolean isInstalled;
-	
+
 	/**
 	 * Written in {@link this.class#applyTextPresentation(TextPresentation)}
 	 * applyTextPresentation and read in the lambda in
@@ -270,15 +270,13 @@ public class SemanticHighlightReconcilerStrategy
 						.ifPresent(versionedSemanticTokens -> {
 							versionedSemanticTokens.apply(this::saveStyle, this::invalidateTextPresentation);
 						});
-			} catch (ResponseErrorException | ExecutionException e) {
-				if (!CancellationUtil.isRequestCancelledException(e)) { // do not report error if the server has cancelled the request
-					LanguageServerPlugin.logError(e);
-				}
 			} catch (InterruptedException e) {
 				LanguageServerPlugin.logError(e);
 				Thread.currentThread().interrupt();
-			} catch (CancellationException e) {
-				// nothing to do, the client has cancelled the request because the document has been closed or a new request has been sent
+			} catch (ResponseErrorException | ExecutionException | CancellationException e) {
+				if (!CancellationUtil.isRequestCancelledException(e)) { // do not report error if the server has cancelled the request
+					LanguageServerPlugin.logError(e);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If the language server throws a `CancellationException` upon cancelling a request, this should not be logged as an error by the `LanguageServerPlugin`.

A check to ensure this behavior already exists in some locations (e.g., `org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor.computeCompletionProposals(ITextViewer, int)`).

However, other locations where this check should be performed do not include it. This commit introduces the missing checks.