### PR TITLE
Fix erratic test failure in DiagnosticsTest

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.15.12.qualifier
+Bundle-Version: 0.15.13.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.15.12-SNAPSHOT</version>
+	<version>0.15.13-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
@@ -191,8 +191,8 @@ public class DiagnosticsTest {
 		Job[] allMarkerJobs = Job.getJobManager().find(LanguageServerPlugin.FAMILY_UPDATE_MARKERS);
 		assertThat(allMarkerJobs.length, is(1));
 		Job markerJob = allMarkerJobs[0];
-		file.delete(true, null);
-		waitForAndAssertCondition(1_000, () -> {
+		waitForAndAssertCondition(2_000, () -> {
+			file.delete(true, null);
 			assertEquals(file.exists(), false);
 			return true;
 		});


### PR DESCRIPTION
This PR fixes the erratic test failure `FileSystemException: The process cannot access the file because it is being used by another process` seen on Windows in `DiagnosticsTest#testDiagnosticsForMarkerUpdateAfterDeletedFile`:
```py
org.eclipse.core.internal.resources.ResourceException: Problems encountered while deleting resources.
	at org.eclipse.core.internal.resources.Resource.delete(Resource.java:816)
	at org.eclipse.core.internal.resources.Resource.delete(Resource.java:772)
	at org.eclipse.lsp4e.test.diagnostics.DiagnosticsTest.testDiagnosticsForMarkerUpdateAfterDeletedFile(DiagnosticsTest.java:192)
Contains: Could not delete 'D:\junit-workspace\DiagnoticsTest1714763955417\test1714763955426.lspt'.
org.eclipse.core.runtime.CoreException: Could not delete: D:\junit-workspace\DiagnoticsTest1714763955417\test1714763955426.lspt.
	at org.eclipse.core.internal.filesystem.local.LocalFile.delete(LocalFile.java:161)
	at org.eclipse.core.internal.resources.ResourceTree.internalDeleteFile(ResourceTree.java:315)
	at org.eclipse.core.internal.resources.ResourceTree.standardDeleteFile(ResourceTree.java:801)
	at org.eclipse.core.internal.resources.Resource.unprotectedDelete(Resource.java:1826)
	at org.eclipse.core.internal.resources.Resource.delete(Resource.java:803)
	at org.eclipse.core.internal.resources.Resource.delete(Resource.java:772)
	at org.eclipse.lsp4e.test.diagnostics.DiagnosticsTest.testDiagnosticsForMarkerUpdateAfterDeletedFile(DiagnosticsTest.java:192)
Caused by: java.nio.file.FileSystemException: D:\junit-workspace\DiagnoticsTest1714763955417\test1714763955426.lspt: The process cannot access the file because it is being used by another process
	at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:92)
	at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
	at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:108)
	at java.base/sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:275)
	at java.base/sun.nio.fs.AbstractFileSystemProvider.deleteIfExists(AbstractFileSystemProvider.java:110)
	at java.base/java.nio.file.Files.deleteIfExists(Files.java:1191)
	at org.eclipse.core.internal.filesystem.local.LocalFile.internalDelete(LocalFile.java:242)
	at org.eclipse.core.internal.filesystem.local.LocalFile.delete(LocalFile.java:159)
	... 64 more
```