### PR TITLE
Add content filtering to outline view based on SymbolKind (fix issue #254)

### DIFF
--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -283,6 +283,27 @@
          </command>
       </menuContribution>
       <menuContribution
+            allPopups="false"
+            locationURI="menu:org.eclipse.ui.views.ContentOutline">
+         <menu
+               id="org.eclipse.lsp4e.outline.hideMenu"
+               label="Hide...">
+            <visibleWhen>
+               <reference
+                     definitionId="org.eclipse.lsp4e.activePartHasCNFOutlinePage">
+               </reference>
+            </visibleWhen>
+         </menu>
+      </menuContribution>
+      <menuContribution
+            allPopups="false"
+            locationURI="menu:org.eclipse.lsp4e.outline.hideMenu">
+         <dynamic
+               class="org.eclipse.lsp4e.outline.OutlineViewFilterMenuContributor"
+               id="org.eclipse.lsp4e.filters.dynamic">
+         </dynamic>
+      </menuContribution>
+      <menuContribution
             allPopups="true"
             locationURI="popup:org.eclipse.ui.genericeditor.source.menu?after=additions">
          <!-- "Source/Format" menu entry in editor popup menu -->

--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -299,7 +299,7 @@
             allPopups="false"
             locationURI="menu:org.eclipse.lsp4e.outline.hideMenu">
          <dynamic
-               class="org.eclipse.lsp4e.outline.OutlineViewFilterMenuContributor"
+               class="org.eclipse.lsp4e.outline.OutlineViewHideSymbolKindMenuContributor"
                id="org.eclipse.lsp4e.filters.dynamic">
          </dynamic>
       </menuContribution>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
@@ -63,6 +63,7 @@ public class CNFOutlinePage implements IContentOutlinePage, ILabelProviderListen
 	public static final String LINK_WITH_EDITOR_PREFERENCE = ID + ".linkWithEditor"; //$NON-NLS-1$
 	public static final String SHOW_KIND_PREFERENCE = ID + ".showKind"; //$NON-NLS-1$
 	public static final String SORT_OUTLINE_PREFERENCE = ID + ".sortOutline"; //$NON-NLS-1$
+	public static final String HIDE_DOCUMENT_SYMBOL_KIND_PREFERENCE_PREFIX = ID + ".hide"; //$NON-NLS-1$
 
 	private CommonViewer outlineViewer = lateNonNull();
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.outline;
 
-import static org.eclipse.lsp4e.internal.NullSafetyHelper.*;
+import static org.eclipse.lsp4e.internal.NullSafetyHelper.lateNonNull;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -267,7 +267,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 
 	public LSSymbolsContentProvider(boolean refreshOnResourceChanged) {
 		this.refreshOnResourceChanged = refreshOnResourceChanged;
-		this.preferencesDependantOutlineUpdater = new PreferencesChangedOutlineUpdater();
+		preferencesDependantOutlineUpdater = new PreferencesChangedOutlineUpdater();
 	}
 
 	@Override
@@ -318,10 +318,10 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 
 	@Override
 	public Object[] getElements(@Nullable Object inputElement) {
-		if (this.symbols != null && !this.symbols.isDone()) {
+		if (symbols != null && !symbols.isDone()) {
 			return new Object[] { new PendingUpdateAdapter() };
 		}
-		if (this.lastError != null && symbolsModel.getElements().length == 0) {
+		if (lastError != null && symbolsModel.getElements().length == 0) {
 			return new Object[] { "An error occured, see log for details" }; //$NON-NLS-1$
 		}
 		return Arrays.stream(symbolsModel.getElements())

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.outline;
 
-import static org.eclipse.lsp4e.internal.NullSafetyHelper.lateNonNull;
+import static org.eclipse.lsp4e.internal.NullSafetyHelper.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -167,11 +167,9 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			if (viewer != null
 					&& event.getKey().startsWith(CNFOutlinePage.HIDE_DOCUMENT_SYMBOL_KIND_PREFERENCE_PREFIX)) {
 				viewer.getControl().getDisplay().asyncExec(() -> {
-					if(viewer.getTree().isDisposed()) {
-						return;
+					if(!viewer.getTree().isDisposed()) {
+						viewer.refresh();
 					}
-
-					viewer.refresh();
 				});
 			}
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -164,11 +164,8 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 
 		@Override
 		public void preferenceChange(PreferenceChangeEvent event) {
-			if (viewer == null || outlineViewerInput == null) {
-				return;
-			}
-
-			if (event.getKey().startsWith(CNFOutlinePage.HIDE_DOCUMENT_SYMBOL_KIND_PREFERENCE_PREFIX)) {
+			if (viewer != null
+					&& event.getKey().startsWith(CNFOutlinePage.HIDE_DOCUMENT_SYMBOL_KIND_PREFERENCE_PREFIX)) {
 				viewer.getControl().getDisplay().asyncExec(() -> {
 					if(viewer.getTree().isDisposed()) {
 						return;
@@ -341,33 +338,18 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			.toArray(Object[]::new);
 	}
 
-	/**
-	 * Decide whether to hide the given element or not.
-	 * Default implementation hides elements depending on a preference
-	 * that determines which {@link SymbolKind}s
-	 * (property in {@link DocumentSymbol}, {@link DocumentSymbolWithURI}s, and {@link SymbolInformation})
-	 * are to be hidden in the outline view.
-	 * Sub-classes may override this method to add language-specific filtering.
-	 *
-	 * @param element an outline view contents element to be checked
-	 * @return <code>true</code> if the given element is not to be shown in the outline view
-	 */
-	protected boolean hideElement(Object element) {
+	private boolean hideElement(Object element) {
 		SymbolKind kind = null;
 
-		if (element instanceof DocumentSymbol) {
-			kind = ((DocumentSymbol) element).getKind();
-		} else if (element instanceof DocumentSymbolWithURI) {
-			kind = ((DocumentSymbolWithURI) element).symbol.getKind();
-		} else if (element instanceof SymbolInformation) {
-			kind = ((SymbolInformation) element).getKind();
+		if (element instanceof DocumentSymbol documentSymbol) {
+			kind = documentSymbol.getKind();
+		} else if (element instanceof DocumentSymbolWithURI documentSymbolWithURI) {
+			kind = documentSymbolWithURI.symbol.getKind();
+		} else if (element instanceof SymbolInformation symbolInformation) {
+			kind = symbolInformation.getKind();
 		}
 
-		if (OutlineViewHideSymbolKindMenuContributor.isHideSymbolKind(kind)) {
-			return true;
-		}
-
-		return false;
+		return OutlineViewHideSymbolKindMenuContributor.isHideSymbolKind(kind);
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -7,9 +7,10 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *  Mickael Istria (Red Hat Inc.) - initial implementation
- *  Lucas Bullen (Red Hat Inc.) - Bug 508472 - Outline to provide "Link with Editor"
- *                              - Bug 517428 - Requests sent before initialization
+ *  Mickael Istria (Red Hat Inc.)   - initial implementation
+ *  Lucas Bullen (Red Hat Inc.)     - Bug 508472 - Outline to provide "Link with Editor"
+ *                                  - Bug 517428 - Requests sent before initialization
+ *  Dietrich Travkin (Solunar GmbH) - Issue 254  - Add outline view contents filtering
  *******************************************************************************/
 package org.eclipse.lsp4e.outline;
 
@@ -340,7 +341,18 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			.toArray(Object[]::new);
 	}
 
-	private boolean hideElement(Object element) {
+	/**
+	 * Decide whether to hide the given element or not.
+	 * Default implementation hides elements depending on a preference
+	 * that determines which {@link SymbolKind}s
+	 * (property in {@link DocumentSymbol}, {@link DocumentSymbolWithURI}s, and {@link SymbolInformation})
+	 * are to be hidden in the outline view.
+	 * Sub-classes may override this method to add language-specific filtering.
+	 *
+	 * @param element an outline view contents element to be checked
+	 * @return <code>true</code> if the given element is not to be shown in the outline view
+	 */
+	protected boolean hideElement(Object element) {
 		SymbolKind kind = null;
 
 		if (element instanceof DocumentSymbol) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -347,7 +347,10 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			kind = symbolInformation.getKind();
 		}
 
-		return OutlineViewHideSymbolKindMenuContributor.isHideSymbolKind(kind);
+		if (kind != null) {
+			return OutlineViewHideSymbolKindMenuContributor.isHideSymbolKind(kind);
+		}
+		return false;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -363,7 +363,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			kind = ((SymbolInformation) element).getKind();
 		}
 
-		if (OutlineViewFilterMenuContributor.isHideSymbolKind(kind)) {
+		if (OutlineViewHideSymbolKindMenuContributor.isHideSymbolKind(kind)) {
 			return true;
 		}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewFilterMenuContributor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewFilterMenuContributor.java
@@ -19,8 +19,11 @@ import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4e.ui.LSPImages;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.actions.CompoundContributionItem;
 
 public class OutlineViewFilterMenuContributor extends CompoundContributionItem {
@@ -57,6 +60,11 @@ public class OutlineViewFilterMenuContributor extends CompoundContributionItem {
 			super(kind.name(), IAction.AS_CHECK_BOX);
 			this.kind = kind;
 			this.setChecked(isHideSymbolKind(kind));
+
+			Image img = LSPImages.imageFromSymbolKind(kind);
+			if (img != null) {
+				this.setImageDescriptor(ImageDescriptor.createFromImage(img));
+			}
 		}
 
 		@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewFilterMenuContributor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewFilterMenuContributor.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4e.outline;
 
 import java.util.Arrays;
+import java.util.Comparator;
 
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -31,6 +32,14 @@ public class OutlineViewFilterMenuContributor extends CompoundContributionItem {
 	@Override
 	protected IContributionItem[] getContributionItems() {
 		return Arrays.stream(SymbolKind.values())
+			.sorted(new Comparator<SymbolKind>() {
+
+				@Override
+				public int compare(SymbolKind sk1, SymbolKind sk2) {
+					return sk1.name().compareToIgnoreCase(sk2.name());
+				}
+
+			})
 			.map(kind -> createHideSymbolKindContributionItem(kind))
 			.toArray(IContributionItem[]::new);
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewFilterMenuContributor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewFilterMenuContributor.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Advantest Europe GmbH. All rights reserved.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dietrich Travkin (Solunar GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.outline;
+
+import java.util.Arrays;
+
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.ActionContributionItem;
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IContributionItem;
+import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.ui.actions.CompoundContributionItem;
+
+public class OutlineViewFilterMenuContributor extends CompoundContributionItem {
+
+	@Override
+	protected IContributionItem[] getContributionItems() {
+		return Arrays.stream(SymbolKind.values())
+			.map(kind -> createHideSymbolKindContributionItem(kind))
+			.toArray(IContributionItem[]::new);
+	}
+
+	private IContributionItem createHideSymbolKindContributionItem(SymbolKind kind) {
+		return new ActionContributionItem(new HideSymbolKindAction(kind));
+	}
+
+	static boolean isHideSymbolKind(SymbolKind kind) {
+		IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(LanguageServerPlugin.PLUGIN_ID);
+		return preferences.getBoolean(CNFOutlinePage.HIDE_DOCUMENT_SYMBOL_KIND_PREFERENCE_PREFIX + kind.name(), false);
+	}
+
+	static boolean toggleHideSymbolKind(SymbolKind kind) {
+		IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(LanguageServerPlugin.PLUGIN_ID);
+		boolean oldValue = isHideSymbolKind(kind);
+
+		preferences.putBoolean(CNFOutlinePage.HIDE_DOCUMENT_SYMBOL_KIND_PREFERENCE_PREFIX + kind.name(), !oldValue);
+
+		return !oldValue;
+	}
+
+	private static class HideSymbolKindAction extends Action {
+		private final SymbolKind kind;
+
+		HideSymbolKindAction(SymbolKind kind) {
+			super(kind.name(), IAction.AS_CHECK_BOX);
+			this.kind = kind;
+			this.setChecked(isHideSymbolKind(kind));
+		}
+
+		@Override
+		public void run() {
+			boolean checkedState = toggleHideSymbolKind(kind);
+			setChecked(checkedState);
+		}
+
+	}
+
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewFilterMenuContributor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewFilterMenuContributor.java
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *  Dietrich Travkin (Solunar GmbH) - initial implementation
+ *  Dietrich Travkin (Solunar GmbH) - initial implementation of outline contents filtering (issue #254)
  *******************************************************************************/
 package org.eclipse.lsp4e.outline;
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewHideSymbolKindMenuContributor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewHideSymbolKindMenuContributor.java
@@ -27,7 +27,7 @@ import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.actions.CompoundContributionItem;
 
-public class OutlineViewFilterMenuContributor extends CompoundContributionItem {
+public class OutlineViewHideSymbolKindMenuContributor extends CompoundContributionItem {
 
 	@Override
 	protected IContributionItem[] getContributionItems() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewHideSymbolKindMenuContributor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewHideSymbolKindMenuContributor.java
@@ -36,7 +36,7 @@ public class OutlineViewHideSymbolKindMenuContributor extends CompoundContributi
 
 				@Override
 				public int compare(SymbolKind sk1, SymbolKind sk2) {
-					return sk1.name().compareToIgnoreCase(sk2.name());
+					return sk1.name().compareTo(sk2.name());
 				}
 
 			})

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewHideSymbolKindMenuContributor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/OutlineViewHideSymbolKindMenuContributor.java
@@ -68,11 +68,11 @@ public class OutlineViewHideSymbolKindMenuContributor extends CompoundContributi
 		HideSymbolKindAction(SymbolKind kind) {
 			super(kind.name(), IAction.AS_CHECK_BOX);
 			this.kind = kind;
-			this.setChecked(isHideSymbolKind(kind));
+			setChecked(isHideSymbolKind(kind));
 
 			Image img = LSPImages.imageFromSymbolKind(kind);
 			if (img != null) {
-				this.setImageDescriptor(ImageDescriptor.createFromImage(img));
+				setImageDescriptor(ImageDescriptor.createFromImage(img));
 			}
 		}
 


### PR DESCRIPTION
Add generic implementation of content filtering in the outline view based on an element's SymbolKind and corresponding preferences, which make the user settings persistent.