### PR TITLE
Fix closing quick outline view

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInFileDialog.java
@@ -148,6 +148,8 @@ public class LSPSymbolInFileDialog extends PopupDialog {
 		Object selectedElement= getSelectedElement();
 
 		if (selectedElement != null) {
+			close();
+
 			Range range = null;
 			if (selectedElement instanceof SymbolInformation symbolInformation) {
 				range = symbolInformation.getLocation().getRange();
@@ -165,7 +167,6 @@ public class LSPSymbolInFileDialog extends PopupDialog {
 				} catch (BadLocationException e) {
 					LanguageServerPlugin.logError(e);
 				}
-				close();
 			}
 		}
 	}


### PR DESCRIPTION
There are a few cases, where updating the selection / cursor position in an open editor might fail. In those cases the solution from PR #901 might not work and the user could only close the quick outline view with the ESC key (the dialog has no x Button). Instead of first updating the editor's selection and then closing the quick outline view, I suggest to change the order, i.e. first close the quick outline view and then update the editor's selection.