### PR TITLE
Fix erratic test failure in DiagnosticsTest#testDiagnosticsFromVariousLS

### DIFF
--- a/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mock Language Server to test LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.tests.mock
-Bundle-Version: 0.16.8.qualifier
+Bundle-Version: 0.16.9.qualifier
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.lsp4j;bundle-version="[0.22.0,0.23.0)",

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -92,7 +92,7 @@ public final class MockLanguageServer implements LanguageServer {
 	private volatile long delay = 0;
 	private volatile boolean started;
 
-	private final List<LanguageClient> remoteProxies = new ArrayList<>();
+	private final List<LanguageClient> remoteProxies = new CopyOnWriteArrayList<>();
 
 	private final List<CompletableFuture<?>> inFlight = new CopyOnWriteArrayList<>();
 

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
 import org.eclipse.lsp4j.CodeAction;
@@ -107,7 +108,7 @@ public class MockTextDocumentService implements TextDocumentService {
 	private ConcurrentLinkedQueue<DidChangeTextDocumentParams> didChangeEvents = new ConcurrentLinkedQueue<>();
 
 	private Function<?, ? extends CompletableFuture<?>> _futureFactory;
-	private List<LanguageClient> remoteProxies;
+	private final List<LanguageClient> remoteProxies = new CopyOnWriteArrayList<>();
 	private Location[] mockReferences = new Location[0];
 	private List<Diagnostic> diagnostics;
 	private List<Either<Command, CodeAction>> mockCodeActions;
@@ -128,7 +129,6 @@ public class MockTextDocumentService implements TextDocumentService {
 		mockHover = new Hover(Collections.singletonList(Either.forLeft("Mock hover")), null);
 		mockPrepareRenameResult = Either3
 				.forSecond(new PrepareRenameResult(new Range(new Position(0, 0), new Position(0, 0)), "placeholder"));
-		this.remoteProxies = new ArrayList<>();
 		this.documentSymbols = Collections.emptyList();
 		this.codeActionRequests = 0;
 	}
@@ -374,7 +374,7 @@ public class MockTextDocumentService implements TextDocumentService {
 		this.mockHover = null;
 		this.mockCodeLenses = null;
 		this.mockReferences = null;
-		this.remoteProxies = new ArrayList<>();
+		this.remoteProxies.clear();
 		this.mockCodeActions = new ArrayList<>();
 		this.mockRenameEdit = null;
 		this.documentSymbols = Collections.emptyList();


### PR DESCRIPTION
Root cause is that `MockLanguageServer#addRemoteProxy` is invoked concurrently which adds the remote proxy to an `ArrayList` which is not thread-safe