### PR TITLE
DSPThread: cannot be suspended if program is terminated

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
-Bundle-Version: 0.15.8.qualifier
+Bundle-Version: 0.15.9.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPThread.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPThread.java
@@ -195,7 +195,7 @@ public class DSPThread extends DSPDebugElement implements IThread {
 
 	@Override
 	public boolean isSuspended() {
-		return isSuspended;
+		return !isTerminated() && isSuspended;
 	}
 
 	@Override


### PR DESCRIPTION
We have started to experiment with replacing our custom debuggers in the [Eclipse Epsilon](https://eclipse.dev/epsilon/) project with LSP4E-based debuggers, and we've noticed one odd issue when we stop at a breakpoint and then resume and let the program stop. This pull request proposes a workaround for the issue for the time being - the deeper issue seems to be how to handle the case where a `continue` request resumes all threads.

# Scenario

In one of our test programs, we have a main thread T1 start, then another thread T2 starts and stops at a breakpoint. In the Epsilon debug adapter, we stop all threads when we hit a breakpoint, so our `stopped` event provides both the specific thread that hit the breakpoint, and also calls `setAllThreadsStopped(true)`. Our program stops as expected, like this:

![image](https://github.com/eclipse/lsp4e/assets/46504/b49e6f78-a7b9-4deb-b84d-2ab8d0c5586f)

I press F8 to continue (which continues all threads: we indicate this in our response to the `continue` request by calling `setAllThreadsContinued(true)`), and hit the next breakpoint as usual:

![image](https://github.com/eclipse/lsp4e/assets/46504/af29f47b-edbd-4604-af9e-cb837d768115)

I press F8 once more, and the program finishes successfully, but I'm left with this odd state:

![image](https://github.com/eclipse/lsp4e/assets/46504/a7a29014-32ae-4eb7-ac6a-70a54d48c8dc)

From what I gathered by debugging, it looks like resuming the thread did not clear the `isSuspended` flag from the other thread, despite the response from the debug adapter that all threads had been continued. I saw that we got to this part of DSPThread just fine, and the resume event was fired:

```java
getDebugProtocolServer().continue_(arguments).thenAccept(response -> {
	if (response == null || response.getAllThreadsContinued() == null || response.getAllThreadsContinued()) {
		// turns out everything was resumed, so need to update other threads too
		getDebugTarget().fireResumeEvent(DebugEvent.CLIENT_REQUEST);
	}
}).exceptionally(this::handleExceptionalResume);
```

However, I did not notice the `continued()` method being called for the other thread, despite this response. We send out `thread` start and exit events, so if those events are processed in time before the `terminated` event then the threads are removed by the time the program exits, but it's not always the case.

# Workaround

I propose changing the `isSuspended()` method in `DSPThread` so it won't return `true` if the program is terminated. This fixes the issues around showing terminated threads in a program as paused or as available to be resumed. This small change results in the desired output:

![image](https://github.com/eclipse/lsp4e/assets/46504/04604ef0-c393-4fe3-a846-f7e9de7cb53c)
