### PR TITLE
Make formatting operations available to consumers

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -53,6 +53,7 @@ Export-Package: org.eclipse.lsp4e;x-internal:=true,
  org.eclipse.lsp4e.format;x-internal:=true,
  org.eclipse.lsp4e.operations.codeactions;x-internal:=true,
  org.eclipse.lsp4e.operations.completion;x-internal:=true,
+ org.eclipse.lsp4e.operations.format;x-internal:=true,
  org.eclipse.lsp4e.operations.hover;x-internal:=true,
  org.eclipse.lsp4e.outline;x-internal:=true,
  org.eclipse.lsp4e.server;version="0.1.0"

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatFilesHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatFilesHandler.java
@@ -98,11 +98,7 @@ public class LSPFormatFilesHandler extends AbstractHandler {
 					}
 				});
 				docProvider.changed(doc);
-				try {
-					docProvider.saveDocument(monitor, file, doc, true);
-				} catch (CoreException e) {
-					LanguageServerPlugin.logError(e);
-				}
+				saveDocument(docProvider, file, monitor);
 			});
 		} catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();
@@ -116,6 +112,14 @@ public class LSPFormatFilesHandler extends AbstractHandler {
 
 	protected IDocumentProvider getDocumentProvider(IFile file) {
 		return DocumentProviderRegistry.getDefault().getDocumentProvider(new FileEditorInput(file));
+	}
+
+	protected void saveDocument(IDocumentProvider docProvider, IFile file, IProgressMonitor monitor) {
+		try {
+			docProvider.saveDocument(monitor, file, docProvider.getDocument(file), true);
+		} catch (CoreException e) {
+			LanguageServerPlugin.logError(e);
+		}
 	}
 
 	protected Set<@NonNull IFile> getSelectedFiles(final ExpressionContext ctx) {


### PR DESCRIPTION
This commit adds org.eclipse.lsp4e.operations.format to the list of exported packages to enable consumers to implement formatting for objects which do not readily adapt to an IFile. There is also a small refactor of the LSPFormatFilesHandler class with the same goal.