### PR TITLE
Fix NPE if ITextViewer is nullified during call to .underline()

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
@@ -62,10 +62,11 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 	}
 
 	private void underline() {
-		if (viewer == null)
+		ITextViewer theViewer = viewer;
+		if (theViewer == null)
 			return;
 
-		final IDocument document = viewer.getDocument();
+		final IDocument document = theViewer.getDocument();
 		if (document == null) {
 			return;
 		}
@@ -76,7 +77,7 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 		}
 		cancel();
 		final var params = new DocumentLinkParams(LSPEclipseUtils.toTextDocumentIdentifier(uri));
-		final Control control = viewer.getTextWidget();
+		final Control control = theViewer.getTextWidget();
 		if (control != null && !control.isDisposed()) {
 			Display display = control.getDisplay();
 			request = LanguageServers.forDocument(document)


### PR DESCRIPTION
Previously, it was possible for the `viewer` variable used in `LSPDocumentLinkPresentationReconcilingStrategy.underline()` to be nullified externally, which caused a null-pointer exception for the call `viewer.getTextWidget()`.

This commit solves this problem by saving the relevant viewer as a variable local to the
`LSPDocumentLinkPresentationReconcilingStrategy.underline()` function.