### PR TITLE
Avoid assertion failure

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.10.qualifier
+Bundle-Version: 0.18.11.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.10-SNAPSHOT</version>
+	<version>0.18.11-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/LSPTextChange.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/LSPTextChange.java
@@ -113,7 +113,9 @@ public class LSPTextChange extends TextChange {
 			try {
 				offset = LSPEclipseUtils.toOffset(range.getStart(), document);
 				length = LSPEclipseUtils.toOffset(range.getEnd(), document) - offset;
-				this.setEdit(new ReplaceEdit(offset, length, newText));
+				if (getEdit() == null) {
+					this.setEdit(new ReplaceEdit(offset, length, newText));
+				}
 			} catch (BadLocationException e) {
 				// Should not happen
 				LanguageServerPlugin.logError(e);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/LSPTextChange.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/LSPTextChange.java
@@ -109,13 +109,11 @@ public class LSPTextChange extends TextChange {
 		final IDocument document  = fBuffer.getDocument();
 		int offset = 0;
 		int length = document.getLength();
-		if (range != null) {
+		if (range != null && getEdit() == null) {
 			try {
 				offset = LSPEclipseUtils.toOffset(range.getStart(), document);
 				length = LSPEclipseUtils.toOffset(range.getEnd(), document) - offset;
-				if (getEdit() == null) {
-					this.setEdit(new ReplaceEdit(offset, length, newText));
-				}
+				this.setEdit(new ReplaceEdit(offset, length, newText));
 			} catch (BadLocationException e) {
 				// Should not happen
 				LanguageServerPlugin.logError(e);


### PR DESCRIPTION
Looks like checking for `null` edit is a proper thing to do as `TextChange` from LTK has an assert `null` for the previous edit. Assertion exception appears in e4.32 but looks like the PR above fixes it.