### PR TITLE
[#902] Do not split line endings in edits

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -308,6 +308,26 @@ public class LSPEclipseUtilsTest {
 		LSPEclipseUtils.applyEdits(document, Arrays.asList(edits));
 		Assert.assertEquals(" throws Exception", document.get());
 	}
+	
+	@Test
+	public void testTextEditSplittedLineEndings() throws Exception {
+		IProject project = null;
+		IEditorPart editor = null;
+		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
+		IFile file = TestUtils.createUniqueTestFile(project, "line1\r\nline2\r\nline3\r\n");
+		editor = TestUtils.openEditor(file);
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		// GIVEN a TextEdit which splits the '\r\n' line ending in the third line:
+		TextEdit[] edits = new TextEdit[] { new TextEdit(new Range(new Position(0, 0), new Position(2, 6)), "line3\r\nline2\r\nline1\r") };
+		IDocument document = viewer.getDocument();
+		int linesBeforeApplyEdits = document.getNumberOfLines();
+		// WHEN the TextEdit gets applied to the document:
+		LSPEclipseUtils.applyEdits(document, Arrays.asList(edits));
+		// THEN line1 has been swapped with line 3:
+		Assert.assertEquals("line3\r\nline2\r\nline1\r\n", document.get());
+		// AND the number of lines is still the same, because we have not appended a line:
+		Assert.assertEquals(linesBeforeApplyEdits, document.getNumberOfLines());
+	}
 
 	@Test
 	public void testURICreationUnix() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -524,8 +524,11 @@ public final class LSPEclipseUtils {
 				// check if that edit would actually change the document
 				if (!document.get(offset, length).equals(textEdit.getNewText())) {
 					var newText = textEdit.getNewText();
+					var zeroBasedDocumentLines = Math.max(0, document.getNumberOfLines() - 1);
+					var endLine = textEdit.getRange().getEnd().getLine();
+					endLine = endLine > zeroBasedDocumentLines ? zeroBasedDocumentLines : endLine;
 					// Do not split "\r\n" line ending:
-					if ("\r\n".equals(document.getLineDelimiter(textEdit.getRange().getEnd().getLine()))) { //$NON-NLS-1$;
+					if ("\r\n".equals(document.getLineDelimiter(endLine))) { //$NON-NLS-1$;
 						// if last char in the newText is a carriage return:
 						if ('\r' == newText.charAt(newText.length()-1) && offset + length < document.getLength()) {
 							// replace the whole line:

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -521,10 +521,20 @@ public final class LSPEclipseUtils {
 					// Must be a bad location: we bail out to avoid corrupting the document.
 					throw new BadLocationException("Invalid location information found applying edits"); //$NON-NLS-1$
 				}
-
 				// check if that edit would actually change the document
-				if (!document.get(offset, length).equals(textEdit.getNewText()))
-					edit.addChild(new ReplaceEdit(offset, length, textEdit.getNewText()));
+				if (!document.get(offset, length).equals(textEdit.getNewText())) {
+					var newText = textEdit.getNewText();
+					// Do not split "\r\n" line ending:
+					if ("\r\n".equals(document.getLineDelimiter(textEdit.getRange().getEnd().getLine()))) { //$NON-NLS-1$;
+						// if last char in the newText is a carriage return:
+						if ('\r' == newText.charAt(newText.length()-1) && offset + length < document.getLength()) {
+							// replace the whole line:
+							newText = newText + '\n';
+							length++;
+						}
+					}
+					edit.addChild(new ReplaceEdit(offset, length, newText));
+				}
 			}
 		}
 


### PR DESCRIPTION
Splitting \r\n line endings leads to a BadLocationException while TextViewer.setRedraw is executed during a document.replace operation triggered by a TextEdit.

fixes #902