### PR TITLE
Add rough sketch for a bugfix for #885

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.15.8.qualifier
+Bundle-Version: 0.15.9.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.15.8-SNAPSHOT</version>
+	<version>0.15.9-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/BlockingWorkspaceJob.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/BlockingWorkspaceJob.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Erik Brangs and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ * Erik Brangs - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.utils;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+
+public class BlockingWorkspaceJob extends WorkspaceJob {
+
+	public BlockingWorkspaceJob(String name) {
+		super(name);
+	}
+
+	private CountDownLatch countDownLatch = new CountDownLatch(1);
+
+	@Override
+	public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+		try {
+			countDownLatch.await();
+		} catch (InterruptedException e) {
+			return Status.CANCEL_STATUS;
+		}
+		return Status.OK_STATUS;
+	}
+
+	public void progress() {
+		countDownLatch.countDown();
+	}
+
+}

--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.2.qualifier
+Bundle-Version: 0.18.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.2-SNAPSHOT</version>
+	<version>0.18.3-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -140,6 +140,10 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 
 			@Override
 			public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+				if (!resource.exists()) {
+					return Status.OK_STATUS;
+				}
+
 				final var toDeleteMarkers = new HashSet<IMarker>(
 						Arrays.asList(resource.findMarkers(markerType, true, IResource.DEPTH_ZERO)));
 				toDeleteMarkers
@@ -166,12 +170,17 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 
 				try {
 					for (Diagnostic diagnostic : newDiagnostics) {
-						Map<String, Object> markerAttributes = computeMarkerAttributes(document, diagnostic, resource);
-						resource.createMarker(markerType, markerAttributes);
+						if (resource.exists()) {
+							Map<String, Object> markerAttributes = computeMarkerAttributes(document, diagnostic, resource);
+							resource.createMarker(markerType, markerAttributes);
+						}
 					}
 					for (Entry<IMarker, Diagnostic> entry : toUpdate.entrySet()) {
-						Map<String, Object> markerAttributes = computeMarkerAttributes(document, entry.getValue(), resource);
-						updateMarker(markerAttributes, entry.getKey());
+						IMarker marker = entry.getKey();
+						if (marker.exists()) {
+							Map<String, Object> markerAttributes = computeMarkerAttributes(document, entry.getValue(), resource);
+							updateMarker(markerAttributes, marker);
+						}
 					}
 					toDeleteMarkers.forEach(t -> {
 						try {
@@ -210,6 +219,9 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 		}
 
 		for (IMarker marker : remainingMarkers) {
+			if (!marker.exists()) {
+				continue;
+			}
 			try {
 				if (LSPEclipseUtils.toOffset(diagnostic.getRange().getStart(), document) == MarkerUtilities.getCharStart(marker)
 						&& (LSPEclipseUtils.toOffset(diagnostic.getRange().getEnd(), document) == MarkerUtilities.getCharEnd(marker) || Objects.equals(diagnostic.getRange().getStart(), diagnostic.getRange().getEnd()))


### PR DESCRIPTION
As requested by @mickaelistria in #885 , here is a pull request that highlights where exists() checks might be missing.

The fix is probably wrong because I wasn't actually able to reproduce the problem. The associated test seems to trigger a different problem.

I suppose the original problem is triggered by the order of operations. I don't know enough to reproduce it in a test case.