### PR TITLE
Refactor Preview for WorkspaceEdit with `needsConfirmation` flag

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -934,7 +934,7 @@ public final class LSPEclipseUtils {
 		Map<URI, Range> changedURIs = new HashMap<>();
 		CompositeChange change = toCompositeChange(wsEdit, name, changedURIs);
 
-		if (wsEdit.getChangeAnnotations().values().stream().anyMatch(ca -> ca.getNeedsConfirmation())) {
+		if (wsEdit.getChangeAnnotations() != null && wsEdit.getChangeAnnotations().values().stream().anyMatch(ca -> ca.getNeedsConfirmation())) {
 			Refactoring refactoring = new Refactoring() {
 
 				@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ServerMessageHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ServerMessageHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Rogue Wave Software Inc. and others.
+ * Copyright (c) 2016, 2024 Rogue Wave Software Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -26,7 +26,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.ISharedImages;
 
 public class ServerMessageHandler {
@@ -104,8 +103,7 @@ public class ServerMessageHandler {
 		final var future = new CompletableFuture<MessageActionItem>();
 
 		Display.getDefault().asyncExec(() -> {
-			final var shell = new Shell(Display.getCurrent());
-			final var dialog = new MessageDialog(shell, wrapper.serverDefinition.label,
+			final var dialog = new MessageDialog(UI.getActiveShell(), wrapper.serverDefinition.label,
 					null, params.getMessage(), MessageDialog.INFORMATION, 0, options);
 			final var result = new MessageActionItem();
 			int dialogResult = dialog.open();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022-3 Cocotec Ltd and others.
+ * Copyright (c) 2022-2024 Cocotec Ltd and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -58,6 +58,7 @@ import org.eclipse.lsp4j.WindowClientCapabilities;
 import org.eclipse.lsp4j.WindowShowMessageRequestCapabilities;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceEditCapabilities;
+import org.eclipse.lsp4j.WorkspaceEditChangeAnnotationSupportCapabilities;
 
 /**
  *
@@ -139,6 +140,7 @@ public class SupportedFeatures {
 		editCapabilities.setResourceOperations(Arrays.asList(ResourceOperationKind.Create,
 				ResourceOperationKind.Delete, ResourceOperationKind.Rename));
 		editCapabilities.setFailureHandling(FailureHandlingKind.Undo);
+		editCapabilities.setChangeAnnotationSupport(new WorkspaceEditChangeAnnotationSupportCapabilities(true));
 		workspaceClientCapabilities.setWorkspaceEdit(editCapabilities);
 		CodeLensWorkspaceCapabilities codeLensWorkspaceCapabilities = new CodeLensWorkspaceCapabilities(true);
 		workspaceClientCapabilities.setCodeLens(codeLensWorkspaceCapabilities);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/UI.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/UI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Vegard IT GmbH and others.
+ * Copyright (c) 2021, 2024 Vegard IT GmbH and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -98,6 +98,14 @@ public final class UI {
 			return display;
 
 		return Display.getDefault();
+	}
+
+	public static void runOnUIThread(Runnable runnable) {
+		if (Display.getCurrent() == null) {
+			getDisplay().asyncExec(runnable);
+		} else {
+			runnable.run();
+		}
 	}
 
 	private UI() {


### PR DESCRIPTION
`WorkspaceEdit` has a map of change annotations where any change annotation is associated with edits from the workspace edit. If any of change annotations has `needsConfirmation` flag on then VSCode would bring up the refactor preview with annotated changes unchecked.

This PR proposes similar (but not the same, there are limitations) behaviour into Eclipse.
If there is at lease one change annotation that requires confirmation then refactor wizard is opened with the Preview page opened. All changes would be checked marked as I couldn't find how to control this piece. Another limitation is Eclipse text edits are in reverse order (they are applied in reverse order for a reason) but the preview doesn't allow to set the tree sorter on the preview tree.

@rubenporras @mickaelistria @martinlippert feedback, ideas are welcomed :-)