### PR TITLE
lsp4e: Patch so we have access to the rename operations

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -56,6 +56,7 @@ Export-Package: org.eclipse.lsp4e;x-internal:=true,
  org.eclipse.lsp4e.operations.completion;x-internal:=true,
  org.eclipse.lsp4e.operations.format;x-internal:=true,
  org.eclipse.lsp4e.operations.hover;x-internal:=true,
+ org.eclipse.lsp4e.operations.rename;x-internal:=true,
  org.eclipse.lsp4e.outline;x-internal:=true,
  org.eclipse.lsp4e.server;version="0.1.0"
 Bundle-Vendor: Eclipse.org


### PR DESCRIPTION
I'm in the process of getting us off a custom (shaded) version of lsp4e. We use some of the rename classes for a custom rename command initiated via a code lens, but this won't compile with production lsp4e as the package isn't exposed. Any objection to exposing it in the same way as some of the other operations (exposed but marked as private so you get a warning)?