### PR TITLE
Add @Nullable Annotation to LSW.connect(document, file)

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -582,7 +582,7 @@ public class LanguageServerWrapper {
 		FileBuffers.getTextFileBufferManager().removeFileBufferListener(fileBufferListener);
 	}
 
-	public @Nullable CompletableFuture<LanguageServerWrapper> connect(IDocument document, IFile file)
+	public @Nullable CompletableFuture<LanguageServerWrapper> connect(@Nullable IDocument document, IFile file)
 			throws IOException {
 		final URI uri = LSPEclipseUtils.toUri(file);
 		if (uri != null) {


### PR DESCRIPTION
Add `@Nullable` Annotation to LSW.connect(document, file) to revert to the state before setting `NonNullByDefault` (3ed68da2e2c21ee12364495b5576d609065d26fb)