### PR TITLE
Fix #969 Add collecting of declarations in addition to definitions

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -100,6 +100,7 @@ import org.eclipse.lsp4j.CompletionContext;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.CompletionTriggerKind;
 import org.eclipse.lsp4j.CreateFile;
+import org.eclipse.lsp4j.DeclarationParams;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DeleteFile;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -313,6 +314,10 @@ public final class LSPEclipseUtils {
 
 	public static DefinitionParams toDefinitionParams(TextDocumentPositionParams params) {
 		return toTextDocumentPositionParamsCommon(new DefinitionParams(), params);
+	}
+
+	public static DeclarationParams toDeclarationParams(TextDocumentPositionParams params) {
+		return toTextDocumentPositionParamsCommon(new DeclarationParams(), params);
 	}
 
 	public static TypeDefinitionParams toTypeDefinitionParams(TextDocumentPositionParams params) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -59,12 +59,14 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 		final var allLinks = new LinkedHashMap<Either<Location, LocationLink>,LSBasedHyperlink>();
 		try {
 			var definitions = LanguageServers.forDocument(document).withCapability(ServerCapabilities::getDefinitionProvider)
-				.collectAll(ls -> ls.getTextDocumentService().definition(LSPEclipseUtils.toDefinitionParams(params)).thenApply(l -> Pair.of(Messages.declarationHyperlinkLabel, l)));
+				.collectAll(ls -> ls.getTextDocumentService().definition(LSPEclipseUtils.toDefinitionParams(params)).thenApply(l -> Pair.of(Messages.definitionHyperlinkLabel, l)));
+			var declarations = LanguageServers.forDocument(document).withCapability(ServerCapabilities::getDeclarationProvider)
+				.collectAll(ls -> ls.getTextDocumentService().declaration(LSPEclipseUtils.toDeclarationParams(params)).thenApply(l -> Pair.of(Messages.declarationHyperlinkLabel, l)));
 			var typeDefinitions = LanguageServers.forDocument(document).withCapability(ServerCapabilities::getTypeDefinitionProvider)
 				.collectAll(ls -> ls.getTextDocumentService().typeDefinition(LSPEclipseUtils.toTypeDefinitionParams(params)).thenApply(l -> Pair.of(Messages.typeDefinitionHyperlinkLabel, l)));
 			var implementations = LanguageServers.forDocument(document).withCapability(ServerCapabilities::getImplementationProvider)
 				.collectAll(ls -> ls.getTextDocumentService().implementation(LSPEclipseUtils.toImplementationParams(params)).thenApply(l -> Pair.of(Messages.implementationHyperlinkLabel, l)));
-			LanguageServers.addAll(LanguageServers.addAll(definitions, typeDefinitions), implementations)
+			LanguageServers.addAll(LanguageServers.addAll(LanguageServers.addAll(definitions, declarations), typeDefinitions), implementations)
 				.get(800, TimeUnit.MILLISECONDS)
 				.stream().flatMap(locations -> toHyperlinks(document, region, locations.getFirst(), locations.getSecond()).stream())
 				.forEach(link -> allLinks.putIfAbsent(link.getLocation(), link));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
@@ -17,6 +17,7 @@ import org.eclipse.osgi.util.NLS;
 
 public final class Messages extends NLS {
 
+	public static String definitionHyperlinkLabel;
 	public static String declarationHyperlinkLabel;
 	public static String typeDefinitionHyperlinkLabel;
 	public static String implementationHyperlinkLabel;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
@@ -11,6 +11,7 @@
 #  Jan Koehnlein (TypeFox) add rename empty message
 # *******************************************************************************/
 declarationHyperlinkLabel=Open Declaration
+definitionHyperlinkLabel=Open Definition
 typeDefinitionHyperlinkLabel=Open Type Definition
 implementationHyperlinkLabel=Open Implementation
 


### PR DESCRIPTION
Instead of collecting only definitions (and type definitions and implementations), I modified the code to also collect declarations for the command "open declaration" in LSP4E. For example, in C++, that makes a difference, since methods can be defined, e.g. in .cpp files and declared in .hpp files.