### PR TITLE
Fix erratic NPE in LanguageServersTest#testCancellable

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
@@ -63,7 +63,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.Assume;
 import org.junit.Before;
@@ -101,8 +100,7 @@ public class LanguageServersTest {
 		});
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -138,8 +136,7 @@ public class LanguageServersTest {
 		});
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -183,8 +180,7 @@ public class LanguageServersTest {
 		});
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -225,8 +221,7 @@ public class LanguageServersTest {
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -293,8 +288,7 @@ public class LanguageServersTest {
 		});
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -344,8 +338,7 @@ public class LanguageServersTest {
 		});
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -380,8 +373,7 @@ public class LanguageServersTest {
 		});
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -425,8 +417,7 @@ public class LanguageServersTest {
 		});
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -483,8 +474,7 @@ public class LanguageServersTest {
 		CompletableFuture<?> initial = CompletableFuture.completedFuture(null);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		StyledText text = viewer.getTextWidget();
@@ -561,8 +551,7 @@ public class LanguageServersTest {
 		CompletableFuture<?> initial = CompletableFuture.completedFuture(null);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 		StyledText text = viewer.getTextWidget();
 		Thread.sleep(1000);
@@ -622,8 +611,7 @@ public class LanguageServersTest {
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(sc -> false);
@@ -666,8 +654,7 @@ public class LanguageServersTest {
 		});
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -694,8 +681,7 @@ public class LanguageServersTest {
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final HoverParams params = new HoverParams();
@@ -772,8 +758,7 @@ public class LanguageServersTest {
 	@Test
 	public void testGetDocument() throws Exception {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
 		final LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document);
@@ -784,8 +769,7 @@ public class LanguageServersTest {
 	@Test
 	public void testCancellable() throws Exception {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "Here is some content");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		Display display = viewer.getTextWidget().getDisplay();
 		DisplayHelper.sleep(display, 2000);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/VersioningSupportTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/VersioningSupportTest.java
@@ -99,8 +99,7 @@ public class VersioningSupportTest {
 		MockLanguageServer.INSTANCE.setFormattingTextEdits(formattingTextEdits);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Formatting Other Text");
-		IEditorPart editor = TestUtils.openEditor(file);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(file);
 
 		final var doc = viewer.getDocument();
 		final var docId = LSPEclipseUtils.toTextDocumentIdentifier(doc);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
@@ -59,8 +59,7 @@ public class DocumentDidChangeTest {
 				.setTextDocumentSync(TextDocumentSyncKind.Incremental);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		LanguageServers.forDocument(viewer.getDocument()).withFilter(new Predicate<ServerCapabilities>() {
 			@Override
 			public boolean test(ServerCapabilities t) {
@@ -126,8 +125,7 @@ public class DocumentDidChangeTest {
 
 		String multiLineText = "line1\nline2\nline3\n";
 		IFile testFile = TestUtils.createUniqueTestFile(project, multiLineText);
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		LanguageServers.forDocument(viewer.getDocument()).withFilter(new Predicate<ServerCapabilities>() {
 			@Override
 			public boolean test(ServerCapabilities t) {
@@ -157,8 +155,7 @@ public class DocumentDidChangeTest {
 	public void testIncrementalEditOrdering() throws Exception {
 		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Incremental);
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		StyledText text = viewer.getTextWidget();
 		for (int i = 0; i < 500; i++) {
 			text.append(i + "\n");
@@ -177,8 +174,7 @@ public class DocumentDidChangeTest {
 				.setTextDocumentSync(TextDocumentSyncKind.Full);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
-		IEditorPart editor = TestUtils.openEditor(testFile);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		LanguageServers.forDocument(viewer.getDocument()).withFilter(new Predicate<ServerCapabilities>() {
 			@Override
 			public boolean test(ServerCapabilities t) {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -268,11 +268,9 @@ public class LSPEclipseUtilsTest {
 	@Test
 	public void testApplyTextEditLongerThanOrigin() throws Exception {
 		IProject project = null;
-		IEditorPart editor = null;
 		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
-		editor = TestUtils.openEditor(file);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(file);
 		TextEdit textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "InsertHere".length())), "Inserted");
 		IDocument document = viewer.getDocument();
 		LSPEclipseUtils.applyEdit(textEdit, document);
@@ -282,11 +280,9 @@ public class LSPEclipseUtilsTest {
 	@Test
 	public void testApplyTextEditShorterThanOrigin() throws Exception {
 		IProject project = null;
-		IEditorPart editor = null;
 		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineHERE");
-		editor = TestUtils.openEditor(file);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(file);
 		TextEdit textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "HERE".length())), "Inserted");
 		IDocument document = viewer.getDocument();
 		LSPEclipseUtils.applyEdit(textEdit, document);
@@ -296,11 +292,9 @@ public class LSPEclipseUtilsTest {
 	@Test
 	public void testTextEditInsertSameOffset() throws Exception {
 		IProject project = null;
-		IEditorPart editor = null;
 		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "");
-		editor = TestUtils.openEditor(file);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(file);
 		TextEdit[] edits = new TextEdit[] {
 				new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), " throws "),
 				new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), "Exception") };
@@ -308,15 +302,13 @@ public class LSPEclipseUtilsTest {
 		LSPEclipseUtils.applyEdits(document, Arrays.asList(edits));
 		Assert.assertEquals(" throws Exception", document.get());
 	}
-	
+
 	@Test
 	public void testTextEditSplittedLineEndings() throws Exception {
 		IProject project = null;
-		IEditorPart editor = null;
 		project = TestUtils.createProject(getClass().getSimpleName() + System.currentTimeMillis());
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\r\nline2\r\nline3\r\n");
-		editor = TestUtils.openEditor(file);
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
+		ITextViewer viewer = TestUtils.openTextViewer(file);
 		// GIVEN a TextEdit which splits the '\r\n' line ending in the third line:
 		TextEdit[] edits = new TextEdit[] { new TextEdit(new Range(new Position(0, 0), new Position(2, 6)), "line3\r\nline2\r\nline1\r") };
 		IDocument document = viewer.getDocument();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
@@ -73,6 +73,7 @@ public class TestUtils {
 
 	public static ITextViewer openTextViewer(IFile file) throws PartInitException {
 		IEditorPart editor = openEditor(file);
+		waitForAndAssertCondition(5_000, () -> LSPEclipseUtils.getTextViewer(editor) != null);
 		return LSPEclipseUtils.getTextViewer(editor);
 	}
 
@@ -85,20 +86,20 @@ public class TestUtils {
 		part.setFocus();
 		return part;
 	}
-	
+
 	public static List<IEditorReference> splitActiveEditor() {
 		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
 		IWorkbenchPage page = workbenchWindow.getActivePage();
 		IEditorPart part = page.getActiveEditor();
-		
+
 		MPart editorPart = part.getSite().getService(MPart.class);
 		if (editorPart != null) {
 			editorPart.getTags().add(IPresentationEngine.SPLIT_HORIZONTAL);
 		}
-		
+
 		return Arrays.asList(page.getEditorReferences());
 	}
-	
+
 	public static IEditorPart openExternalFileInEditor(File file) throws PartInitException {
 		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
 		IWorkbenchPage page = workbenchWindow.getActivePage();


### PR DESCRIPTION
This commit fixes the NPE:

```
org.eclipse.lsp4e.test.LanguageServersTest.testCancellable -- Time
elapsed: 0.112 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke
"org.eclipse.jface.text.ITextViewer.getTextWidget()" because "viewer" is
null
	at org.eclipse.lsp4e.test.LanguageServersTest.testCancellable(LanguageServersTest.java:789)
```

which may occur for the code:
```java
IEditorPart editor = TestUtils.openEditor(testFile);
ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
IDocument document = viewer.getDocument();
```
where viewer may be null if it has not been initialized fast enough in the UI thread.

As a remedy, a `waitForAndAssertCondition` is added to the function `openTextViewer`:
```java
public static ITextViewer openTextViewer(IFile file) throws PartInitException {
	IEditorPart editor = openEditor(file);
	waitForAndAssertCondition(5_000, () -> LSPEclipseUtils.getTextViewer(editor) != null);
	return LSPEclipseUtils.getTextViewer(editor);
}
```
and all occurrences of 
```java
IEditorPart editor = TestUtils.openEditor(testFile);
ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
```
are replaced with
```java
ITextViewer viewer = TestUtils.openTextViewer(testFile);
```