### PR TITLE
feat: make diagnostic marker messages configurable

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/IMarkerAttributeComputer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/IMarkerAttributeComputer.java
@@ -17,6 +17,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /**
  * An interface that allows adding custom attributes to a
@@ -41,4 +42,14 @@ public interface IMarkerAttributeComputer {
 	 */
 	public void addMarkerAttributesForDiagnostic(Diagnostic diagnostic, @Nullable IDocument document,
 			IResource resource, Map<String, Object> attributes);
+
+	/**
+	 * Computes a string to be used as Marker message.
+	 */
+	public default String computeMarkerMessage(Diagnostic diagnostic) {
+		final Either<String, Integer> code = diagnostic.getCode();
+		return code == null //
+				? diagnostic.getMessage()
+				: diagnostic.getMessage() + " [" + code.get() + "]";  //$NON-NLS-1$//$NON-NLS-2$
+	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/DiagnosticAnnotation.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/DiagnosticAnnotation.java
@@ -11,16 +11,20 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.diagnostics;
 
+import java.util.function.Function;
+
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.lsp4j.Diagnostic;
 
-public class DiagnosticAnnotation extends Annotation {
+class DiagnosticAnnotation extends Annotation {
 
 	private final Diagnostic diagnostic;
+	private final Function<Diagnostic, String> textComputer;
 
-	public DiagnosticAnnotation(Diagnostic diagnostic) {
+	public DiagnosticAnnotation(Diagnostic diagnostic, Function<Diagnostic, String> textComputer) {
 		this.diagnostic = diagnostic;
+		this.textComputer = textComputer;
 	}
 
 	@Override
@@ -29,7 +33,7 @@ public class DiagnosticAnnotation extends Annotation {
 		case Error -> "org.eclipse.ui.workbench.texteditor.error"; //$NON-NLS-1$
 		case Warning -> "org.eclipse.ui.workbench.texteditor.warning"; //$NON-NLS-1$
 		case Information -> "org.eclipse.ui.workbench.texteditor.info"; //$NON-NLS-1$
-		case Hint ->"org.eclipse.ui.workbench.texteditor.info"; //$NON-NLS-1$
+		case Hint -> "org.eclipse.ui.workbench.texteditor.info"; //$NON-NLS-1$
 		};
 	}
 
@@ -40,7 +44,7 @@ public class DiagnosticAnnotation extends Annotation {
 
 	@Override
 	public String getText() {
-		return LSPDiagnosticsToMarkers.computeMarkerMessage(diagnostic);
+		return textComputer.apply(diagnostic);
 	}
 
 	@Override


### PR DESCRIPTION
This PR extends the `IMarkerAttributeComputer` with a method `computeMarkerMessage(Diagnostic)` allowing language server providers to customize the message to be used for markers.