### PR TITLE
Add spacing to inline type hints. Fixes #981

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.8.qualifier
+Bundle-Version: 0.18.9.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.8-SNAPSHOT</version>
+	<version>0.18.9-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/LSPLineContentCodeMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/LSPLineContentCodeMining.java
@@ -63,6 +63,14 @@ public class LSPLineContentCodeMining extends LineContentCodeMining {
 		setLabel(getInlayHintString(inlayHint));
 	}
 
+	@Override
+	public void setLabel(final String label) {
+		if (label == null || label.isEmpty() || Character.isWhitespace(label.charAt(label.length() - 1)))
+			super.setLabel(label);
+		else
+			super.setLabel(label + " "); //$NON-NLS-1$
+	}
+
 	protected static @Nullable String getInlayHintString(@NonNull InlayHint inlayHint) {
 		Either<String, List<InlayHintLabelPart>> label = inlayHint.getLabel();
 		return label.map(Function.identity(), (parts) -> {
@@ -186,6 +194,5 @@ public class LSPLineContentCodeMining extends LineContentCodeMining {
 		this.fontData = gc.getFont().getFontData();
 		return size;
 	}
-
 
 }


### PR DESCRIPTION
Adds a space separator between the inline type hint and the variable name.

Before this PR:
![image](https://github.com/eclipse/lsp4e/assets/426959/70cb849d-63fe-4bae-8a9e-fb0e0fc7d9d6)

After this PR:
![image](https://github.com/eclipse/lsp4e/assets/426959/2fab08f0-2373-4c6b-bee2-a18b80a63878)

This is similar to what JDT does:
https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/6333016444d089418d28a0e5e331ae3545030d82/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaMethodParameterCodeMining.java#L31