### PR TITLE
Expand root outline view in outline view by default

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -338,16 +338,22 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 					return;
 				}
 
+				final int EXPAND_ROOT_LEVEL = 2;  // Expansion level that displays root node and its children
 				if (isQuickOutline) {
 					viewer.refresh();
+					viewer.expandToLevel(EXPAND_ROOT_LEVEL);
 				} else {
 					TreePath[] expandedElements = viewer.getExpandedTreePaths();
 					TreePath[] initialSelection = ((ITreeSelection) viewer.getSelection()).getPaths();
 					viewer.refresh();
-					viewer.setExpandedTreePaths(Arrays.stream(expandedElements).map(symbolsModel::toUpdatedSymbol)
+					if (expandedElements.length > 0) {
+						viewer.setExpandedTreePaths(Arrays.stream(expandedElements).map(symbolsModel::toUpdatedSymbol)
 							.filter(Objects::nonNull).toArray(TreePath[]::new));
-					viewer.setSelection(new TreeSelection(Arrays.stream(initialSelection)
-							.map(symbolsModel::toUpdatedSymbol).filter(Objects::nonNull).toArray(TreePath[]::new)));
+						viewer.setSelection(new TreeSelection(Arrays.stream(initialSelection)
+								.map(symbolsModel::toUpdatedSymbol).filter(Objects::nonNull).toArray(TreePath[]::new)));
+					} else {
+						viewer.expandToLevel(EXPAND_ROOT_LEVEL);
+					}
 				}
 
 				if (linkWithEditor) {


### PR DESCRIPTION
Before this commit, the outline view is drawn with all elements collapsed by default. This often results in plenty of wasted space in the UI and low information density.

Instead, as discussed in #693, it would be preferable to draw the outline view with its first level expanded by default (i.e., displaying the root node and its immediate children by default).

Issue: #693