### PR TITLE
Bump version of a test plugin

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.15.10.qualifier
+Bundle-Version: 0.15.11.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.15.10-SNAPSHOT</version>
+	<version>0.15.11-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mock Language Server to test LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.tests.mock
-Bundle-Version: 0.16.8.qualifier
+Bundle-Version: 0.16.9.qualifier
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.lsp4j;bundle-version="[0.22.0,0.23.0)",


### PR DESCRIPTION
Unblocks #688

Fixes 
```
Failed to execute goal org.eclipse.tycho.extras:tycho-p2-extras-plugin:4.0.6:compare-version-with-baselines (compare-version-with-baseline) on project org.eclipse.lsp4e.tests.mock: Only qualifier changed for (org.eclipse.lsp4e.tests.mock/0.16.8.202403191733). Expected to have bigger x.y.z than what is available in baseline (0.16.8.202402141138) -> [Help 1]
```