### PR TITLE
[#934] fix removed folding annotations on document change

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.5.qualifier
+Bundle-Version: 0.18.6.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.5-SNAPSHOT</version>
+	<version>0.18.6-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -139,6 +139,7 @@ public class LSPFoldingReconcilingStrategy
 	private void applyFolding(List<FoldingRange> ranges) {
 		// these are what are passed off to the annotation model to
 		// actually create and maintain the annotations
+		final var modifications = new ArrayList<Annotation>(); // not used anymore
 		final var deletions = new ArrayList<FoldingAnnotation>();
 		final var existing = new ArrayList<FoldingAnnotation>();
 		final var additions = new HashMap<Annotation, Position>();
@@ -150,7 +151,7 @@ public class LSPFoldingReconcilingStrategy
 			if (ranges != null) {
 				Collections.sort(ranges, Comparator.comparing(FoldingRange::getEndLine));
 				for (FoldingRange foldingRange : ranges) {
-					updateAnnotation(deletions, existing, additions, foldingRange.getStartLine(),
+					updateAnnotation(modifications, deletions, existing, additions, foldingRange.getStartLine(),
 							foldingRange.getEndLine(), FoldingRangeKind.Imports.equals(foldingRange.getKind()));
 				}
 			}
@@ -228,7 +229,8 @@ public class LSPFoldingReconcilingStrategy
 	 *            the end line number
 	 * @throws BadLocationException
 	 */
-	private void updateAnnotation(List<FoldingAnnotation> deletions, List<FoldingAnnotation> existing, Map<Annotation, Position> additions, int line, Integer endLineNumber, boolean collapsedByDefault)
+	private void updateAnnotation(List<Annotation> modifications, List<FoldingAnnotation> deletions,
+			List<FoldingAnnotation> existing, Map<Annotation, Position> additions, int line, Integer endLineNumber, boolean collapsedByDefault)
 			throws BadLocationException {
 		int startOffset = document.getLineOffset(line);
 		int endOffset = document.getLineOffset(endLineNumber) + document.getLineLength(endLineNumber);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -238,7 +238,7 @@ public class LSPFoldingReconcilingStrategy
 		final var newPos = new Position(startOffset, endOffset - startOffset);
 		if (!existing.isEmpty()) {
 			FoldingAnnotation existingAnnotation = existing.remove(existing.size() - 1);
-			updateAnnotations(existingAnnotation, newPos, deletions);
+			updateAnnotations(existingAnnotation, newPos, modifications, deletions);
 		} else {
 			additions.put(new FoldingAnnotation(collapsedByDefault), newPos);
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -167,7 +167,8 @@ public class LSPFoldingReconcilingStrategy
 			}
 			// send the calculated updates to the annotations to the
 			// annotation model
-			theProjectionAnnotationModel.modifyAnnotations(deletions.toArray(new Annotation[1]), additions, new Annotation[0]);
+			theProjectionAnnotationModel.modifyAnnotations(deletions.toArray(new Annotation[1]), additions,
+					modifications.toArray(new Annotation[0]));
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -139,7 +139,7 @@ public class LSPFoldingReconcilingStrategy
 	private void applyFolding(List<FoldingRange> ranges) {
 		// these are what are passed off to the annotation model to
 		// actually create and maintain the annotations
-		final var modifications = new ArrayList<Annotation>(); // not used anymore
+		final var modifications = new ArrayList<Annotation>(); // not used anymore, can be removed later with the deprecated updateAnnotations method
 		final var deletions = new ArrayList<FoldingAnnotation>();
 		final var existing = new ArrayList<FoldingAnnotation>();
 		final var additions = new HashMap<Annotation, Position>();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -269,9 +269,7 @@ public class LSPFoldingReconcilingStrategy
 				Position oldPos = theProjectionAnnotationModel.getPosition(foldingAnnotation);
 				// only update the position if we have to
 				if (!newPos.equals(oldPos)) {
-					oldPos.setOffset(newPos.offset);
-					oldPos.setLength(newPos.length);
-					modifications.add(foldingAnnotation);
+					theProjectionAnnotationModel.modifyAnnotationPosition(foldingAnnotation, newPos);
 				}
 			} else {
 				deletions.add(foldingAnnotation);


### PR DESCRIPTION
The method
ProjectionAnnotationModel.modifyAnnotations(Annotation[], Map<? extends Annotation, ? extends Position>, Annotation[]) does not consider Position changes in any cases. On large annotations the positions won't get updated properly which leads to removed folding annotations.

fixes #934