### PR TITLE
Use Rename and MoveRename ResourceChange classes if possible

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -131,6 +131,8 @@ import org.eclipse.ltk.core.refactoring.Refactoring;
 import org.eclipse.ltk.core.refactoring.RefactoringCore;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.resource.DeleteResourceChange;
+import org.eclipse.ltk.core.refactoring.resource.MoveRenameResourceChange;
+import org.eclipse.ltk.core.refactoring.resource.RenameResourceChange;
 import org.eclipse.ltk.ui.refactoring.RefactoringWizard;
 import org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation;
 import org.eclipse.mylyn.wikitext.markdown.MarkdownLanguage;
@@ -1130,6 +1132,20 @@ public final class LSPEclipseUtils {
 						URI newURI = URI.create(rename.getNewUri());
 						IFile oldFile = getFileHandle(oldURI);
 						IFile newFile = getFileHandle(newURI);
+
+						// If both files are within Eclipse workspace utilize Eclipse ltk MoveRenameResourceChange and RenameResourceChange
+						if (oldFile != null && oldFile.exists() && oldFile.getParent() != null
+								&& newFile != null && newFile.getParent() != null) {
+							if (!newFile.exists() || rename.getOptions().getOverwrite()) {
+								if (oldFile.getParent().equals(newFile.getParent())) {
+									change.add(new RenameResourceChange(oldFile.getFullPath(), newFile.getName()));
+								} else {
+									change.add(new MoveRenameResourceChange(oldFile, newFile.getParent(), newFile.getName()));
+								}
+								return;
+							}
+						}
+
 						DeleteResourceChange removeNewFile = null;
 						if (newFile != null && newFile.exists()) {
 							if (rename.getOptions().getOverwrite()) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -1135,14 +1135,15 @@ public final class LSPEclipseUtils {
 
 						// If both files are within Eclipse workspace utilize Eclipse ltk MoveRenameResourceChange and RenameResourceChange
 						if (oldFile != null && oldFile.exists() && oldFile.getParent() != null
-								&& newFile != null && newFile.getParent() != null) {
+								&& newFile != null && newFile.getParent() != null && newFile.getParent().exists()) {
 							if (!newFile.exists() || rename.getOptions().getOverwrite()) {
 								if (oldFile.getParent().equals(newFile.getParent())) {
 									change.add(new RenameResourceChange(oldFile.getFullPath(), newFile.getName()));
+									return;
 								} else {
 									change.add(new MoveRenameResourceChange(oldFile, newFile.getParent(), newFile.getName()));
+									return;
 								}
-								return;
 							}
 						}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -1139,11 +1139,10 @@ public final class LSPEclipseUtils {
 							if (!newFile.exists() || rename.getOptions().getOverwrite()) {
 								if (oldFile.getParent().equals(newFile.getParent())) {
 									change.add(new RenameResourceChange(oldFile.getFullPath(), newFile.getName()));
-									return;
 								} else {
 									change.add(new MoveRenameResourceChange(oldFile, newFile.getParent(), newFile.getName()));
-									return;
 								}
+								return;
 							}
 						}
 


### PR DESCRIPTION
If the change is rename and then modify the content of a file. This translates into
1. Delete the file
2. Create the new named file 
3. Set its new content 

This doesn't let to see the diffs in the refactor preview between the old file name file and the new name file side by side. If the Rename or MoveRename ResourceChange is used then refactor preview has more useful content.

This PR suggests to use Rename and MoveRename if this possible, i.e. both resources are in the workspace.