### PR TITLE
[#932] prevent reconcile on every dirty region

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -121,11 +121,9 @@ public class LSPFoldingReconcilingStrategy
 	@Override
 	public void reconcile(IRegion subRegion) {
 		IDocument theDocument = document;
-		var ts = DocumentUtil.getDocumentModificationStamp(theDocument);
-		if (projectionAnnotationModel == null || theDocument == null || ts == timestamp) {
+		if (projectionAnnotationModel == null || theDocument == null) {
 			return;
 		}
-		timestamp = ts;
 
 		URI uri = LSPEclipseUtils.toUri(theDocument);
 		if (uri == null) {
@@ -316,7 +314,13 @@ public class LSPFoldingReconcilingStrategy
 
 	@Override
 	public void reconcile(DirtyRegion dirtyRegion, IRegion partition) {
-		reconcile(dirtyRegion);
+		// Because a reconcile will be performed always on the whole document (this is specified by the LSP),
+		// prevent consecutive reconciling on every dirty region if the document has not changed.
+		var ts = DocumentUtil.getDocumentModificationStamp(document);
+		if (ts != timestamp) {
+			reconcile(dirtyRegion);
+			timestamp = ts;
+		}
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -38,6 +38,7 @@ import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4e.internal.DocumentUtil;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeKind;
 import org.eclipse.lsp4j.FoldingRangeRequestParams;
@@ -59,6 +60,7 @@ public class LSPFoldingReconcilingStrategy
 	private ProjectionAnnotationModel projectionAnnotationModel;
 	private ProjectionViewer viewer;
 	private @NonNull List<CompletableFuture<List<FoldingRange>>> requests = List.of();
+	private volatile long timestamp = 0;
 
 	/**
 	 * A FoldingAnnotation is a {@link ProjectionAnnotation} it is folding and
@@ -119,9 +121,11 @@ public class LSPFoldingReconcilingStrategy
 	@Override
 	public void reconcile(IRegion subRegion) {
 		IDocument theDocument = document;
-		if (projectionAnnotationModel == null || theDocument == null) {
+		var ts = DocumentUtil.getDocumentModificationStamp(theDocument);
+		if (projectionAnnotationModel == null || theDocument == null || ts == timestamp) {
 			return;
 		}
+		timestamp = ts;
 
 		URI uri = LSPEclipseUtils.toUri(theDocument);
 		if (uri == null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -256,12 +256,10 @@ public class SemanticHighlightReconcilerStrategy
 	}
 
 	private void fullReconcile() {
-		IDocument theDocument = document;
-		var ts = DocumentUtil.getDocumentModificationStamp(theDocument);
-		if (disabled || !isInstalled || ts == timestamp) { // Skip any processing
+		if (disabled || !isInstalled) { // Skip any processing
 			return;
 		}
-		timestamp = ts;
+		IDocument theDocument = document;
 		cancelSemanticTokensFull();
 		if (theDocument != null) {
 			long modificationStamp = DocumentUtil.getDocumentModificationStamp(theDocument);
@@ -295,12 +293,24 @@ public class SemanticHighlightReconcilerStrategy
 
 	@Override
 	public void reconcile(final DirtyRegion dirtyRegion, final IRegion subRegion) {
-		fullReconcile();
+		fullReconcileOnce();
 	}
 
 	@Override
 	public void reconcile(final IRegion partition) {
-		fullReconcile();
+		fullReconcileOnce();
+	}
+
+	/**
+	 * Because a full reconcile will be performed always on the whole document,
+	 * prevent consecutive reconciling on dirty regions or partitions if the document has not changed.
+	 */
+	private void fullReconcileOnce() {
+		var ts = DocumentUtil.getDocumentModificationStamp(document);
+		if (ts != timestamp) {
+			fullReconcile();
+			timestamp = ts;
+		}
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -105,6 +105,8 @@ public class SemanticHighlightReconcilerStrategy
 	 */
 	private volatile long documentTimestampAtLastAppliedTextPresentation;
 
+	private volatile long timestamp = 0;
+
 	private CompletableFuture<Optional<VersionedSemanticTokens>> semanticTokensFullFuture;
 
 	public SemanticHighlightReconcilerStrategy() {
@@ -254,10 +256,12 @@ public class SemanticHighlightReconcilerStrategy
 	}
 
 	private void fullReconcile() {
-		if (disabled || !isInstalled) { // Skip any processing
+		IDocument theDocument = document;
+		var ts = DocumentUtil.getDocumentModificationStamp(theDocument);
+		if (disabled || !isInstalled || ts == timestamp) { // Skip any processing
 			return;
 		}
-		IDocument theDocument = document;
+		timestamp = ts;
 		cancelSemanticTokensFull();
 		if (theDocument != null) {
 			long modificationStamp = DocumentUtil.getDocumentModificationStamp(theDocument);


### PR DESCRIPTION
This change prevents reconcile run on every dirty region which can be many thousands in a large source file (> 5000 lines) Since the reconciler operate on the whole document it needed to be executed only when the file document changes.

fixes #932