### PR TITLE
Fix race condition in LanguageServerWrapper resulting in NullPointerException during LS initialization

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -19,6 +19,7 @@ package org.eclipse.lsp4e;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -297,7 +298,7 @@ public class LanguageServerWrapper {
 				try {
 					lspStreamProvider.start();
 				} catch (IOException e) {
-					throw new RuntimeException(e);
+					throw new UncheckedIOException(e);
 				}
 				return null;
 			}).thenRun(() -> {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -286,7 +286,7 @@ public class LanguageServerWrapper {
 			final Job job = createInitializeLanguageServerJob();
 			this.launcherFuture = new CompletableFuture<>();
 			this.initializeFuture = CompletableFuture.supplyAsync(() -> {
-				advanceinitializeFutureMonitor();
+				advanceInitializeFutureMonitor();
 				if (LoggingStreamConnectionProviderProxy.shouldLog(serverDefinition.id)) {
 					this.lspStreamProvider = new LoggingStreamConnectionProviderProxy(
 							serverDefinition.createConnectionProvider(), serverDefinition.id);
@@ -301,7 +301,7 @@ public class LanguageServerWrapper {
 				}
 				return null;
 			}).thenRun(() -> {
-				advanceinitializeFutureMonitor();
+				advanceInitializeFutureMonitor();
 				languageClient = serverDefinition.createLanguageClient();
 
 				initParams.setProcessId((int) ProcessHandle.current().pid());
@@ -333,18 +333,18 @@ public class LanguageServerWrapper {
 				this.launcherFuture = launcher.startListening();
 			})
 			.thenCompose(unused -> {
-				advanceinitializeFutureMonitor();
+				advanceInitializeFutureMonitor();
 				return initServer(rootURI);
 			})
 			.thenAccept(res -> {
-				advanceinitializeFutureMonitor();
+				advanceInitializeFutureMonitor();
 				serverCapabilities = res.getCapabilities();
 				this.initiallySupportsWorkspaceFolders = supportsWorkspaceFolders(serverCapabilities);
 			}).thenRun(() -> {
-				advanceinitializeFutureMonitor();
+				advanceInitializeFutureMonitor();
 				this.languageServer.initialized(new InitializedParams());
 			}).thenRun(() -> {
-				advanceinitializeFutureMonitor();
+				advanceInitializeFutureMonitor();
 				final Map<URI, IDocument> toReconnect = filesToReconnect;
 				initializeFuture.thenRunAsync(() -> {
 					watchProjects();
@@ -357,7 +357,7 @@ public class LanguageServerWrapper {
 					}
 				});
 				FileBuffers.getTextFileBufferManager().addFileBufferListener(fileBufferListener);
-				advanceinitializeFutureMonitor();
+				advanceInitializeFutureMonitor();
 			}).exceptionally(e -> {
 				stop();
 				final Throwable cause = e.getCause();
@@ -378,7 +378,7 @@ public class LanguageServerWrapper {
 		}
 	}
 
-	private void advanceinitializeFutureMonitor() {
+	private void advanceInitializeFutureMonitor() {
 		final var initializeFutureMonitor = initializeFutureMonitorRef.get();
 		if (initializeFutureMonitor != null) {
 			if (initializeFutureMonitor.isCanceled()) {


### PR DESCRIPTION
When running the test suite on Windows and in Docker with Ubuntu, **a lot** of NPEs with the following stacktrace are thrown:
```py
java.lang.NullPointerException: Cannot invoke
"org.eclipse.core.runtime.IProgressMonitor.done()" because
"this.this$0.initializeFutureMonitor" is null
	at org.eclipse.lsp4e.LanguageServerWrapper$2.run(LanguageServerWrapper.java:407)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```
and because of the NPE random tests seem to fail.