### PR TITLE
Do not return a Consumer<MouseEvent> if the code mining has no action.

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/InlayHintProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/InlayHintProvider.java
@@ -63,8 +63,8 @@ public class InlayHintProvider extends AbstractCodeMiningProvider {
 		}
 	}
 
-	private LSPLineContentCodeMining toCodeMining(IDocument document, LanguageServerWrapper languageServerWrapper,
-			InlayHint inlayHint) {
+	private LSPLineContentCodeMining toCodeMining(@NonNull IDocument document, @NonNull LanguageServerWrapper languageServerWrapper,
+			@NonNull InlayHint inlayHint) {
 		try {
 			return new LSPLineContentCodeMining(inlayHint, document, languageServerWrapper, InlayHintProvider.this);
 		} catch (BadLocationException e) {


### PR DESCRIPTION
According to ICodeMining.getAction(), null should be returned if there is no action to be executed when the mining is clicked.

When several InlayHintLabelParts are used, we cannot be sure if there is an action or not without knowing the actual MouseEvent. However, if no InlayHint has an action, we can be sure there is none even without knowing the MouseEvent. For these cases, the code returns null now.