### PR TITLE
DSPProcess::getExitValue should only raise an exception if the process is still alive

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
-Bundle-Version: 0.15.9.qualifier
+Bundle-Version: 0.15.10.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPProcess.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/console/DSPProcess.java
@@ -107,7 +107,7 @@ public class DSPProcess implements IProcess {
 
 	@Override
 	public int getExitValue() throws DebugException {
-		if (handle.isPresent() && !handle.get().isAlive()) {
+		if (handle.isPresent() && handle.get().isAlive()) {
 			throw new DebugException(Status.error(handle.get().pid() + " is still running"));
 		}
 		return 0;


### PR DESCRIPTION
Fix small logic error when checking if thread is still alive