### PR TITLE
refact: Use `var` keyword and `List.of` and `Set.of` where applicable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ _LOCAL/
 /*/target/
 .polyglot.*
 .META-INF_MANIFEST.MF
+**/.tycho-consumer-pom.xml
 dash-licenses/
 *.log
 

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPBreakpointManager.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPBreakpointManager.java
@@ -177,7 +177,7 @@ public class DSPBreakpointManager implements IBreakpointManagerListener, IBreakp
 
 			List<SourceBreakpoint> sourceBreakpoints = targetBreakpoints.computeIfAbsent(source,
 					s -> new ArrayList<>());
-			SourceBreakpoint sourceBreakpoint = new SourceBreakpoint();
+			final var sourceBreakpoint = new SourceBreakpoint();
 			sourceBreakpoint.setLine(lineNumber);
 			sourceBreakpoints.add(sourceBreakpoint);
 		}

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
@@ -354,10 +354,10 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 
 	@Override
 	public CompletableFuture<Void> startDebugging(StartDebuggingRequestArguments args) {
-		Map<String, Object> parameters = new HashMap<>(/* dspParameters */);
+		final var parameters = new HashMap<String, Object>(/* dspParameters */);
 		parameters.putAll(args.getConfiguration());
 		try {
-			DSPDebugTarget newTarget = new DSPDebugTarget(launch, streamsSupplier, parameters);
+			final var newTarget = new DSPDebugTarget(launch, streamsSupplier, parameters);
 			launch.addDebugTarget(newTarget);
 			newTarget.initialize(new NullProgressMonitor());
 			debuggees.add(newTarget);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPStackFrame.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPStackFrame.java
@@ -141,7 +141,7 @@ public class DSPStackFrame extends DSPDebugElement implements IStackFrame {
 			Scope[] scopes = complete(getDebugTarget().getDebugProtocolServer().scopes(arguments)).getScopes();
 			final var vars = new ArrayList<DSPVariable>();
 			for (Scope scope : scopes) {
-				DSPVariable variable = new DSPVariable(getDebugTarget(), -1, scope.getName(), "",
+				final var variable = new DSPVariable(getDebugTarget(), -1, scope.getName(), "",
 						scope.getVariablesReference());
 				vars.add(variable);
 			}

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPThread.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPThread.java
@@ -240,7 +240,7 @@ public class DSPThread extends DSPDebugElement implements IThread {
 			}
 		}
 		try {
-			StackTraceArguments arguments = new StackTraceArguments();
+			final var arguments = new StackTraceArguments();
 			arguments.setThreadId(id);
 			// TODO implement paging to get rest of frames
 			arguments.setStartFrame(0);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
@@ -214,7 +214,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 
 		String dspParametersJson = configuration.getAttribute(DSPPlugin.ATTR_DSP_PARAM, "{}");
 		try {
-			JsonParserWithStringSubstitution jsonUtils = new JsonParserWithStringSubstitution(
+			final var jsonUtils = new JsonParserWithStringSubstitution(
 					VariablesPlugin.getDefault().getStringVariableManager());
 			Map<String, Object> customParams = jsonUtils.parseJsonObjectAndRemoveNulls(dspParametersJson);
 			builder.dspParameters.putAll(customParams);
@@ -249,7 +249,7 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 			String dspParametersJson = builder.configuration.getAttribute(DSPPlugin.ATTR_DSP_PARAM, "");
 			if (!dspParametersJson.isBlank()) {
 				try {
-					JsonParserWithStringSubstitution jsonUtils = new JsonParserWithStringSubstitution(
+					final var jsonUtils = new JsonParserWithStringSubstitution(
 							VariablesPlugin.getDefault().getStringVariableManager());
 					Map<String, Object> customParams = jsonUtils.parseJsonObjectAndRemoveNulls(dspParametersJson);
 					builder.dspParameters.putAll(customParams);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPMainTab.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPMainTab.java
@@ -121,7 +121,7 @@ public class DSPMainTab extends AbstractLaunchConfigurationTab {
 		final var filler = new Composite(debugAdapterSettingsGroup, SWT.NONE);
 		filler.setLayoutData(new GridData(0, 0));
 		monitorAdapterLauncherProcessCheckbox = new Button(debugAdapterSettingsGroup, SWT.CHECK);
-		GridData layoutData = new GridData(SWT.LEFT, SWT.DEFAULT, true, false);
+		final var layoutData = new GridData(SWT.LEFT, SWT.DEFAULT, true, false);
 		monitorAdapterLauncherProcessCheckbox.setLayoutData(layoutData);
 		monitorAdapterLauncherProcessCheckbox
 				.addSelectionListener(widgetSelectedAdapter(e -> updateLaunchConfigurationDialog()));

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionProposalComputer.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionProposalComputer.java
@@ -106,7 +106,7 @@ public class LSJavaCompletionProposalComputer implements IJavaCompletionProposal
 	public List<IContextInformation> computeContextInformation(ContentAssistInvocationContext context,
 			IProgressMonitor monitor) {
 		IContextInformation[] contextInformation = lsContentAssistProcessor.computeContextInformation(context.getViewer(), context.getInvocationOffset());
-		return Arrays.asList(contextInformation);
+		return List.of(contextInformation);
 	}
 
 	@Override

--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.15.16.qualifier
+Bundle-Version: 0.15.17.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.15.16-SNAPSHOT</version>
+	<version>0.15.17-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
@@ -16,7 +16,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -75,13 +74,13 @@ public class LanguageServerWrapperTest extends AbstractTestWithProject {
 	 * @see https://github.com/eclipse/lsp4e/pull/688
 	 */
 	@Test
-	public void testStopAndActive() throws CoreException, IOException, AssertionError, InterruptedException, ExecutionException {
+	public void testStopAndActive() throws CoreException, AssertionError, InterruptedException, ExecutionException {
 		IFile testFile1 = TestUtils.createFile(project, "shouldUseExtension.lsptWithMultiRoot", "");
 		IEditorPart editor1 = TestUtils.openEditor(testFile1);
 		@NonNull Collection<LanguageServerWrapper> wrappers = LanguageServiceAccessor.getLSWrappers(testFile1, request -> true);
 		assertEquals(1, wrappers.size());
 		LanguageServerWrapper wrapper = wrappers.iterator().next();
-		CountDownLatch started = new CountDownLatch(1);
+		final var started = new CountDownLatch(1);
 		try {
 			var startStopJob = ForkJoinPool.commonPool().submit(() -> {
 				started.countDown();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
@@ -65,7 +65,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 	@Test
 	public void testCollectAll() throws Exception {
-		final AtomicInteger hoverCount = new AtomicInteger();
+		final var hoverCount = new AtomicInteger();
 		MockLanguageServer.INSTANCE.setTextDocumentService(new MockTextDocumentService(MockLanguageServer.INSTANCE::buildMaybeDelayedFuture) {
 			@Override
 			public synchronized void didChange(DidChangeTextDocumentParams params) {
@@ -74,7 +74,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				return CompletableFuture.completedFuture(hoverResponse);
 			}
 		});
@@ -83,8 +83,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -101,7 +101,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 	@Test
 	public void testCollectAllExcludesNulls() throws Exception {
-		final AtomicInteger hoverCount = new AtomicInteger();
+		final var hoverCount = new AtomicInteger();
 		MockLanguageServer.INSTANCE.setTextDocumentService(new MockTextDocumentService(MockLanguageServer.INSTANCE::buildMaybeDelayedFuture) {
 			@Override
 			public synchronized void didChange(DidChangeTextDocumentParams params) {
@@ -110,7 +110,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				return CompletableFuture.completedFuture(hoverCount.get() == 1 ? hoverResponse : null);
 			}
 		});
@@ -119,8 +119,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -137,7 +137,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 	@Test
 	public void testComputeAll() throws Exception {
-		final AtomicInteger hoverCount = new AtomicInteger();
+		final var hoverCount = new AtomicInteger();
 		MockLanguageServer.INSTANCE.setTextDocumentService(new MockTextDocumentService(MockLanguageServer.INSTANCE::buildMaybeDelayedFuture) {
 			@Override
 			public synchronized void didChange(DidChangeTextDocumentParams params) {
@@ -146,7 +146,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				final int currentCount = hoverCount.get();
 				return CompletableFuture.completedFuture(hoverResponse).thenApplyAsync(t -> {
 					try {
@@ -163,8 +163,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -197,15 +197,15 @@ public class LanguageServersTest extends AbstractTestWithProject {
 	public void testCollectAllUserCannotBlockListener() throws Exception {
 		// This test will only work if a minimum of two tasks can be run in the common pool without blocking!
 		Assume.assumeTrue("Test skipped as common thread pool does not have multiple executors", ForkJoinPool.commonPool().getParallelism() >= 2);
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "Here is some content");
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -242,8 +242,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 	@Test
 	public void testComputeFirst() throws Exception {
-		final AtomicInteger hoverCount = new AtomicInteger();
-		Vector<CompletableFuture<?>> internalResults = new Vector<>();
+		final var hoverCount = new AtomicInteger();
+		final var internalResults = new Vector<CompletableFuture<?>>();
 		MockLanguageServer.INSTANCE.setTextDocumentService(new MockTextDocumentService(MockLanguageServer.INSTANCE::buildMaybeDelayedFuture) {
 			@Override
 			public synchronized void didChange(DidChangeTextDocumentParams params) {
@@ -252,7 +252,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				final int currentCount = hoverCount.get();
 				CompletableFuture<Hover> result =  CompletableFuture.completedFuture(hoverResponse).thenApplyAsync(t -> {
 					try {
@@ -271,8 +271,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -293,7 +293,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 	@Test
 	public void testComputeFirstSkipsEmptyResults() throws Exception {
-		final AtomicInteger hoverCount = new AtomicInteger();
+		final var hoverCount = new AtomicInteger();
 		MockLanguageServer.INSTANCE.setTextDocumentService(new MockTextDocumentService(MockLanguageServer.INSTANCE::buildMaybeDelayedFuture) {
 			@Override
 			public synchronized void didChange(DidChangeTextDocumentParams params) {
@@ -302,7 +302,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				if (hoverCount.get() == 1) {
 					return CompletableFuture.completedFuture(null);
 				}
@@ -321,8 +321,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -356,8 +356,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -372,7 +372,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 	@Test
 	public void testComputeFirstTreatsEmptyListAsNull() throws Exception {
-		final AtomicInteger hoverCount = new AtomicInteger();
+		final var hoverCount = new AtomicInteger();
 		MockLanguageServer.INSTANCE.setTextDocumentService(new MockTextDocumentService(MockLanguageServer.INSTANCE::buildMaybeDelayedFuture) {
 			@Override
 			public synchronized void didChange(DidChangeTextDocumentParams params) {
@@ -381,7 +381,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				if (hoverCount.get() == 1) {
 					return CompletableFuture.completedFuture(null);
 				}
@@ -400,8 +400,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -449,7 +449,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 			}
 		});
 
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 		CompletableFuture<?> initial = CompletableFuture.completedFuture(null);
 
@@ -463,8 +463,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		for (int i = 0; i < 5000; i++) {
 			final int current = i + 1;
 			text.append(i + "\n");
-			final HoverParams params = new HoverParams();
-			final Position position = new Position();
+			final var params = new HoverParams();
+			final var position = new Position();
 
 			// encode the iteration number in a suitable numeric field on the hover request params, so the
 			// mock server can use it to verify the requests are indeed received in the correct order
@@ -479,7 +479,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		}
 
 		initial.join();
-		StringBuilder message = new StringBuilder();
+		final var message = new StringBuilder();
 		message.append("Too Early hover requests: "); message.append(tooEarlyHover.size());
 		message.append(System.lineSeparator());
 		tooEarlyHover.forEach(i -> {
@@ -503,7 +503,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 	 */
 	@Test
 	public void testBlockingServerDoesNotBlockUIThread() throws Exception {
-		final AtomicInteger uiDispatchCount = new AtomicInteger();
+		final var uiDispatchCount = new AtomicInteger();
 
 		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
 		.setTextDocumentSync(TextDocumentSyncKind.Incremental);
@@ -526,7 +526,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 			}
 		});
 
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 		CompletableFuture<?> initial = CompletableFuture.completedFuture(null);
 
@@ -538,7 +538,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 		final long startTime = System.currentTimeMillis();
 
-		final StringBuilder bulkyText = new StringBuilder();
+		final var bulkyText = new StringBuilder();
 
 		// Construct a reasonably bulky payload for the document updates: if the
 		// payload is small then buffering will mitigate any back-pressure from the server
@@ -552,8 +552,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		for (int i = 0; i < 10; i++) {
 			final int current = i + 1;
 			text.append(content + "\n");
-			final HoverParams params = new HoverParams();
-			final Position position = new Position();
+			final var params = new HoverParams();
+			final var position = new Position();
 			position.setCharacter(current);
 			position.setLine(0);
 			params.setPosition(position);
@@ -587,7 +587,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 	@Test
 	public void testNoMatchingServers() throws Exception {
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
@@ -598,8 +598,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 		assertFalse("Should not have been any valid LS", executor.anyMatching());
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -627,7 +627,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				final CompletableFuture<Hover> result = new CompletableFuture<>();
+				final var result = new CompletableFuture<Hover>();
 				result.completeExceptionally(new IllegalStateException("No hovering here"));
 				return result;
 			}
@@ -637,8 +637,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -657,15 +657,15 @@ public class LanguageServersTest extends AbstractTestWithProject {
 	 */
 	@Test
 	public void testWrapperWrapsSameLS() throws Exception {
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		final IDocument document = viewer.getDocument();
 
-		final HoverParams params = new HoverParams();
-		final Position position = new Position();
+		final var params = new HoverParams();
+		final var position = new Position();
 		position.setCharacter(10);
 		position.setLine(0);
 		params.setPosition(position);
@@ -676,7 +676,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 		final List<Pair<LanguageServerWrapper, LanguageServer>> result = async.join();
 
-		final AtomicInteger matching = new AtomicInteger();
+		final var matching = new AtomicInteger();
 
 		assertEquals("Should have had two responses", 2, result.size());
 		assertNotEquals("LS should have been different proxies", result.get(0).second(), result.get(1).second());
@@ -708,7 +708,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 		var editor1 = openEditor(testFile1);
 		var editor2 = openEditor(testFile2);
 
-		final AtomicInteger serverCounter = new AtomicInteger();
+		final var serverCounter = new AtomicInteger();
 
 		final List<String> serversForProject = LanguageServers.forProject(project).collectAll(ls -> CompletableFuture.completedFuture("Server" + serverCounter.incrementAndGet())).join();
 		assertTrue(serversForProject.contains("Server1"));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
@@ -74,7 +74,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				return CompletableFuture.completedFuture(hoverResponse);
 			}
 		});
@@ -110,7 +110,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				return CompletableFuture.completedFuture(hoverCount.get() == 1 ? hoverResponse : null);
 			}
 		});
@@ -146,7 +146,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				final int currentCount = hoverCount.get();
 				return CompletableFuture.completedFuture(hoverResponse).thenApplyAsync(t -> {
 					try {
@@ -197,7 +197,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 	public void testCollectAllUserCannotBlockListener() throws Exception {
 		// This test will only work if a minimum of two tasks can be run in the common pool without blocking!
 		Assume.assumeTrue("Test skipped as common thread pool does not have multiple executors", ForkJoinPool.commonPool().getParallelism() >= 2);
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "Here is some content");
@@ -252,7 +252,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				final int currentCount = hoverCount.get();
 				CompletableFuture<Hover> result =  CompletableFuture.completedFuture(hoverResponse).thenApplyAsync(t -> {
 					try {
@@ -302,7 +302,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				if (hoverCount.get() == 1) {
 					return CompletableFuture.completedFuture(null);
 				}
@@ -381,7 +381,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 			@Override
 			public synchronized CompletableFuture<Hover> hover(HoverParams position) {
-				final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
+				final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent" + hoverCount.incrementAndGet())), new Range(new Position(0,  0), new Position(0, 10)));
 				if (hoverCount.get() == 1) {
 					return CompletableFuture.completedFuture(null);
 				}
@@ -408,7 +408,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 		CompletableFuture<Optional<List<String>>> response =  LanguageServers.forDocument(document)
 				.withFilter(capabilities -> LSPEclipseUtils.hasCapability(capabilities.getHoverProvider()))
-				.computeFirst(ls -> ls.getTextDocumentService().hover(params).thenApply(h -> h == null ? Collections.emptyList() : Collections.singletonList(h.getContents().getLeft().get(0).getLeft())));
+				.computeFirst(ls -> ls.getTextDocumentService().hover(params).thenApply(h -> h == null ? Collections.emptyList() : List.of(h.getContents().getLeft().get(0).getLeft())));
 
 		Optional<List<String>> result = response.join();
 		assertTrue("Should have returned a result", result.isPresent());
@@ -449,7 +449,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 			}
 		});
 
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 		CompletableFuture<?> initial = CompletableFuture.completedFuture(null);
 
@@ -526,7 +526,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 			}
 		});
 
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 		CompletableFuture<?> initial = CompletableFuture.completedFuture(null);
 
@@ -587,7 +587,7 @@ public class LanguageServersTest extends AbstractTestWithProject {
 
 	@Test
 	public void testNoMatchingServers() throws Exception {
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "");
@@ -657,7 +657,8 @@ public class LanguageServersTest extends AbstractTestWithProject {
 	 */
 	@Test
 	public void testWrapperWrapsSameLS() throws Exception {
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(
+				List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile testFile = TestUtils.createUniqueTestFileMultiLS(project, "Here is some content");

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/VersioningSupportTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/VersioningSupportTest.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
-import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.BadLocationException;
@@ -42,7 +41,7 @@ public class VersioningSupportTest extends AbstractTestWithProject {
 
 	@Test
 	public void testVersionSupportSuccess() throws Exception {
-		List<TextEdit> formattingTextEdits = new ArrayList<>();
+		final var formattingTextEdits = new ArrayList<TextEdit>();
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 0), new Position(0, 1)), "MyF"));
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 21), new Position(0, 21)), " Second"));
@@ -79,7 +78,7 @@ public class VersioningSupportTest extends AbstractTestWithProject {
 
 	@Test(expected=ConcurrentModificationException.class)
 	public void testVersionedEditsFailsOnModification() throws Exception {
-		List<TextEdit> formattingTextEdits = new ArrayList<>();
+		final var formattingTextEdits = new ArrayList<TextEdit>();
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 0), new Position(0, 1)), "MyF"));
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 21), new Position(0, 21)), " Second"));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/WorkspaceFoldersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/WorkspaceFoldersTest.java
@@ -13,8 +13,7 @@
 package org.eclipse.lsp4e.test;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.net.URI;
@@ -109,7 +108,7 @@ public class WorkspaceFoldersTest extends AbstractTestWithProject {
 		LanguageServiceAccessor.getLSWrappers(testFile1, capabilities -> true).iterator().next();
 		waitForAndAssertCondition(5_000, () -> MockLanguageServer.INSTANCE.isRunning());
 		ConnectDocumentToLanguageServerSetupParticipant.waitForAll();
-		final JobSynchronizer synchronizer = new JobSynchronizer();
+		final var synchronizer = new JobSynchronizer();
 		project.close(synchronizer);
 		synchronizer.await();
 
@@ -138,8 +137,8 @@ public class WorkspaceFoldersTest extends AbstractTestWithProject {
 		assertTrue(wrapper1.isActive());
 
 		// Grab this before deletion otherwise project.getLocationURI will be null...
-		final File expected = new File(project.getLocationURI());
-		final JobSynchronizer synchronizer = new JobSynchronizer();
+		final var expected = new File(project.getLocationURI());
+		final var synchronizer = new JobSynchronizer();
 		project.delete(true, true, synchronizer);
 		synchronizer.await();
 		final MockWorkspaceService mockWorkspaceService = MockLanguageServer.INSTANCE.getWorkspaceService();
@@ -161,13 +160,13 @@ public class WorkspaceFoldersTest extends AbstractTestWithProject {
 		waitForAndAssertCondition(5_000, () -> MockLanguageServer.INSTANCE.isRunning());
 		ConnectDocumentToLanguageServerSetupParticipant.waitForAll();
 
-		final JobSynchronizer synchronizer = new JobSynchronizer();
+		final var synchronizer = new JobSynchronizer();
 		project.close(synchronizer);
 		synchronizer.await();
 
 		waitForAndAssertCondition(5_000, () -> !project.isOpen());
 
-		final JobSynchronizer synchronizer2 = new JobSynchronizer();
+		final var synchronizer2 = new JobSynchronizer();
 		project.open(synchronizer2);
 		synchronizer2.await();
 
@@ -189,8 +188,8 @@ public class WorkspaceFoldersTest extends AbstractTestWithProject {
 		// Enable workspace folders on the mock server (for this test only)
 		final ServerCapabilities base = MockLanguageServer.defaultServerCapabilities();
 
-		final WorkspaceServerCapabilities wsc = new WorkspaceServerCapabilities();
-		final WorkspaceFoldersOptions wso = new WorkspaceFoldersOptions();
+		final var wsc = new WorkspaceServerCapabilities();
+		final var wso = new WorkspaceFoldersOptions();
 		wso.setSupported(true);
 		wso.setChangeNotifications(true);
 		wsc.setWorkspaceFolders(wso);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
@@ -11,10 +11,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.codeactions;
 
-import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.eclipse.lsp4e.test.utils.TestUtils.waitForCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.eclipse.lsp4e.test.utils.TestUtils.*;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,7 +71,7 @@ public class CodeActionTests extends AbstractTestWithProject {
 		));
 		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
-		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		try {
 			IMarker m = assertDiagnostics(f, "error", "fixme");
 			assertResolution(editor, m, "fixed");
@@ -86,8 +84,8 @@ public class CodeActionTests extends AbstractTestWithProject {
 	public void testCodeActionsClientCommandForWorkspaceEdit() throws CoreException {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
-		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
 		MockLanguageServer.INSTANCE.setCodeActions(Collections
 				.singletonList(Either.forLeft(new Command(
 				"fixme",
@@ -97,7 +95,7 @@ public class CodeActionTests extends AbstractTestWithProject {
 		));
 		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
-		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 
 		IMarker m = assertDiagnostics(f, "error", "fixme");
 		assertResolution(editor, m, "fixed");
@@ -116,8 +114,8 @@ public class CodeActionTests extends AbstractTestWithProject {
 		MockLanguageServer.reset();
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
-		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
 		MockLanguageServer.INSTANCE.setCodeActions(Collections
 				.singletonList(Either.forLeft(new Command(
 				"fixme",
@@ -125,10 +123,10 @@ public class CodeActionTests extends AbstractTestWithProject {
 				Collections.singletonList(wEdit))
 			)
 		));
-		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		final Set<Shell> beforeShells = Arrays.stream(editor.getSite().getShell().getDisplay().getShells()).filter(Shell::isVisible).collect(Collectors.toSet());
 		editor.selectAndReveal(3, 0);
-		TextOperationAction action = (TextOperationAction) editor.getAction(ITextEditorActionConstants.QUICK_ASSIST);
+		final var action = (TextOperationAction) editor.getAction(ITextEditorActionConstants.QUICK_ASSIST);
 		action.update();
 		action.run();
 		Shell completionShell= TestUtils.findNewShell(beforeShells, editor.getSite().getShell().getDisplay());
@@ -141,8 +139,8 @@ public class CodeActionTests extends AbstractTestWithProject {
 		MockLanguageServer.reset();
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
-		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
 		MockLanguageServer.INSTANCE.setCodeActions(Collections
 				.singletonList(Either.forLeft(new Command(
 				"fixme",
@@ -151,10 +149,10 @@ public class CodeActionTests extends AbstractTestWithProject {
 			)
 		));
 		MockLanguageServer.INSTANCE.setTimeToProceedQueries(1000);
-		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		final Set<Shell> beforeShells = Arrays.stream(editor.getSite().getShell().getDisplay().getShells()).filter(Shell::isVisible).collect(Collectors.toSet());
 		editor.selectAndReveal(3, 0);
-		TextOperationAction action = (TextOperationAction) editor.getAction(ITextEditorActionConstants.QUICK_ASSIST);
+		final var action = (TextOperationAction) editor.getAction(ITextEditorActionConstants.QUICK_ASSIST);
 		action.update();
 		action.run();
 		waitForAndAssertCondition(3000, () -> {
@@ -172,14 +170,14 @@ public class CodeActionTests extends AbstractTestWithProject {
 	public void testCodeActionLiteralWorkspaceEdit() throws CoreException {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
-		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
-		CodeAction codeAction = new CodeAction("fixme");
+		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var codeAction = new CodeAction("fixme");
 		codeAction.setEdit(wEdit);
 		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forRight(codeAction)));
 		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
-		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		IMarker m = assertDiagnostics(f, "error", "fixme");
 		assertResolution(editor, m, "fixed");
 	}
@@ -194,9 +192,9 @@ public class CodeActionTests extends AbstractTestWithProject {
 			}
 		});
 
-		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
-		CodeAction codeAction = new CodeAction("fixme");
+		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var codeAction = new CodeAction("fixme");
 		codeAction.setEdit(wEdit);
 		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forRight(codeAction)));
 		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
@@ -209,14 +207,14 @@ public class CodeActionTests extends AbstractTestWithProject {
 	public void testCodeActionLiteralWithClientCommand() throws CoreException {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
-		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
-		CodeAction codeAction = new CodeAction("fixme");
+		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var codeAction = new CodeAction("fixme");
 		codeAction.setCommand(new Command("editCommand", "mockEditCommand", Collections.singletonList(wEdit)));
 		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forRight(codeAction)));
 		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
-		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		IMarker m = assertDiagnostics(f, "error", "fixme");
 		assertResolution(editor, m, "fixed");
 	}
@@ -228,9 +226,9 @@ public class CodeActionTests extends AbstractTestWithProject {
 
 		// create a diagnostic on the sourceFile with a code action
 		// that changes the targetFile
-		TextEdit tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		WorkspaceEdit wEdit = new WorkspaceEdit(Collections.singletonMap(targetFile.getLocationURI().toString(), Collections.singletonList(tEdit)));
-		CodeAction codeAction = new CodeAction("fixme");
+		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(targetFile.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var codeAction = new CodeAction("fixme");
 		codeAction.setCommand(new Command("editCommand", "mockEditCommand", Collections.singletonList(wEdit)));
 		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forRight(codeAction)));
 		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
@@ -290,7 +288,7 @@ public class CodeActionTests extends AbstractTestWithProject {
 
 		IEditorPart editorPart = TestUtils.getEditor(targetFile);
 		assertTrue(editorPart instanceof AbstractTextEditor);
-		AbstractTextEditor editor = (AbstractTextEditor)editorPart;
+		final var editor = (AbstractTextEditor)editorPart;
 
 		waitForCondition(1_000,
 				() -> newText.equals(editor.getDocumentProvider().getDocument(editor.getEditorInput()).get()));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -59,17 +60,17 @@ public class CodeActionTests extends AbstractTestWithProject {
 	@Test
 	public void testCodeActionsClientCommandForTextEdit() throws CoreException {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
-		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forLeft(new Command(
+		MockLanguageServer.INSTANCE.setCodeActions(List.of(Either.forLeft(new Command(
 				"fixme",
 				"edit",
-				Collections.singletonList(
+				List.of(
 					new TextEdit(
 							new Range(new Position(0, 0), new Position(0, 5)),
 							"fixed"))
 				)
 			)
 		));
-		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
+		MockLanguageServer.INSTANCE.setDiagnostics(List.of(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
 		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		try {
@@ -85,15 +86,15 @@ public class CodeActionTests extends AbstractTestWithProject {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
-		MockLanguageServer.INSTANCE.setCodeActions(Collections
-				.singletonList(Either.forLeft(new Command(
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), List.of(tEdit)));
+		MockLanguageServer.INSTANCE.setCodeActions(List
+				.of(Either.forLeft(new Command(
 				"fixme",
 				"edit",
-				Collections.singletonList(wEdit))
+				List.of(wEdit))
 			)
 		));
-		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
+		MockLanguageServer.INSTANCE.setDiagnostics(List.of(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
 		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 
@@ -115,12 +116,12 @@ public class CodeActionTests extends AbstractTestWithProject {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
-		MockLanguageServer.INSTANCE.setCodeActions(Collections
-				.singletonList(Either.forLeft(new Command(
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), List.of(tEdit)));
+		MockLanguageServer.INSTANCE.setCodeActions(List
+				.of(Either.forLeft(new Command(
 				"fixme",
 				"edit",
-				Collections.singletonList(wEdit))
+				List.of(wEdit))
 			)
 		));
 		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
@@ -140,12 +141,12 @@ public class CodeActionTests extends AbstractTestWithProject {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
-		MockLanguageServer.INSTANCE.setCodeActions(Collections
-				.singletonList(Either.forLeft(new Command(
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), List.of(tEdit)));
+		MockLanguageServer.INSTANCE.setCodeActions(List
+				.of(Either.forLeft(new Command(
 				"fixme",
 				"edit",
-				Collections.singletonList(wEdit))
+				List.of(wEdit))
 			)
 		));
 		MockLanguageServer.INSTANCE.setTimeToProceedQueries(1000);
@@ -171,11 +172,11 @@ public class CodeActionTests extends AbstractTestWithProject {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), List.of(tEdit)));
 		final var codeAction = new CodeAction("fixme");
 		codeAction.setEdit(wEdit);
-		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forRight(codeAction)));
-		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
+		MockLanguageServer.INSTANCE.setCodeActions(List.of(Either.forRight(codeAction)));
+		MockLanguageServer.INSTANCE.setDiagnostics(List.of(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
 		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		IMarker m = assertDiagnostics(f, "error", "fixme");
@@ -193,11 +194,11 @@ public class CodeActionTests extends AbstractTestWithProject {
 		});
 
 		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), List.of(tEdit)));
 		final var codeAction = new CodeAction("fixme");
 		codeAction.setEdit(wEdit);
-		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forRight(codeAction)));
-		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
+		MockLanguageServer.INSTANCE.setCodeActions(List.of(Either.forRight(codeAction)));
+		MockLanguageServer.INSTANCE.setDiagnostics(List.of(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
 		TestUtils.openEditor(f);
 		assertDiagnostics(f, "error", "fixme", false);
@@ -208,11 +209,11 @@ public class CodeActionTests extends AbstractTestWithProject {
 		IFile f = TestUtils.createUniqueTestFile(project, "error");
 
 		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(f.getLocationURI().toString(), List.of(tEdit)));
 		final var codeAction = new CodeAction("fixme");
-		codeAction.setCommand(new Command("editCommand", "mockEditCommand", Collections.singletonList(wEdit)));
-		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forRight(codeAction)));
-		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
+		codeAction.setCommand(new Command("editCommand", "mockEditCommand", List.of(wEdit)));
+		MockLanguageServer.INSTANCE.setCodeActions(List.of(Either.forRight(codeAction)));
+		MockLanguageServer.INSTANCE.setDiagnostics(List.of(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
 		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		IMarker m = assertDiagnostics(f, "error", "fixme");
@@ -227,11 +228,11 @@ public class CodeActionTests extends AbstractTestWithProject {
 		// create a diagnostic on the sourceFile with a code action
 		// that changes the targetFile
 		final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
-		final var wEdit = new WorkspaceEdit(Collections.singletonMap(targetFile.getLocationURI().toString(), Collections.singletonList(tEdit)));
+		final var wEdit = new WorkspaceEdit(Collections.singletonMap(targetFile.getLocationURI().toString(), List.of(tEdit)));
 		final var codeAction = new CodeAction("fixme");
-		codeAction.setCommand(new Command("editCommand", "mockEditCommand", Collections.singletonList(wEdit)));
-		MockLanguageServer.INSTANCE.setCodeActions(Collections.singletonList(Either.forRight(codeAction)));
-		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
+		codeAction.setCommand(new Command("editCommand", "mockEditCommand", List.of(wEdit)));
+		MockLanguageServer.INSTANCE.setCodeActions(List.of(Either.forRight(codeAction)));
+		MockLanguageServer.INSTANCE.setDiagnostics(List.of(
 				new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
 
 		TestUtils.openEditor(sourceFile);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
@@ -58,9 +58,7 @@ public class ColorTest extends AbstractTestWithProject {
 	@Test
 	public void testColorProviderExternalFile() throws Exception {
 		File file = TestUtils.createTempFile("testColorProviderExternalFile", ".lspt");
-		try (
-			FileOutputStream out = new FileOutputStream(file);
-		) {
+		try (var out = new FileOutputStream(file)) {
 			out.write("\u2588\u2588\u2588\u2588\u2588".getBytes());
 		}
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI())));
@@ -75,8 +73,8 @@ public class ColorTest extends AbstractTestWithProject {
 		if (widget.getSize().x == 0) {
 			return false;
 		}
-		GC gc = new GC(widget);
-		Image image = new Image(widget.getDisplay(), widget.getSize().x, widget.getSize().y);
+		final var gc = new GC(widget);
+		final var image = new Image(widget.getDisplay(), widget.getSize().x, widget.getSize().y);
 		gc.copyArea(image, 0, 0);
 		gc.dispose();
 		ImageData imageData = image.getImageData();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
@@ -15,7 +15,7 @@ import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.jface.text.ITextViewer;
@@ -45,7 +45,7 @@ public class ColorTest extends AbstractTestWithProject {
 	@Before
 	public void setUp() {
 		color = new RGB(56, 78, 90); // a color that's not likely used anywhere else
-		MockLanguageServer.INSTANCE.getTextDocumentService().setDocumentColors(Collections.singletonList(new ColorInformation(new Range(new Position(0, 0), new Position(0, 1)), new Color(color.red / 255., color.green / 255., color.blue / 255., 255))));
+		MockLanguageServer.INSTANCE.getTextDocumentService().setDocumentColors(List.of(new ColorInformation(new Range(new Position(0, 0), new Position(0, 1)), new Color(color.red / 255., color.green / 255., color.blue / 255., 255))));
 	}
 
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
@@ -12,10 +12,7 @@
 package org.eclipse.lsp4e.test.commands;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -100,7 +97,7 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 
 	private void unregister(UUID registration) throws Exception {
 		LanguageClient client = getMockClient();
-		Unregistration unregistration = new Unregistration(registration.toString(), WORKSPACE_EXECUTE_COMMAND);
+		final var unregistration = new Unregistration(registration.toString(), WORKSPACE_EXECUTE_COMMAND);
 		client.unregisterCapability(new UnregistrationParams(Arrays.asList(unregistration)))
 			.get(1, TimeUnit.SECONDS);
 	}
@@ -108,7 +105,7 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 	private UUID registerWorkspaceFolders() throws Exception {
 		UUID id = UUID.randomUUID();
 		LanguageClient client = getMockClient();
-		Registration registration = new Registration();
+		final var registration = new Registration();
 		registration.setId(id.toString());
 		registration.setMethod(WORKSPACE_DID_CHANGE_FOLDERS);
 		client.registerCapability(new RegistrationParams(Arrays.asList(registration)))
@@ -119,7 +116,7 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 	private UUID registerCommands(String... command) throws Exception {
 		UUID id = UUID.randomUUID();
 		LanguageClient client = getMockClient();
-		Registration registration = new Registration();
+		final var registration = new Registration();
 		registration.setId(id.toString());
 		registration.setMethod(WORKSPACE_EXECUTE_COMMAND);
 		registration.setRegisterOptions(new Gson().toJsonTree(new ExecuteCommandOptions(Arrays.asList(command))));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
@@ -98,7 +98,7 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 	private void unregister(UUID registration) throws Exception {
 		LanguageClient client = getMockClient();
 		final var unregistration = new Unregistration(registration.toString(), WORKSPACE_EXECUTE_COMMAND);
-		client.unregisterCapability(new UnregistrationParams(Arrays.asList(unregistration)))
+		client.unregisterCapability(new UnregistrationParams(List.of(unregistration)))
 			.get(1, TimeUnit.SECONDS);
 	}
 
@@ -108,7 +108,7 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 		final var registration = new Registration();
 		registration.setId(id.toString());
 		registration.setMethod(WORKSPACE_DID_CHANGE_FOLDERS);
-		client.registerCapability(new RegistrationParams(Arrays.asList(registration)))
+		client.registerCapability(new RegistrationParams(List.of(registration)))
 			.get(1, TimeUnit.SECONDS);
 		return id;
 	}
@@ -119,8 +119,8 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 		final var registration = new Registration();
 		registration.setId(id.toString());
 		registration.setMethod(WORKSPACE_EXECUTE_COMMAND);
-		registration.setRegisterOptions(new Gson().toJsonTree(new ExecuteCommandOptions(Arrays.asList(command))));
-		client.registerCapability(new RegistrationParams(Arrays.asList(registration))).get(1, TimeUnit.SECONDS);
+		registration.setRegisterOptions(new Gson().toJsonTree(new ExecuteCommandOptions(List.of(command))));
+		client.registerCapability(new RegistrationParams(List.of(registration))).get(1, TimeUnit.SECONDS);
 		return id;
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/AbstractCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/AbstractCompletionTest.java
@@ -31,7 +31,6 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.ui.PartInitException;
 import org.junit.Before;
 
 public abstract class AbstractCompletionTest extends AbstractTestWithProject {
@@ -48,7 +47,7 @@ public abstract class AbstractCompletionTest extends AbstractTestWithProject {
 	}
 
 	protected CompletionItem createCompletionItem(String label, CompletionItemKind kind, Range range) {
-		CompletionItem item = new CompletionItem();
+		final var item = new CompletionItem();
 		item.setLabel(label);
 		item.setKind(kind);
 		item.setTextEdit(Either.forLeft(new TextEdit(range, label)));
@@ -56,10 +55,10 @@ public abstract class AbstractCompletionTest extends AbstractTestWithProject {
 	}
 
 	protected CompletionItem createCompletionItemWithInsertReplace(String label, CompletionItemKind kind, Range insertRange, Range replaceRange) {
-		CompletionItem item = new CompletionItem();
+		final var item = new CompletionItem();
 		item.setLabel(label);
 		item.setKind(kind);
-		InsertReplaceEdit insertReplaceEdit = new InsertReplaceEdit();
+		final var insertReplaceEdit = new InsertReplaceEdit();
 		insertReplaceEdit.setNewText(label);
 		insertReplaceEdit.setInsert(insertRange);
 		insertReplaceEdit.setReplace(replaceRange);
@@ -68,9 +67,9 @@ public abstract class AbstractCompletionTest extends AbstractTestWithProject {
 	}
 
 	protected void confirmCompletionResults(String[] completions, String content, Integer cursorIndexInContent,
-			String[] expectedOrder) throws PartInitException, CoreException {
-		Range range = new Range(new Position(0, 0), new Position(0, cursorIndexInContent));
-		List<CompletionItem> items = new ArrayList<>();
+			String[] expectedOrder) throws CoreException {
+		final var range = new Range(new Position(0, 0), new Position(0, cursorIndexInContent));
+		final var items = new ArrayList<CompletionItem>();
 		for (String string : completions) {
 			items.add(createCompletionItem(string, CompletionItemKind.Class, range));
 		}
@@ -78,7 +77,7 @@ public abstract class AbstractCompletionTest extends AbstractTestWithProject {
 	}
 
 	protected void confirmCompletionResults(List<CompletionItem> completions, String content,
-			Integer cursorIndexInContent, String[] expectedOrder) throws PartInitException, CoreException {
+			Integer cursorIndexInContent, String[] expectedOrder) throws CoreException {
 
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, completions));
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -139,10 +139,10 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	public void testCommandExecution() throws CoreException, InterruptedException, ExecutionException, TimeoutException {
 		CompletionItem completionItem = createCompletionItem("Bla", CompletionItemKind.Class);
 		final var expectedParameter = "command execution parameter";
-		List<Object> commandArguments = Arrays.asList(expectedParameter);
+		List<Object> commandArguments = List.of(expectedParameter);
 		completionItem.setCommand(new Command("TestCommand", MockLanguageServer.SUPPORTED_COMMAND_ID, commandArguments));
 
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Arrays.asList(completionItem)));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(completionItem)));
 
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, ""));
 
@@ -156,7 +156,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		ExecuteCommandParams executedCommand = MockLanguageServer.INSTANCE.getWorkspaceService().getExecutedCommand().get(2, TimeUnit.SECONDS);
 
 		assertEquals(MockLanguageServer.SUPPORTED_COMMAND_ID, executedCommand.getCommand());
-		List<JsonPrimitive> expectedParameterList = Arrays.asList(new JsonPrimitive(expectedParameter));
+		List<JsonPrimitive> expectedParameterList = List.of(new JsonPrimitive(expectedParameter));
 		assertEquals(expectedParameterList, executedCommand.getArguments());
 	}
 
@@ -321,14 +321,13 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testItemOrdering() throws Exception {
 		final var range = new Range(new Position(0, 0), new Position(0, 1));
-		List<CompletionItem> items = Arrays.asList(new CompletionItem[] {
-			createCompletionItem("AA", CompletionItemKind.Class, range),
-			createCompletionItem("AB", CompletionItemKind.Class, range),
-			createCompletionItem("BA", CompletionItemKind.Class, range),
-			createCompletionItem("BB", CompletionItemKind.Class, range),
-			createCompletionItem("CB", CompletionItemKind.Class, range),
-			createCompletionItem("CC", CompletionItemKind.Class, range),
-		});
+		List<CompletionItem> items = List.of( //
+				createCompletionItem("AA", CompletionItemKind.Class, range),
+				createCompletionItem("AB", CompletionItemKind.Class, range),
+				createCompletionItem("BA", CompletionItemKind.Class, range),
+				createCompletionItem("BB", CompletionItemKind.Class, range),
+				createCompletionItem("CB", CompletionItemKind.Class, range),
+				createCompletionItem("CC", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
 		final var content = "B";
@@ -369,10 +368,10 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
 		assertEquals(1, proposals.length);
-		final var beforeShells = new HashSet<>(Arrays.asList(viewer.getTextWidget().getDisplay().getShells()));
+		final var beforeShells = new HashSet<>(List.of(viewer.getTextWidget().getDisplay().getShells()));
 		((LSCompletionProposal) proposals[0]).apply(viewer, '\n', 0, invokeOffset);
 		assertEquals("1a2", viewer.getDocument().get());
-		final var newShells = new HashSet<>(Arrays.asList(viewer.getTextWidget().getDisplay().getShells()));
+		final var newShells = new HashSet<>(List.of(viewer.getTextWidget().getDisplay().getShells()));
 		newShells.removeAll(beforeShells);
 		assertNotEquals(Collections.emptySet(), newShells);
 		final var proposalList = (Table) newShells.iterator().next().getChildren()[0];

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -13,14 +13,8 @@
 package org.eclipse.lsp4e.test.completion;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +22,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -64,10 +57,8 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ST;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
-import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.Test;
 
@@ -80,8 +71,8 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	 * file-specific LS already associated is something we want to support.
 	 */
 	@Test
-	public void testAssistForUnknownButConnectedType() throws CoreException, IOException {
-		List<CompletionItem> items = new ArrayList<>();
+	public void testAssistForUnknownButConnectedType() throws CoreException {
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
@@ -100,14 +91,14 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(items.size(), proposals.length);
 		// TODO compare both structures
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 0);
 		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
 	}
 
 	@Test
 	public void testNoPrefix() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
@@ -117,25 +108,25 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(items.size(), proposals.length);
 		// TODO compare both structures
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 0);
 		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
 	}
 
 	@Test
 	public void testPrefix() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		items.add(createCompletionItem("SecondClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
-		String content = "First";
+		final var content = "First";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
 		assertEquals(1, proposals.length);
 		// TODO compare items
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 0);
 		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
 	}
@@ -147,7 +138,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testCommandExecution() throws CoreException, InterruptedException, ExecutionException, TimeoutException {
 		CompletionItem completionItem = createCompletionItem("Bla", CompletionItemKind.Class);
-		String expectedParameter = "command execution parameter";
+		final var expectedParameter = "command execution parameter";
 		List<Object> commandArguments = Arrays.asList(expectedParameter);
 		completionItem.setCommand(new Command("TestCommand", MockLanguageServer.SUPPORTED_COMMAND_ID, commandArguments));
 
@@ -158,7 +149,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(1, proposals.length);
 
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 0);
 
 		// Assert command was invoked on langauge server
@@ -171,37 +162,37 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testPrefixCaseSensitivity() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
-		String content = "FIRST";
+		final var content = "FIRST";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
 		assertEquals(1, proposals.length);
 		// TODO compare items
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 0);
 		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
 	}
 
 	@Test
 	public void testCompleteOnFileEnd() throws CoreException { // bug 508842
-		CompletionItem item = new CompletionItem();
+		final var item = new CompletionItem();
 		item.setLabel("1024M");
 		item.setKind(CompletionItemKind.Value);
 		item.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(2, 10), new Position(2, 10)), "1024M")));
-		CompletionList completionList = new CompletionList(false, Collections.singletonList(item));
+		final var completionList = new CompletionList(false, Collections.singletonList(item));
 		MockLanguageServer.INSTANCE.setCompletionList(completionList);
 
-		String content = "applications:\n" + "- name: hello\n" + "  memory: ";
+		final var content = "applications:\n" + "- name: hello\n" + "  memory: ";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
 		assertEquals(1, proposals.length);
 
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, content.length());
 		assertEquals(content + "1024M", viewer.getDocument().get());
 		assertEquals(new Point(viewer.getDocument().getLength(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
@@ -209,12 +200,12 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testTriggerCharsWithoutPreliminaryCompletion() throws CoreException { // bug 508463
-		Set<String> triggers = new HashSet<>();
+		final var triggers = new HashSet<String>();
 		triggers.add("a");
 		triggers.add("b");
 		MockLanguageServer.INSTANCE.setCompletionTriggerChars(triggers);
 
-		String content = "First";
+		final var content = "First";
 		TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		waitForAndAssertCondition(3_000, () -> Arrays.equals(
@@ -234,16 +225,16 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testApplyCompletionWithPrefix() throws CoreException {
-		Range range = new Range(new Position(0, 0), new Position(0, 5));
+		final var range = new Range(new Position(0, 0), new Position(0, 5));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
-		String content = "First";
+		final var content = "First";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, content.length());
 		assertEquals(true, viewer.getDocument().get().equals("FirstClass"));
 		assertEquals(new Point(viewer.getDocument().getLength(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
@@ -251,15 +242,15 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testApplyCompletionReplace() throws CoreException {
-		Range range = new Range(new Position(0, 0), new Position(0, 20));
+		final var range = new Range(new Position(0, 0), new Position(0, 20));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
-		String content = "FirstNotMatchedLabel";
+		final var content = "FirstNotMatchedLabel";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 5);
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 5);
 		assertEquals("FirstClass", viewer.getDocument().get());
 		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
@@ -267,17 +258,17 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testApplyCompletionReplaceAndTypingWithTextEdit() throws CoreException, BadLocationException {
-		Range range = new Range(new Position(0, 0), new Position(0, 20));
+		final var range = new Range(new Position(0, 0), new Position(0, 20));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
-		String content = "FirstNotMatchedLabel";
+		final var content = "FirstNotMatchedLabel";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,content));
 
 		int invokeOffset = 5;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 
 		// simulate additional typing (to filter) after invoking completion
 		viewer.getDocument().replace(5, 0, "No");
@@ -289,19 +280,19 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testApplyCompletionReplaceAndTyping() throws CoreException, BadLocationException {
-		CompletionItem item = new CompletionItem("strncasecmp");
+		final var item = new CompletionItem("strncasecmp");
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("strncasecmp()");
 
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false,  Collections.singletonList(item)));
 
-		String content = "str";
+		final var content = "str";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		int invokeOffset = content.length();
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
 		assertEquals(1, proposals.length);
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 
 		// simulate additional typing (to filter) after invoking completion
 		viewer.getDocument().replace(content.length(), 0, "nc");
@@ -321,7 +312,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 		int invokeOffset = viewer.getDocument().getLength() - "InsertHere".length();
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, invokeOffset);
 		assertEquals("line1\nlineInserted", viewer.getDocument().get());
 		assertEquals(new Point(viewer.getDocument().getLength(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
@@ -329,7 +320,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testItemOrdering() throws Exception {
-		Range range = new Range(new Position(0, 0), new Position(0, 1));
+		final var range = new Range(new Position(0, 0), new Position(0, 1));
 		List<CompletionItem> items = Arrays.asList(new CompletionItem[] {
 			createCompletionItem("AA", CompletionItemKind.Class, range),
 			createCompletionItem("AB", CompletionItemKind.Class, range),
@@ -340,7 +331,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		});
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
-		String content = "B";
+		final var content = "B";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,content));
 
 		int invokeOffset = 1;
@@ -356,7 +347,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testBasicSnippet() throws PartInitException, CoreException {
+	public void testBasicSnippet() throws CoreException {
 		CompletionItem completionItem = createCompletionItem("$1 and ${2:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
@@ -370,7 +361,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testChoiceSnippet() throws PartInitException, CoreException {
+	public void testChoiceSnippet() throws CoreException {
 		CompletionItem completionItem = createCompletionItem("1${1|a,b|}2", CompletionItemKind.Class);
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
@@ -378,19 +369,19 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
 		assertEquals(1, proposals.length);
-		Set<Shell> beforeShells = new HashSet<>(Arrays.asList(viewer.getTextWidget().getDisplay().getShells()));
+		final var beforeShells = new HashSet<>(Arrays.asList(viewer.getTextWidget().getDisplay().getShells()));
 		((LSCompletionProposal) proposals[0]).apply(viewer, '\n', 0, invokeOffset);
 		assertEquals("1a2", viewer.getDocument().get());
-		Set<Shell> newShells = new HashSet<>(Arrays.asList(viewer.getTextWidget().getDisplay().getShells()));
+		final var newShells = new HashSet<>(Arrays.asList(viewer.getTextWidget().getDisplay().getShells()));
 		newShells.removeAll(beforeShells);
 		assertNotEquals(Collections.emptySet(), newShells);
-		Table proposalList = (Table)newShells.iterator().next().getChildren()[0];
+		final var proposalList = (Table) newShells.iterator().next().getChildren()[0];
 		String[] itemLabels = Arrays.stream(proposalList.getItems()).map(TableItem::getText).toArray(String[]::new);
 		assertArrayEquals(new String[] {"a", "b"}, itemLabels);
 	}
 
 	@Test
-	public void testDuplicateVariable() throws PartInitException, CoreException {
+	public void testDuplicateVariable() throws CoreException {
 		CompletionItem completionItem = createCompletionItem("${1:foo} and ${1:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
@@ -406,7 +397,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testComplexSnippets() throws PartInitException, CoreException {
+	public void testComplexSnippets() throws CoreException {
 		Map<String, String> tests = Map.ofEntries(
 				// Variables and escaped dollars
 				Map.entry("$TM_LINE_NUMBER - \\$TM_LINE_NUMBER - ${TM_LINE_NUMBER} - \\${TM_LINE_NUMBER}", "1 - $TM_LINE_NUMBER - 1 - ${TM_LINE_NUMBER}"),
@@ -450,7 +441,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testSnippetTabStops() throws PartInitException, CoreException {
+	public void testSnippetTabStops() throws CoreException {
 		CompletionItem completionItem = createCompletionItem("sum(${1:x}, ${2:y})", CompletionItemKind.Method,
 				new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
@@ -468,7 +459,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		assertEquals(1, range.y);
 
 		// fake a VerifyKey tabbing event to jump to the y parameter
-		Event event = new Event();
+		final var event = new Event();
 		event.character = SWT.TAB;
 		viewer.getTextWidget().notifyListeners(ST.VerifyKey, event);
 		range = viewer.getSelectedRange();
@@ -478,7 +469,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testMultipleLS() throws Exception {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
@@ -491,7 +482,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testReopeningFileAndReusingContentAssist() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
@@ -500,7 +491,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(items.size(), proposals.length); // TODO compare both structures
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal) proposals[0];
+		var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 0);
 		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
 
@@ -519,8 +510,8 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testFilterNonmatchingCompletions() throws Exception {
-		List<CompletionItem> items = new ArrayList<>();
-		CompletionItem item = new CompletionItem("server.web");
+		final var items = new ArrayList<CompletionItem>();
+		var item = new CompletionItem("server.web");
 		item.setFilterText("server.web");
 		item.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(0, 0), new Position(0, 10)), item.getFilterText())));
 		items.add(item);
@@ -545,7 +536,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 				.get(0);
 		// The completion ': 1.0.1' was given, then the user types a 's', which is used
 		// as a filter and removes the completion
-		LSCompletionProposal completionProposal = new LSCompletionProposal(document, 0, new CompletionItem(": 1.0.1"),
+		final var completionProposal = new LSCompletionProposal(document, 0, new CompletionItem(": 1.0.1"),
 				wrapper);
 		assertTrue(completionProposal.isValidFor(document, 6));
 		assertFalse(completionProposal.isValidFor(document, 7));
@@ -554,7 +545,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testAdjustIndentation() throws Exception {
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "a\n\tb\n\t\nc"));
-		CompletionItem item = new CompletionItem("line1\nline2");
+		final var item = new CompletionItem("line1\nline2");
 		item.setInsertTextMode(InsertTextMode.AdjustIndentation);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(item)));
 		int invokeOffset = 6;
@@ -567,7 +558,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testAdjustIndentationWithPrefixInLine() throws Exception {
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "a\n\tb\n\tprefix\nc"));
-		CompletionItem item = new CompletionItem("line1\n\tline2\nline3");
+		final var item = new CompletionItem("line1\n\tline2\nline3");
 		item.setInsertTextMode(InsertTextMode.AdjustIndentation);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(item)));
 		int invokeOffset = 12;
@@ -581,7 +572,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	public void testCancellation() throws Exception {
 		MockConnectionProvider.cancellations.clear();
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "a\n\tb\n\t\nc"));
-		CompletionItem item = new CompletionItem("a");
+		final var item = new CompletionItem("a");
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(item)));
 		MockLanguageServer.INSTANCE.setTimeToProceedQueries(10000);
 		CompletableFuture.runAsync(() -> contentAssistProcessor.computeCompletionProposals(viewer, 1));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -183,7 +183,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		item.setLabel("1024M");
 		item.setKind(CompletionItemKind.Value);
 		item.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(2, 10), new Position(2, 10)), "1024M")));
-		final var completionList = new CompletionList(false, Collections.singletonList(item));
+		final var completionList = new CompletionList(false, List.of(item));
 		MockLanguageServer.INSTANCE.setCompletionList(completionList);
 
 		final var content = "applications:\n" + "- name: hello\n" + "  memory: ";
@@ -226,8 +226,8 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testApplyCompletionWithPrefix() throws CoreException {
 		final var range = new Range(new Position(0, 0), new Position(0, 5));
-		List<CompletionItem> items = Collections
-				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
+		List<CompletionItem> items = List
+				.of(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
 		final var content = "First";
@@ -243,8 +243,8 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testApplyCompletionReplace() throws CoreException {
 		final var range = new Range(new Position(0, 0), new Position(0, 20));
-		List<CompletionItem> items = Collections
-				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
+		List<CompletionItem> items = List
+				.of(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
 		final var content = "FirstNotMatchedLabel";
@@ -259,8 +259,8 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testApplyCompletionReplaceAndTypingWithTextEdit() throws CoreException, BadLocationException {
 		final var range = new Range(new Position(0, 0), new Position(0, 20));
-		List<CompletionItem> items = Collections
-				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
+		List<CompletionItem> items = List
+				.of(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
 
 		final var content = "FirstNotMatchedLabel";
@@ -284,7 +284,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("strncasecmp()");
 
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false,  Collections.singletonList(item)));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false,  List.of(item)));
 
 		final var content = "str";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
@@ -306,7 +306,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	public void testCompletionReplace() throws CoreException {
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(
 			createCompletionItem("Inserted", CompletionItemKind.Text, new Range(new Position(1, 4), new Position(1, 4 + "InsertHere".length())))
 		)));
 
@@ -350,7 +350,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	public void testBasicSnippet() throws CoreException {
 		CompletionItem completionItem = createCompletionItem("$1 and ${2:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(completionItem)));
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,""));
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
@@ -364,7 +364,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	public void testChoiceSnippet() throws CoreException {
 		CompletionItem completionItem = createCompletionItem("1${1|a,b|}2", CompletionItemKind.Class);
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(completionItem)));
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,""));
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
@@ -384,7 +384,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 	public void testDuplicateVariable() throws CoreException {
 		CompletionItem completionItem = createCompletionItem("${1:foo} and ${1:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(completionItem)));
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,""));
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
@@ -427,7 +427,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 					new Range(new Position(0, 0), new Position(0, 1))
 			);
 			completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
-			MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
+			MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(completionItem)));
 			ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,""));
 			int invokeOffset = 0;
 			ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
@@ -446,7 +446,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 				new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
-				.setCompletionList(new CompletionList(false, Collections.singletonList(completionItem)));
+				.setCompletionList(new CompletionList(false, List.of(completionItem)));
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, ""));
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -18,10 +18,9 @@ import static org.junit.Assert.*;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -200,9 +199,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testTriggerCharsWithoutPreliminaryCompletion() throws CoreException { // bug 508463
-		final var triggers = new HashSet<String>();
-		triggers.add("a");
-		triggers.add("b");
+		final Set<String> triggers = Set.of("a", "b");
 		MockLanguageServer.INSTANCE.setCompletionTriggerChars(triggers);
 
 		final var content = "First";
@@ -368,13 +365,13 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
 		assertEquals(1, proposals.length);
-		final var beforeShells = new HashSet<>(List.of(viewer.getTextWidget().getDisplay().getShells()));
+		final var shellsBefore = Set.of(viewer.getTextWidget().getDisplay().getShells());
 		((LSCompletionProposal) proposals[0]).apply(viewer, '\n', 0, invokeOffset);
 		assertEquals("1a2", viewer.getDocument().get());
-		final var newShells = new HashSet<>(List.of(viewer.getTextWidget().getDisplay().getShells()));
-		newShells.removeAll(beforeShells);
-		assertNotEquals(Collections.emptySet(), newShells);
-		final var proposalList = (Table) newShells.iterator().next().getChildren()[0];
+		final var shellsAfter = Set.of(viewer.getTextWidget().getDisplay().getShells());
+		final var shellsAdded = shellsAfter.stream().filter(shell -> !shellsBefore.contains(shell)).toList();
+		assertFalse(shellsAdded.isEmpty());
+		final var proposalList = (Table) shellsAdded.iterator().next().getChildren()[0];
 		String[] itemLabels = Arrays.stream(proposalList.getItems()).map(TableItem::getText).toArray(String[]::new);
 		assertArrayEquals(new String[] {"a", "b"}, itemLabels);
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompletionOrderingTests.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompletionOrderingTests.java
@@ -11,11 +11,9 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.completion;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.IDocument;
@@ -45,8 +43,8 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 	@Test
 	public void testOrderByCategory() throws Exception {
 		// Category 1 before Category 2 (testa)
-		String[] completions = new String[] { "testa", "test.a", "a.test.a", "a.testa", "test" };
-		String[] orderedResults = new String[] { "test", "testa", "a.testa", "test.a", "a.test.a" };
+		var completions = new String[] { "testa", "test.a", "a.test.a", "a.testa", "test" };
+		var orderedResults = new String[] { "test", "testa", "a.testa", "test.a", "a.test.a" };
 		confirmCompletionResults(completions, "test", 4, orderedResults);
 
 		// Category 2 before Category 3 (atest)
@@ -68,8 +66,8 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 	@Test
 	public void testOrderByRank() throws Exception {
 		// Category 1
-		String[] completions = new String[] { "prefix.test", "alongprefix.test", "test", "test.test", "pretest.test" };
-		String[] orderedResults = new String[] { "test", "test.test", "pretest.test", "prefix.test",
+		var completions = new String[] { "prefix.test", "alongprefix.test", "test", "test.test", "pretest.test" };
+		var orderedResults = new String[] { "test", "test.test", "pretest.test", "prefix.test",
 				"alongprefix.test" };
 		confirmCompletionResults(completions, "test", 4, orderedResults);
 
@@ -92,8 +90,8 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 	@Test
 	public void testOrderWithCapitalization() throws Exception {
 		// Category 1
-		String[] completions = new String[] { "prefiX.Test", "alongprefix.test", "tEsT", "teSt.teST", "preTEst.test" };
-		String[] orderedResults = new String[] { "tEsT", "teSt.teST", "preTEst.test", "prefiX.Test",
+		var completions = new String[] { "prefiX.Test", "alongprefix.test", "tEsT", "teSt.teST", "preTEst.test" };
+		var orderedResults = new String[] { "tEsT", "teSt.teST", "preTEst.test", "prefiX.Test",
 				"alongprefix.test" };
 		confirmCompletionResults(completions, "test", 4, orderedResults);
 
@@ -115,8 +113,8 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 
 	@Test
 	public void testOrderWithLongInsert() throws Exception {
-		List<CompletionItem> items = new ArrayList<>();
-		CompletionItem item = new CompletionItem("server.address");
+		var items = new ArrayList<CompletionItem>();
+		var item = new CompletionItem("server.address");
 		item.setFilterText("server.address");
 		item.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(1, 12), new Position(5, 7)),
 						"  address: $1\n" +
@@ -138,7 +136,7 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 		item.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(5, 0), new Position(0, 12)),item.getFilterText())));
 		items.add(item);
 
-		String[] orderedResults = new String[] { "server.address", "management.server.address",
+		final var orderedResults = new String[] { "server.address", "management.server.address",
 				"→ spring.jta.atomikos.datasource.xa-data-source-class-name" };
 
 		confirmCompletionResults(items,
@@ -153,7 +151,7 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 
 	@Test
 	public void testMovingOffset() throws Exception {
-		Range range = new Range(new Position(0, 0), new Position(0, 4));
+		final var range = new Range(new Position(0, 0), new Position(0, 4));
 		IFile testFile = TestUtils.createUniqueTestFile(project, "test");
 		IDocument document = TestUtils.openTextViewer(testFile).getDocument();
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile,
@@ -162,7 +160,7 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 				.get(0);
 
 		CompletionItem completionItem = createCompletionItem("test", CompletionItemKind.Class, range);
-		LSCompletionProposal completionProposal = new LSCompletionProposal(document, 0,
+		var completionProposal = new LSCompletionProposal(document, 0,
 				completionItem, wrapper);
 		// Blank input ''
 		assertEquals("", completionProposal.getDocumentFilter());
@@ -196,8 +194,8 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 
 	@Test
 	public void testPerformance() throws Exception {
-		final int[] batchSizes = new int[] { 10, 100, 1000, 10000 };
-		int[] resultAverages = new int[batchSizes.length];
+		final var batchSizes = new int[] { 10, 100, 1000, 10000 };
+		final var resultAverages = new int[batchSizes.length];
 		final int repeat = 5;
 		final ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "abcdefgh"));
 
@@ -233,9 +231,9 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 		return denominator == 0 ? 0 : numerator / denominator;
 	}
 
-	private long timeToDisplayCompletionList(ITextViewer viewer, int size) throws Exception {
-		Range range = new Range(new Position(0, 0), new Position(0, 8));
-		List<CompletionItem> items = new ArrayList<>();
+	private long timeToDisplayCompletionList(ITextViewer viewer, int size) {
+		final var range = new Range(new Position(0, 0), new Position(0, 8));
+		final var items = new ArrayList<CompletionItem>();
 		for (int i = 0; i < size; i++) {
 			items.add(createCompletionItem(randomString(), CompletionItemKind.Class, range));
 		}
@@ -251,7 +249,7 @@ public class CompletionOrderingTests extends AbstractCompletionTest {
 
 	private String randomString() {
 		int count = 50;
-		StringBuilder builder = new StringBuilder();
+		final var builder = new StringBuilder();
 		while (count-- != 0) {
 			int character = (int) (Math.random() * CHARACTERS.length());
 			builder.append(CHARACTERS.charAt(character));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
@@ -51,8 +50,8 @@ public class ContextInformationTest extends AbstractCompletionTest {
 
 	@Test
 	public void testContextInformationNoParameters() throws CoreException {
-		SignatureHelp signatureHelp = new SignatureHelp();
-		SignatureInformation information = new SignatureInformation("label", "documentation", Collections.emptyList());
+		final var signatureHelp = new SignatureHelp();
+		final var information = new SignatureInformation("label", "documentation", Collections.emptyList());
 		signatureHelp.setSignatures(Collections.singletonList(information));
 		MockLanguageServer.INSTANCE.setSignatureHelp(signatureHelp);
 
@@ -70,12 +69,12 @@ public class ContextInformationTest extends AbstractCompletionTest {
 
 	@Test
 	public void testTriggerChars() throws CoreException {
-		Set<String> triggers = new HashSet<>();
+		final var triggers = new HashSet<String>();
 		triggers.add("a");
 		triggers.add("b");
 		MockLanguageServer.INSTANCE.setContextInformationTriggerChars(triggers);
 
-		String content = "First";
+		final var content = "First";
 		TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		assertArrayEquals(new char[] { 'a', 'b' },

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
@@ -14,8 +14,8 @@ package org.eclipse.lsp4e.test.completion;
 import static org.junit.Assert.*;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
@@ -70,9 +70,7 @@ public class ContextInformationTest extends AbstractCompletionTest {
 
 	@Test
 	public void testTriggerChars() throws CoreException {
-		final var triggers = new HashSet<String>();
-		triggers.add("a");
-		triggers.add("b");
+		final Set<String> triggers = Set.of("a", "b");
 		MockLanguageServer.INSTANCE.setContextInformationTriggerChars(triggers);
 
 		final var content = "First";

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
@@ -52,7 +53,7 @@ public class ContextInformationTest extends AbstractCompletionTest {
 	public void testContextInformationNoParameters() throws CoreException {
 		final var signatureHelp = new SignatureHelp();
 		final var information = new SignatureInformation("label", "documentation", Collections.emptyList());
-		signatureHelp.setSignatures(Collections.singletonList(information));
+		signatureHelp.setSignatures(List.of(information));
 		MockLanguageServer.INSTANCE.setSignatureHelp(signatureHelp);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "method()");

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
@@ -13,13 +13,9 @@
 package org.eclipse.lsp4e.test.completion;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,7 +52,6 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.Test;
@@ -68,8 +63,8 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	 * file-specific LS already associated is something we want to support.
 	 */
 	@Test
-	public void testAssistForUnknownButConnectedType() throws CoreException, IOException {
-		List<CompletionItem> items = new ArrayList<>();
+	public void testAssistForUnknownButConnectedType() throws CoreException {
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
@@ -88,7 +83,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(items.size(), proposals.length);
 		// TODO compare both structures
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 		assertEquals(new Point("FirstClass".length(), 0),
 				LSIncompleteCompletionProposal.getSelection(viewer.getDocument()));
@@ -96,7 +91,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testNoPrefix() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
@@ -106,7 +101,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(items.size(), proposals.length);
 		// TODO compare both structures
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 		assertEquals(new Point("FirstClass".length(), 0),
 				LSIncompleteCompletionProposal.getSelection(viewer.getDocument()));
@@ -116,19 +111,19 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	public void testDeprecatedCompletion() throws Exception {
 		BoldStylerProvider boldStyleProvider = null;
 		try {
-			List<CompletionItem> items = new ArrayList<>();
+			final var items = new ArrayList<CompletionItem>();
 			CompletionItem completionItem = createCompletionItem("FirstClassDeprecated", CompletionItemKind.Class);
 			completionItem.setDeprecated(true);
 			items.add(completionItem);
 			MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-			String content = "First";
+			final var content = "First";
 			ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 			ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer,
 					content.length());
 			assertEquals(1, proposals.length);
-			LSCompletionProposal proposal = (LSCompletionProposal) proposals[0];
+			final var proposal = (LSCompletionProposal) proposals[0];
 
 			StyledString simpleStyledStr = proposal.getStyledDisplayString();
 			assertEquals("FirstClassDeprecated", simpleStyledStr.getString());
@@ -151,18 +146,18 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testPrefix() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		items.add(createCompletionItem("SecondClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "First";
+		final var content = "First";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
 		assertEquals(1, proposals.length);
 		// TODO compare items
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 		assertEquals(new Point("FirstClass".length(), 0),
 				LSIncompleteCompletionProposal.getSelection(viewer.getDocument()));
@@ -170,17 +165,17 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testPrefixCaseSensitivity() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "FIRST";
+		final var content = "FIRST";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
 		assertEquals(1, proposals.length);
 		// TODO compare items
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 		assertEquals(new Point("FirstClass".length(), 0),
 				LSIncompleteCompletionProposal.getSelection(viewer.getDocument()));
@@ -188,20 +183,20 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testCompleteOnFileEnd() throws CoreException { // bug 508842
-		CompletionItem item = new CompletionItem();
+		final var item = new CompletionItem();
 		item.setLabel("1024M");
 		item.setKind(CompletionItemKind.Value);
 		item.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(2, 10), new Position(2, 10)), "1024M")));
-		CompletionList completionList = new CompletionList(true, Collections.singletonList(item));
+		final var completionList = new CompletionList(true, Collections.singletonList(item));
 		MockLanguageServer.INSTANCE.setCompletionList(completionList);
 
-		String content = "applications:\n" + "- name: hello\n" + "  memory: ";
+		final var content = "applications:\n" + "- name: hello\n" + "  memory: ";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
 		assertEquals(1, proposals.length);
 
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 		assertEquals(content + "1024M", viewer.getDocument().get());
 		assertEquals(new Point(viewer.getDocument().getLength(), 0),
@@ -210,15 +205,15 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testCompletionWithAdditionalEditsBeforeOffsetInSameLine() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
-		CompletionItem item = new CompletionItem("additionaEditsCompletion");
+		final var items = new ArrayList<CompletionItem>();
+		final var item = new CompletionItem("additionaEditsCompletion");
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("MainInsertText");
 
-		List<TextEdit> additionalTextEdits = new ArrayList<>();
+		final var additionalTextEdits = new ArrayList<TextEdit>();
 
-		TextEdit additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
-		TextEdit additionaEdit2 = new TextEdit(new Range(new Position(0, 12), new Position(0, 12)), "addOnText2");
+		final var additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
+		final var additionaEdit2 = new TextEdit(new Range(new Position(0, 12), new Position(0, 12)), "addOnText2");
 		additionalTextEdits.add(additionaEdit1);
 		additionalTextEdits.add(additionaEdit2);
 
@@ -226,14 +221,14 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		items.add(item);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "this <> is <> the main <> content of the file";
+		final var content = "this <> is <> the main <> content of the file";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 24);
 		assertEquals(items.size(), proposals.length);
 		// TODO compare both structures
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 
 		String newContent = viewer.getDocument().get();
@@ -242,15 +237,15 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testCompletionWithAdditionalEditsBeforeAndAfterOffsetInSameLine() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
-		CompletionItem item = new CompletionItem("additionaEditsCompletion");
+		final var items = new ArrayList<CompletionItem>();
+		final var item = new CompletionItem("additionaEditsCompletion");
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("MainInsertText");
 
-		List<TextEdit> additionalTextEdits = new ArrayList<>();
+		final var additionalTextEdits = new ArrayList<TextEdit>();
 
-		TextEdit additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
-		TextEdit additionaEdit2 = new TextEdit(new Range(new Position(0, 24), new Position(0, 24)), "addOnText2");
+		final var additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
+		final var additionaEdit2 = new TextEdit(new Range(new Position(0, 24), new Position(0, 24)), "addOnText2");
 		additionalTextEdits.add(additionaEdit1);
 		additionalTextEdits.add(additionaEdit2);
 
@@ -258,14 +253,14 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		items.add(item);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "this <> is <> the main <> content of the file";
+		final var content = "this <> is <> the main <> content of the file";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 12);
 		assertEquals(items.size(), proposals.length);
 		// TODO compare both structures
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 
 		String newContent = viewer.getDocument().get();
@@ -274,16 +269,16 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testCompletionWithAdditionalEditsBeforeAndAfterOffsetInVariousLines() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
-		CompletionItem item = new CompletionItem("additionaEditsCompletion");
+		final var items = new ArrayList<CompletionItem>();
+		final var item = new CompletionItem("additionaEditsCompletion");
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("MainInsertText");
 
-		List<TextEdit> additionalTextEdits = new ArrayList<>();
+		final var additionalTextEdits = new ArrayList<TextEdit>();
 
-		TextEdit additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
-		TextEdit additionaEdit2 = new TextEdit(new Range(new Position(0, 24), new Position(0, 24)), "addOnText2");
-		TextEdit additionaEdit3 = new TextEdit(new Range(new Position(1, 9), new Position(1, 9)), "addOnText3");
+		final var additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
+		final var additionaEdit2 = new TextEdit(new Range(new Position(0, 24), new Position(0, 24)), "addOnText2");
+		final var additionaEdit3 = new TextEdit(new Range(new Position(1, 9), new Position(1, 9)), "addOnText3");
 		additionalTextEdits.add(additionaEdit1);
 		additionalTextEdits.add(additionaEdit2);
 		additionalTextEdits.add(additionaEdit3);
@@ -292,14 +287,14 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		items.add(item);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "this <> is <> the main <> content of the file\nthis is <> the second line";
+		final var content = "this <> is <> the main <> content of the file\nthis is <> the second line";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 12);
 		assertEquals(items.size(), proposals.length);
 		// TODO compare both structures
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 
 		String newContent = viewer.getDocument().get();
@@ -308,16 +303,16 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testCompletionWithAdditionalEditsBeforeAndAfterOffsetInVariousLinesAndTypedText() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
-		CompletionItem item = new CompletionItem("additionaEditsCompletion");
+		final var items = new ArrayList<CompletionItem>();
+		final var item = new CompletionItem("additionaEditsCompletion");
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("MainInsertText");
 
-		List<TextEdit> additionalTextEdits = new ArrayList<>();
+		final var additionalTextEdits = new ArrayList<TextEdit>();
 
-		TextEdit additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
-		TextEdit additionaEdit2 = new TextEdit(new Range(new Position(0, 24), new Position(0, 24)), "addOnText2");
-		TextEdit additionaEdit3 = new TextEdit(new Range(new Position(1, 9), new Position(1, 9)), "addOnText3");
+		final var additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
+		final var additionaEdit2 = new TextEdit(new Range(new Position(0, 24), new Position(0, 24)), "addOnText2");
+		final var additionaEdit3 = new TextEdit(new Range(new Position(1, 9), new Position(1, 9)), "addOnText3");
 		additionalTextEdits.add(additionaEdit1);
 		additionalTextEdits.add(additionaEdit2);
 		additionalTextEdits.add(additionaEdit3);
@@ -326,14 +321,14 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		items.add(item);
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "this <> is <Main> the main <> content of the file\nthis is <> the second line";
+		final var content = "this <> is <Main> the main <> content of the file\nthis is <> the second line";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 12);
 		assertEquals(items.size(), proposals.length);
 		// TODO compare both structures
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument(), Character.MIN_VALUE, 16);
 
 		String newContent = viewer.getDocument().get();
@@ -341,16 +336,15 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testSnippetCompletionWithAdditionalEdits()
-			throws PartInitException, CoreException {
-		CompletionItem item = new CompletionItem("snippet item");
+	public void testSnippetCompletionWithAdditionalEdits() throws CoreException {
+		final var item = new CompletionItem("snippet item");
 		item.setInsertText("$1 and ${2:foo}");
 		item.setKind(CompletionItemKind.Class);
 		item.setInsertTextFormat(InsertTextFormat.Snippet);
-		List<TextEdit> additionalTextEdits = new ArrayList<>();
+		final var additionalTextEdits = new ArrayList<TextEdit>();
 
-		TextEdit additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
-		TextEdit additionaEdit2 = new TextEdit(new Range(new Position(0, 12), new Position(0, 12)), "addOnText2");
+		final var additionaEdit1 = new TextEdit(new Range(new Position(0, 6), new Position(0, 6)), "addOnText1");
+		final var additionaEdit2 = new TextEdit(new Range(new Position(0, 12), new Position(0, 12)), "addOnText2");
 		additionalTextEdits.add(additionaEdit1);
 		additionalTextEdits.add(additionaEdit2);
 
@@ -358,7 +352,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, Collections.singletonList(item)));
 
-		String content = "this <> is <> the main <> content of the file";
+		final var content = "this <> is <> the main <> content of the file";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 24);
@@ -372,16 +366,16 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testApplyCompletionWithPrefix() throws CoreException {
-		Range range = new Range(new Position(0, 0), new Position(0, 5));
+		final var range = new Range(new Position(0, 0), new Position(0, 5));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "First";
+		final var content = "First";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 		assertEquals(true, viewer.getDocument().get().equals("FirstClass"));
 		assertEquals(new Point(viewer.getDocument().getLength(), 0),
@@ -390,15 +384,15 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testApplyCompletionReplace() throws CoreException {
-		Range range = new Range(new Position(0, 0), new Position(0, 20));
+		final var range = new Range(new Position(0, 0), new Position(0, 20));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "FirstNotMatchedLabel";
+		final var content = "FirstNotMatchedLabel";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 5);
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 		assertEquals("FirstClass", viewer.getDocument().get());
 		assertEquals(new Point("FirstClass".length(), 0),
@@ -407,17 +401,17 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testApplyCompletionReplaceAndTypingWithTextEdit() throws CoreException, BadLocationException {
-		Range range = new Range(new Position(0, 0), new Position(0, 22));
+		final var range = new Range(new Position(0, 0), new Position(0, 22));
 		List<CompletionItem> items = Collections
 				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "FirstNotMatchedLabel";
+		final var content = "FirstNotMatchedLabel";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,content));
 
 		int invokeOffset = 5;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 
 		// simulate additional typing (to filter) after invoking completion
 		viewer.getDocument().replace(5, 0, "No");
@@ -430,19 +424,19 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testApplyCompletionReplaceAndTyping() throws CoreException, BadLocationException {
-		CompletionItem item = new CompletionItem("strncasecmp");
+		final var item = new CompletionItem("strncasecmp");
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("strncasecmp()");
 
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, Collections.singletonList(item)));
 
-		String content = "str";
+		final var content = "str";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
 
 		int invokeOffset = content.length();
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
 		assertEquals(1, proposals.length);
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 
 		// simulate additional typing (to filter) after invoking completion
 		viewer.getDocument().replace(content.length(), 0, "nc");
@@ -463,7 +457,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 		int invokeOffset = viewer.getDocument().getLength() - "InsertHere".length();
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 		LSIncompleteCompletionProposal.apply(viewer.getDocument());
 		assertEquals("line1\nlineInserted", viewer.getDocument().get());
 		assertEquals(new Point(viewer.getDocument().getLength(), 0),
@@ -472,7 +466,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testItemOrdering() throws Exception {
-		Range range = new Range(new Position(0, 0), new Position(0, 1));
+		final var range = new Range(new Position(0, 0), new Position(0, 1));
 		List<CompletionItem> items = Arrays.asList(new CompletionItem[] {
 			createCompletionItem("AA", CompletionItemKind.Class, range),
 			createCompletionItem("AB", CompletionItemKind.Class, range),
@@ -483,7 +477,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		});
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		String content = "B";
+		final var content = "B";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,content));
 
 		int invokeOffset = 1;
@@ -499,7 +493,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testBasicSnippet() throws PartInitException, CoreException {
+	public void testBasicSnippet() throws CoreException {
 		CompletionItem completionItem = createCompletionItem("$1 and ${2:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
@@ -515,7 +509,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testMultipleLS() throws Exception {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
@@ -537,7 +531,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 						new Position(1, "<tag>".length()),
 						new Position(1,  "<tag>".length() + "tag".length())));
 		// Set additional TExtEdits on the item
-		List<TextEdit> additionalEdits = new ArrayList<>(2);
+		final var additionalEdits = new ArrayList<TextEdit>(2);
 		// Prefix to be inserted to the end of line that precedes the line to be "completed"
 		additionalEdits.add(new TextEdit(new Range(
 				new Position(1, 0),
@@ -555,13 +549,13 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		String text = viewer.getDocument().get();
 		int invokeOffset = text.indexOf("<tag>tag") + "<tag>tag".length();
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
-		LSCompletionProposal LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
+		final var LSIncompleteCompletionProposal = (LSCompletionProposal) proposals[0];
 
 		// Apply the proposal using an offset shifted by 4 chars, thus emulating a user typed character after the CA invocation
 		int currentOffset = invokeOffset + "Text".length(); // Emulate 1 character typed in after CA invocation
 		LSIncompleteCompletionProposal.apply(viewer.getDocument(), Character.MIN_VALUE, currentOffset);
 
-		final String expectedText = "Some Text Before\n"
+		final var expectedText = "Some Text Before\n"
 				+ "<prefix>prefixText</prefix>\n"
 				+ "<tag>tagText</tag>\n"
 				+ "<postfix>postfixText</postfix>\n"
@@ -573,12 +567,12 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 	@Test
 	public void testCompletionExternalFile() throws Exception {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClassExternal", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
 		File file = TestUtils.createTempFile("testCompletionExternalFile", ".lspt");
-		ITextEditor editor = (ITextEditor) IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+		final var editor = (ITextEditor) IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(1, proposals.length);
@@ -593,7 +587,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile, capabilities -> capabilities.getCompletionProvider() != null
 						|| capabilities.getSignatureHelpProvider() != null)
 				.get(0);
-		LSCompletionProposal completionProposal = new LSCompletionProposal(document, 0,
+		final var completionProposal = new LSCompletionProposal(document, 0,
 				new CompletionItem("blah"), wrapper);
 		completionProposal.getAdditionalProposalInfo(new NullProgressMonitor()); // check no exception is sent
 	}
@@ -605,9 +599,9 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile, capabilities -> capabilities.getCompletionProvider() != null
 						|| capabilities.getSignatureHelpProvider() != null)
 				.get(0);
-		CompletionItem item = new CompletionItem("blah");
+		final var item = new CompletionItem("blah");
 		item.setDetail("");
-		LSCompletionProposal completionProposal = new LSCompletionProposal(document, 0,
+		final var completionProposal = new LSCompletionProposal(document, 0,
 				item, wrapper);
 		String addInfo = completionProposal.getAdditionalProposalInfo(new NullProgressMonitor()); // check no exception is sent
 		assertTrue(addInfo.isEmpty());
@@ -620,9 +614,9 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile, capabilities -> capabilities.getCompletionProvider() != null
 						|| capabilities.getSignatureHelpProvider() != null)
 				.get(0);
-		CompletionItem item = new CompletionItem("blah");
+		final var item = new CompletionItem("blah");
 		item.setDetail("detail");
-		LSCompletionProposal completionProposal = new LSCompletionProposal(document, 0,
+		final var completionProposal = new LSCompletionProposal(document, 0,
 				item, wrapper);
 		String addInfo = completionProposal.getAdditionalProposalInfo(new NullProgressMonitor()); // check no exception is sent
 		assertTrue(addInfo.indexOf("<p>detail</p>") >= 0);
@@ -635,9 +629,9 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile, capabilities -> capabilities.getCompletionProvider() != null
 						|| capabilities.getSignatureHelpProvider() != null)
 				.get(0);
-		CompletionItem item = new CompletionItem("blah");
+		final var item = new CompletionItem("blah");
 		item.setDocumentation("");
-		LSCompletionProposal completionProposal = new LSCompletionProposal(document, 0,
+		final var completionProposal = new LSCompletionProposal(document, 0,
 				item, wrapper);
 		String addInfo = completionProposal.getAdditionalProposalInfo(new NullProgressMonitor()); // check no exception is sent
 		assertTrue(addInfo.isEmpty());
@@ -650,17 +644,17 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile, capabilities -> capabilities.getCompletionProvider() != null
 						|| capabilities.getSignatureHelpProvider() != null)
 				.get(0);
-		CompletionItem item = new CompletionItem("blah");
+		final var item = new CompletionItem("blah");
 		item.setDocumentation("documentation");
-		LSCompletionProposal completionProposal = new LSCompletionProposal(document, 0,
+		final var completionProposal = new LSCompletionProposal(document, 0,
 				item, wrapper);
 		String addInfo = completionProposal.getAdditionalProposalInfo(new NullProgressMonitor()); // check no exception is sent
 		assertFalse(addInfo.isEmpty());
 	}
-	
+
 	@Test
 	public void testIncompleteIndication() throws CoreException {
-		List<CompletionItem> items = new ArrayList<>();
+		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClass", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
@@ -672,7 +666,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		assertEquals(1, proposals.length);
 
 		// with incomplete indication
-		LSContentAssistProcessor incompleIndicatingProcessor = new LSContentAssistProcessor(true, true);
+		final var incompleIndicatingProcessor = new LSContentAssistProcessor(true, true);
 		ICompletionProposal[] proposalsWithIncompleteProposal = incompleIndicatingProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(2, proposalsWithIncompleteProposal.length);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.filesystem.EFS;
@@ -466,14 +465,13 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testItemOrdering() throws Exception {
 		final var range = new Range(new Position(0, 0), new Position(0, 1));
-		List<CompletionItem> items = Arrays.asList(new CompletionItem[] {
-			createCompletionItem("AA", CompletionItemKind.Class, range),
-			createCompletionItem("AB", CompletionItemKind.Class, range),
-			createCompletionItem("BA", CompletionItemKind.Class, range),
-			createCompletionItem("BB", CompletionItemKind.Class, range),
-			createCompletionItem("CB", CompletionItemKind.Class, range),
-			createCompletionItem("CC", CompletionItemKind.Class, range),
-		});
+		List<CompletionItem> items = List.of( //
+				createCompletionItem("AA", CompletionItemKind.Class, range),
+				createCompletionItem("AB", CompletionItemKind.Class, range),
+				createCompletionItem("BA", CompletionItemKind.Class, range),
+				createCompletionItem("BB", CompletionItemKind.Class, range),
+				createCompletionItem("CB", CompletionItemKind.Class, range),
+				createCompletionItem("CC", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
 		final var content = "B";

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.filesystem.EFS;
@@ -187,7 +186,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		item.setLabel("1024M");
 		item.setKind(CompletionItemKind.Value);
 		item.setTextEdit(Either.forLeft(new TextEdit(new Range(new Position(2, 10), new Position(2, 10)), "1024M")));
-		final var completionList = new CompletionList(true, Collections.singletonList(item));
+		final var completionList = new CompletionList(true, List.of(item));
 		MockLanguageServer.INSTANCE.setCompletionList(completionList);
 
 		final var content = "applications:\n" + "- name: hello\n" + "  memory: ";
@@ -350,7 +349,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 
 		item.setAdditionalTextEdits(additionalTextEdits);
 
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, Collections.singletonList(item)));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, List.of(item)));
 
 		final var content = "this <> is <> the main <> content of the file";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
@@ -367,8 +366,8 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testApplyCompletionWithPrefix() throws CoreException {
 		final var range = new Range(new Position(0, 0), new Position(0, 5));
-		List<CompletionItem> items = Collections
-				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
+		List<CompletionItem> items = List
+				.of(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
 		final var content = "First";
@@ -385,8 +384,8 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testApplyCompletionReplace() throws CoreException {
 		final var range = new Range(new Position(0, 0), new Position(0, 20));
-		List<CompletionItem> items = Collections
-				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
+		List<CompletionItem> items = List
+				.of(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
 		final var content = "FirstNotMatchedLabel";
@@ -402,8 +401,8 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	@Test
 	public void testApplyCompletionReplaceAndTypingWithTextEdit() throws CoreException, BadLocationException {
 		final var range = new Range(new Position(0, 0), new Position(0, 22));
-		List<CompletionItem> items = Collections
-				.singletonList(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
+		List<CompletionItem> items = List
+				.of(createCompletionItem("FirstClass", CompletionItemKind.Class, range));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
 		final var content = "FirstNotMatchedLabel";
@@ -428,7 +427,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		item.setKind(CompletionItemKind.Function);
 		item.setInsertText("strncasecmp()");
 
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, Collections.singletonList(item)));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, List.of(item)));
 
 		final var content = "str";
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
@@ -451,7 +450,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	public void testCompletionReplace() throws CoreException {
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, Collections.singletonList(
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, List.of(
 			createCompletionItem("Inserted", CompletionItemKind.Text, new Range(new Position(1, 4), new Position(1, 4 + "InsertHere".length())))
 		)));
 
@@ -497,7 +496,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 		CompletionItem completionItem = createCompletionItem("$1 and ${2:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
-				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+				.setCompletionList(new CompletionList(true, List.of(completionItem)));
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,""));
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
@@ -544,7 +543,7 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 				"\n<postfix>postfixText</postfix>"));
 		item.setAdditionalTextEdits(additionalEdits);
 
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, Collections.singletonList(item)));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, List.of(item)));
 
 		String text = viewer.getDocument().get();
 		int invokeOffset = text.indexOf("<tag>tag") + "<tag>tag".length();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/InsertReplaceCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/InsertReplaceCompletionTest.java
@@ -49,7 +49,7 @@ public class InsertReplaceCompletionTest extends AbstractCompletionTest {
 
 		int invokeOffset = viewer.getDocument().getLength() - "InsertHere".length();
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
-		LSCompletionProposal lsCompletionProposal = (LSCompletionProposal)proposals[0];
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, invokeOffset);
 		assertEquals("line1\nlineInserted", viewer.getDocument().get());
 		assertEquals(new Point(viewer.getDocument().getLength(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/InsertReplaceCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/InsertReplaceCompletionTest.java
@@ -18,7 +18,7 @@ package org.eclipse.lsp4e.test.completion;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.ITextViewer;
@@ -39,7 +39,7 @@ public class InsertReplaceCompletionTest extends AbstractCompletionTest {
 	public void testInsert() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
-		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, Collections.singletonList(
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(
 			createCompletionItemWithInsertReplace(
 					"Inserted",
 					CompletionItemKind.Text,

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/VariableReplacementTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/VariableReplacementTest.java
@@ -53,7 +53,7 @@ public class VariableReplacementTest extends AbstractCompletionTest {
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
 				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
-		String content = "line1\nline2\nline3";
+		final var content = "line1\nline2\nline3";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		int invokeOffset = 0;
@@ -78,7 +78,7 @@ public class VariableReplacementTest extends AbstractCompletionTest {
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
 				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
-		String content = "line1\nline2\nline3";
+		final var content = "line1\nline2\nline3";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		int invokeOffset = 0;
@@ -90,7 +90,7 @@ public class VariableReplacementTest extends AbstractCompletionTest {
 		assertEquals(fileNameBase + "ine1\nline2\nline3", viewer.getDocument().get());
 		// TODO check link edit groups
 	}
-	
+
 	@Test
 	public void testVariableNameWithBraces() throws PartInitException, CoreException {
 		CompletionItem completionItem = createCompletionItem(
@@ -99,7 +99,7 @@ public class VariableReplacementTest extends AbstractCompletionTest {
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
 				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
-		String content = "line1\nline2\nline3";
+		final var content = "line1\nline2\nline3";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		int invokeOffset = 0;

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/VariableReplacementTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/VariableReplacementTest.java
@@ -10,7 +10,7 @@ package org.eclipse.lsp4e.test.completion;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
@@ -35,7 +35,7 @@ public class VariableReplacementTest extends AbstractCompletionTest {
 		CompletionItem completionItem = createCompletionItem("${1:foo} and ${1:foo}", CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
-				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+				.setCompletionList(new CompletionList(true, List.of(completionItem)));
 		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project,""));
 		int invokeOffset = 0;
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
@@ -52,7 +52,7 @@ public class VariableReplacementTest extends AbstractCompletionTest {
 				CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
-				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+				.setCompletionList(new CompletionList(true, List.of(completionItem)));
 		final var content = "line1\nline2\nline3";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
@@ -77,7 +77,7 @@ public class VariableReplacementTest extends AbstractCompletionTest {
 				CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
-				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+				.setCompletionList(new CompletionList(true, List.of(completionItem)));
 		final var content = "line1\nline2\nline3";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
@@ -98,7 +98,7 @@ public class VariableReplacementTest extends AbstractCompletionTest {
 				CompletionItemKind.Class, new Range(new Position(0, 0), new Position(0, 1)));
 		completionItem.setInsertTextFormat(InsertTextFormat.Snippet);
 		MockLanguageServer.INSTANCE
-				.setCompletionList(new CompletionList(true, Collections.singletonList(completionItem)));
+				.setCompletionList(new CompletionList(true, List.of(completionItem)));
 		final var content = "line1\nline2\nline3";
 		IFile testFile = TestUtils.createUniqueTestFile(project, content);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/debug/debugmodel/JsonParserWithStringSubstitutionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/debug/debugmodel/JsonParserWithStringSubstitutionTest.java
@@ -132,8 +132,8 @@ public class JsonParserWithStringSubstitutionTest extends AbstractTest {
 	 */
 	@Test(expected = IllegalStateException.class)
 	public void testThrowsIllegaStateException() throws IllegalStateException, CoreException {
-		String json = "[\"value1\", \"value2\", \"value3\"]";
-		JsonParserWithStringSubstitution jsonParser = new JsonParserWithStringSubstitution(new StringVariableManagerMock());
+		final var json = "[\"value1\", \"value2\", \"value3\"]";
+		final var jsonParser = new JsonParserWithStringSubstitution(new StringVariableManagerMock());
 		jsonParser.parseJsonObject(json);
 	}
 
@@ -146,9 +146,9 @@ public class JsonParserWithStringSubstitutionTest extends AbstractTest {
 	 */
 	@Test(expected = CoreException.class)
 	public void testThrowsCoreException() throws IllegalStateException, CoreException {
-		String json = "{\"key\":\"unknown_variable\"}";
-		StringVariableManagerMock stringVariableManager = new StringVariableManagerMock("Test", "Test");
-		JsonParserWithStringSubstitution jsonParser = new JsonParserWithStringSubstitution(stringVariableManager);
+		final var json = "{\"key\":\"unknown_variable\"}";
+		final var stringVariableManager = new StringVariableManagerMock("Test", "Test");
+		final var jsonParser = new JsonParserWithStringSubstitution(stringVariableManager);
 		jsonParser.parseJsonObject(json);
 	}
 
@@ -158,18 +158,18 @@ public class JsonParserWithStringSubstitutionTest extends AbstractTest {
 	@Test
 	public void testSubstituteVariableInJsonObject() throws IllegalStateException, CoreException {
 		// # SETUP #
-		String key = "key";
-		String variableReference = "variableReference";
-		String variableReplacement = "variableReplacement";
- 		String json = "{\"" + key + "\":\"" + variableReference + "\"}";
-		StringVariableManagerMock stringVariableManager = new StringVariableManagerMock(variableReference, variableReplacement);
-		JsonParserWithStringSubstitution jsonParser = new JsonParserWithStringSubstitution(stringVariableManager);
+		final var key = "key";
+		final var variableReference = "variableReference";
+		final var variableReplacement = "variableReplacement";
+		final var json = "{\"" + key + "\":\"" + variableReference + "\"}";
+		final var stringVariableManager = new StringVariableManagerMock(variableReference, variableReplacement);
+		final var jsonParser = new JsonParserWithStringSubstitution(stringVariableManager);
 
 		// # TEST #
 		Map<String, Object> parsedJson = jsonParser.parseJsonObject(json);
 
 		// # ASSERT #
-		String resultValue = (String) parsedJson.get(key);
+		final var resultValue = (String) parsedJson.get(key);
 		assertEquals(variableReplacement, resultValue);
 	}
 
@@ -179,20 +179,20 @@ public class JsonParserWithStringSubstitutionTest extends AbstractTest {
 	@Test
 	public void testSubstituteVariableInJsonObjectWithArray() throws IllegalStateException, CoreException {
 		// # SETUP #
-		String key = "key";
-		String variableReference = "variableReference";
-		String variableReplacement = "variableReplacement";
- 		String json = "{\"" + key + "\":[\"" + variableReference + "\"]}";
-		StringVariableManagerMock stringVariableManager = new StringVariableManagerMock(variableReference, variableReplacement);
-		JsonParserWithStringSubstitution jsonParser = new JsonParserWithStringSubstitution(stringVariableManager);
+		final var key = "key";
+		final var variableReference = "variableReference";
+		final var variableReplacement = "variableReplacement";
+		final var json = "{\"" + key + "\":[\"" + variableReference + "\"]}";
+		final var stringVariableManager = new StringVariableManagerMock(variableReference, variableReplacement);
+		final var jsonParser = new JsonParserWithStringSubstitution(stringVariableManager);
 
 		// # TEST #
 		Map<String, Object> parsedJson = jsonParser.parseJsonObject(json);
 
 		// # ASSERT #
 		@SuppressWarnings("unchecked")
-		ArrayList<Object> resultArray =  (ArrayList<Object>) parsedJson.get(key);
-		String resultValue = (String) resultArray.get(0);
+		final var resultArray =  (ArrayList<Object>) parsedJson.get(key);
+		final var resultValue = (String) resultArray.get(0);
 		assertEquals(variableReplacement, resultValue);
 	}
 
@@ -202,21 +202,21 @@ public class JsonParserWithStringSubstitutionTest extends AbstractTest {
 	@Test
 	public void testSubstituteVariableInJsonObjectInJsonObject() throws IllegalStateException, CoreException {
 		// # SETUP #
-		String key1 = "key1";
-		String key2 = "key2";
-		String variableReference = "variableReference";
-		String variableReplacement = "variableReplacement";
- 		String json = "{\"" + key1 + "\":{\"" + key2 + "\":\"" + variableReference + "\"}}";
-		StringVariableManagerMock stringVariableManager = new StringVariableManagerMock(variableReference, variableReplacement);
-		JsonParserWithStringSubstitution jsonParser = new JsonParserWithStringSubstitution(stringVariableManager);
+		final var key1 = "key1";
+		final var key2 = "key2";
+		final var variableReference = "variableReference";
+		final var variableReplacement = "variableReplacement";
+		final var json = "{\"" + key1 + "\":{\"" + key2 + "\":\"" + variableReference + "\"}}";
+ 		final var stringVariableManager = new StringVariableManagerMock(variableReference, variableReplacement);
+		final var jsonParser = new JsonParserWithStringSubstitution(stringVariableManager);
 
 		// # TEST #
 		Map<String, Object> parsedJson = jsonParser.parseJsonObject(json);
 
 		// # ASSERT #
 		@SuppressWarnings("unchecked")
-		Map<String, Object> secondObject =  (Map<String, Object>) parsedJson.get(key1);
-		String resultValue = (String) secondObject.get(key2);
+		final var secondObject =  (Map<String, Object>) parsedJson.get(key1);
+		final var resultValue = (String) secondObject.get(key2);
 		assertEquals(variableReplacement, resultValue);
 	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/declaration/LSBasedHyperlinkTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/declaration/LSBasedHyperlinkTest.java
@@ -33,17 +33,17 @@ public class LSBasedHyperlinkTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHyperlinkLabelNoLocation() {
-		Location location = new Location();
-		LSBasedHyperlink hyperlink = new LSBasedHyperlink(location, null, locationType);
+		final var location = new Location();
+		final var hyperlink = new LSBasedHyperlink(location, null, locationType);
 
 		assertEquals(locationType, hyperlink.getHyperlinkText());
 	}
 
 	@Test
 	public void testHyperlinkLabelForFileLocation() throws URISyntaxException {
-		Location location = new Location();
+		final var location = new Location();
 		location.setUri("file:///Users/someuser/testfile");
-		LSBasedHyperlink hyperlink = new LSBasedHyperlink(location, null, locationType);
+		final var hyperlink = new LSBasedHyperlink(location, null, locationType);
 
 		assertEquals("Open Declaration - testfile - " + Path.of(new URI(location.getUri())),
 				hyperlink.getHyperlinkText());
@@ -51,45 +51,45 @@ public class LSBasedHyperlinkTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHyperlinkLabelForFileLocationLink() throws URISyntaxException {
-		LocationLink location = new LocationLink();
+		final var location = new LocationLink();
 		location.setTargetUri("file:///Users/someuser/testfile");
-		LSBasedHyperlink hyperlink = new LSBasedHyperlink(location, null, locationType);
+		final var hyperlink = new LSBasedHyperlink(location, null, locationType);
 
 		assertEquals("Open Declaration - testfile - " + Path.of(new URI(location.getTargetUri())), hyperlink.getHyperlinkText());
 	}
 
 	@Test
 	public void testHyperlinkLabelForIntroBasedLocationWithoutLabel() {
-		Location location = new Location();
+		final var location = new Location();
 		location.setUri("http://org.eclipse.ui.intro/execute?command=mycommand%28bindingKey%3DLorg%2Ftest%2Fmvctest%2FMyComponent%3B%2CprojectName%3Dmvctest%29");
-		LSBasedHyperlink hyperlink = new LSBasedHyperlink(location, null, locationType);
+		final var hyperlink = new LSBasedHyperlink(location, null, locationType);
 
 		assertEquals("Open Declaration", hyperlink.getHyperlinkText());
 	}
 
 	@Test
 	public void testHyperlinkLabelForIntroBasedLocationLinkWithLabel() {
-		LocationLink location = new LocationLink();
+		final var location = new LocationLink();
 		location.setTargetUri("http://org.eclipse.ui.intro/execute?command=org.springframework.tooling.ls.eclipse.commons.commands.OpenJavaElementInEditor%28bindingKey%3DLorg%2Ftest%2Fmvctest%2FMyComponent%3B%2CprojectName%3Dmvctest%29&label=MyComponent+-+org.test.mvctest");
-		LSBasedHyperlink hyperlink = new LSBasedHyperlink(location, null, locationType);
+		final var hyperlink = new LSBasedHyperlink(location, null, locationType);
 
 		assertEquals("Open Declaration - MyComponent - org.test.mvctest", hyperlink.getHyperlinkText());
 	}
 
 	@Test
 	public void testHyperlinkLabelForRandomURLLocation() {
-		Location location = new Location();
+		final var location = new Location();
 		location.setUri("http://eclipse.org");
-		LSBasedHyperlink hyperlink = new LSBasedHyperlink(location, null, locationType);
+		final var hyperlink = new LSBasedHyperlink(location, null, locationType);
 
 		assertEquals("Open Declaration - http://eclipse.org", hyperlink.getHyperlinkText());
 	}
 
 	@Test
 	public void testHyperlinkLabelForRandomURLLocationLink() {
-		LocationLink location = new LocationLink();
+		final var location = new LocationLink();
 		location.setTargetUri("http://eclipse.org");
-		LSBasedHyperlink hyperlink = new LSBasedHyperlink(location, null, locationType);
+		final var hyperlink = new LSBasedHyperlink(location, null, locationType);
 
 		assertEquals("Open Declaration - http://eclipse.org", hyperlink.getHyperlinkText());
 	}
@@ -97,9 +97,9 @@ public class LSBasedHyperlinkTest extends AbstractTestWithProject {
 	@Test
 	public void testHyperlinkLabelForFileInProject() throws Exception {
 		IFile file = TestUtils.createFile(project, "my-test.txt", "Example Text");
-		LocationLink location = new LocationLink();
+		final var location = new LocationLink();
 		location.setTargetUri(LSPEclipseUtils.toUri(new File(file.getLocation().toOSString())).toASCIIString());
-		LSBasedHyperlink hyperlink = new LSBasedHyperlink(location, null, locationType);
+		final var hyperlink = new LSBasedHyperlink(location, null, locationType);
 
 		assertEquals("Open Declaration - my-test.txt - " + project.getName(), hyperlink.getHyperlinkText());
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,7 +49,7 @@ public class DefinitionTest extends AbstractTestWithProject {
 	@Test
 	public void testDefinitionOneLocation() throws Exception {
 		final var location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
-		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(location));
+		MockLanguageServer.INSTANCE.setDefinition(List.of(location));
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Example Text");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
@@ -61,9 +62,9 @@ public class DefinitionTest extends AbstractTestWithProject {
 	@Test
 	public void testDefinitionAndTypeDefinition() throws Exception {
 		final var definitionRange = new Range(new Position(0, 0), new Position(0, 1));
-		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(new Location("file://testDefinition", definitionRange)));
+		MockLanguageServer.INSTANCE.setDefinition(List.of(new Location("file://testDefinition", definitionRange)));
 		final var typeDefinitionRange = new Range(new Position(0, 2), new Position(0, 3));
-		MockLanguageServer.INSTANCE.setTypeDefinitions(Collections.singletonList(new LocationLink("file://testTypeDefinition", typeDefinitionRange, typeDefinitionRange)));
+		MockLanguageServer.INSTANCE.setTypeDefinitions(List.of(new LocationLink("file://testTypeDefinition", typeDefinitionRange, typeDefinitionRange)));
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Example Text");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
@@ -83,7 +84,7 @@ public class DefinitionTest extends AbstractTestWithProject {
 	@Test
 	public void testDefinitionOneLocationExternalFile() throws Exception {
 		final var location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
-		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(location));
+		MockLanguageServer.INSTANCE.setDefinition(List.of(location));
 
 		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
 		final var editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
@@ -134,7 +135,7 @@ public class DefinitionTest extends AbstractTestWithProject {
 	@Test
 	public void testReturnsPromptly() throws Exception {
 		final var location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
-		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(location));
+		MockLanguageServer.INSTANCE.setDefinition(List.of(location));
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Example Text");
 		ITextViewer viewer = TestUtils.openTextViewer(file);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,7 +47,7 @@ public class DefinitionTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDefinitionOneLocation() throws Exception {
-		Location location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
+		final var location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(location));
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Example Text");
@@ -61,9 +60,9 @@ public class DefinitionTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDefinitionAndTypeDefinition() throws Exception {
-		Range definitionRange = new Range(new Position(0, 0), new Position(0, 1));
+		final var definitionRange = new Range(new Position(0, 0), new Position(0, 1));
 		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(new Location("file://testDefinition", definitionRange)));
-		Range typeDefinitionRange = new Range(new Position(0, 2), new Position(0, 3));
+		final var typeDefinitionRange = new Range(new Position(0, 2), new Position(0, 3));
 		MockLanguageServer.INSTANCE.setTypeDefinitions(Collections.singletonList(new LocationLink("file://testTypeDefinition", typeDefinitionRange, typeDefinitionRange)));
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Example Text");
@@ -83,11 +82,11 @@ public class DefinitionTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDefinitionOneLocationExternalFile() throws Exception {
-		Location location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
+		final var location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(location));
 
 		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
-		ITextEditor editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+		final var editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		IHyperlink[] hyperlinks = hyperlinkDetector.detectHyperlinks(viewer, new Region(0, 0), true);
@@ -96,7 +95,7 @@ public class DefinitionTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDefinitionManyLocation() throws Exception {
-		List<Location> locations = new ArrayList<>();
+		final var locations = new ArrayList<Location>();
 		locations.add(new Location("file://test0", new Range(new Position(0, 0), new Position(0, 10))));
 		locations.add(new Location("file://test1", new Range(new Position(1, 0), new Position(1, 10))));
 		locations.add(new Location("file://test2", new Range(new Position(2, 0), new Position(2, 10))));
@@ -134,7 +133,7 @@ public class DefinitionTest extends AbstractTestWithProject {
 
 	@Test
 	public void testReturnsPromptly() throws Exception {
-		Location location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
+		final var location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setDefinition(Collections.singletonList(location));
 
 		IFile file = TestUtils.createUniqueTestFile(project, "Example Text");

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
@@ -162,7 +162,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 		final var range = new Range(
 				new Position(markerLineIndex, markerCharStart),
 				new Position(markerLineIndex, markerCharEnd));
-		List<Diagnostic> diagnostics = Collections.singletonList(
+		List<Diagnostic> diagnostics = List.of(
 				createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1"));
 		final var diagnosticsParamsForFileDeletedInTheMeantime = new PublishDiagnosticsParams(file.getLocationURI().toString(), diagnostics);
 		final var blockingWorkspaceJob = new BlockingWorkspaceJob("blockingJob");
@@ -213,8 +213,8 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 		IFile file = TestUtils.createUniqueTestFile(project, content);
 
 		final var range = new Range(new Position(1, 0), new Position(1, 5));
-		List<Diagnostic> diagnostics = Collections
-				.singletonList(createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1"));
+		List<Diagnostic> diagnostics = List
+				.of(createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1"));
 
 		diagnosticsToMarkers.accept(new PublishDiagnosticsParams(file.getLocationURI().toString(), diagnostics));
 
@@ -244,7 +244,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 		final var content = "Diagnostic Other Text";
 		IFile file = TestUtils.createUniqueTestFileMultiLS(project, content);
 		final var range = new Range(new Position(1, 0), new Position(1, 0));
-		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
+		MockLanguageServer.INSTANCE.setDiagnostics(List.of(
 				createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1")));
 		IMarker[] markers = file.findMarkers(LSPDiagnosticsToMarkers.LS_DIAGNOSTIC_MARKER_TYPE, true, IResource.DEPTH_ZERO);
 		assertEquals("no marker should be shown at file initialization", 0, markers.length);
@@ -280,7 +280,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDiagnosticsOnExternalFile() throws Exception {
-		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(new Diagnostic(new Range(new Position(0, 0), new Position(0, 1)), "This is a warning", DiagnosticSeverity.Warning, null)));
+		MockLanguageServer.INSTANCE.setDiagnostics(List.of(new Diagnostic(new Range(new Position(0, 0), new Position(0, 1)), "This is a warning", DiagnosticSeverity.Warning, null)));
 		File file = TestUtils.createTempFile("testDiagnosticsOnExternalFile", ".lspt");
 		Font font = null;
 		try {
@@ -335,7 +335,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 		workspace.addResourceChangeListener(redrawCountListener);
 		try {
 			diagnosticsToMarkers.accept(new PublishDiagnosticsParams(file.getLocationURI().toString(),
-					Collections.singletonList(diagnostic)));
+					List.of(diagnostic)));
 			waitForAndAssertCondition(10_000, () -> {
 				IMarker[] markers = file.findMarkers(LSPDiagnosticsToMarkers.LS_DIAGNOSTIC_MARKER_TYPE, false,
 						IResource.DEPTH_INFINITE);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
@@ -72,7 +72,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 		int markerLineIndex = 0;
 		int markerCharStart = 0;
 		int markerCharEnd = 10;
-		Range range = new Range(
+		final var range = new Range(
 				new Position(markerLineIndex, markerCharStart),
 				new Position(markerLineIndex, markerCharEnd));
 		List<Diagnostic> diagnostics = List.of(
@@ -123,7 +123,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 		int markerLineIndex = 0;
 		int markerCharStart = 0;
 		int markerCharEnd = 10;
-		Range range = new Range(
+		final var range = new Range(
 				new Position(markerLineIndex, markerCharStart),
 				new Position(markerLineIndex, markerCharEnd));
 		List<Diagnostic> diagnostics = List.of(
@@ -131,7 +131,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 				createDiagnostic("2", "message2", range, DiagnosticSeverity.Warning, "source2"),
 				createDiagnostic("3", "message3", range, DiagnosticSeverity.Information, "source3"),
 				createDiagnostic("4", "message4", range, DiagnosticSeverity.Hint, "source4"));
-		PublishDiagnosticsParams diagnosticsParamsForFileDeletedInTheMeantime = new PublishDiagnosticsParams(file.getLocationURI().toString(), diagnostics);
+		final var diagnosticsParamsForFileDeletedInTheMeantime = new PublishDiagnosticsParams(file.getLocationURI().toString(), diagnostics);
 		Job.getJobManager().suspend();
 		diagnosticsToMarkers.accept(diagnosticsParamsForFileDeletedInTheMeantime);
 		waitForAndAssertCondition(1_000, () -> {
@@ -159,13 +159,13 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 		int markerLineIndex = 0;
 		int markerCharStart = 0;
 		int markerCharEnd = 10;
-		Range range = new Range(
+		final var range = new Range(
 				new Position(markerLineIndex, markerCharStart),
 				new Position(markerLineIndex, markerCharEnd));
 		List<Diagnostic> diagnostics = Collections.singletonList(
 				createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1"));
-		PublishDiagnosticsParams diagnosticsParamsForFileDeletedInTheMeantime = new PublishDiagnosticsParams(file.getLocationURI().toString(), diagnostics);
-		BlockingWorkspaceJob blockingWorkspaceJob = new BlockingWorkspaceJob("blockingJob");
+		final var diagnosticsParamsForFileDeletedInTheMeantime = new PublishDiagnosticsParams(file.getLocationURI().toString(), diagnostics);
+		final var blockingWorkspaceJob = new BlockingWorkspaceJob("blockingJob");
 		blockingWorkspaceJob.setRule(file.getWorkspace().getRuleFactory().markerRule(file));
 		blockingWorkspaceJob.schedule();
 		waitForAndAssertCondition(1_000, () -> {
@@ -190,8 +190,8 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 	public void testFileBuffersNotLeaked() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "Diagnostic Other Text");
 
-		Range range = new Range(new Position(0, 0), new Position(0, 10));
-		List<Diagnostic> diagnostics = new ArrayList<>();
+		final var range = new Range(new Position(0, 0), new Position(0, 10));
+		final var diagnostics = new ArrayList<Diagnostic>();
 		diagnostics.add(createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1"));
 
 		IDocument existingDocument = LSPEclipseUtils.getExistingDocument(file);
@@ -209,10 +209,10 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDiagnosticsRangeAfterDocument() throws CoreException {
-		String content = "Diagnostic Other Text";
+		final var content = "Diagnostic Other Text";
 		IFile file = TestUtils.createUniqueTestFile(project, content);
 
-		Range range = new Range(new Position(1, 0), new Position(1, 5));
+		final var range = new Range(new Position(1, 0), new Position(1, 5));
 		List<Diagnostic> diagnostics = Collections
 				.singletonList(createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1"));
 
@@ -241,9 +241,9 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDiagnosticsFromVariousLS() throws Exception {
-		String content = "Diagnostic Other Text";
+		final var content = "Diagnostic Other Text";
 		IFile file = TestUtils.createUniqueTestFileMultiLS(project, content);
-		Range range = new Range(new Position(1, 0), new Position(1, 0));
+		final var range = new Range(new Position(1, 0), new Position(1, 0));
 		MockLanguageServer.INSTANCE.setDiagnostics(Collections.singletonList(
 				createDiagnostic("1", "message1", range, DiagnosticSeverity.Error, "source1")));
 		IMarker[] markers = file.findMarkers(LSPDiagnosticsToMarkers.LS_DIAGNOSTIC_MARKER_TYPE, true, IResource.DEPTH_ZERO);
@@ -261,8 +261,8 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 	public void testDiagnosticRedrawingCalls() throws CoreException {
 		IFile file = TestUtils.createUniqueTestFile(project, "Diagnostic Other Text\nDiagnostic Other Text");
 
-		final Range range1 = new Range(new Position(0, 0), new Position(0, 10));
-		final Range range2 = new Range(new Position(1, 0), new Position(1, 10));
+		final var range1 = new Range(new Position(0, 0), new Position(0, 10));
+		final var range2 = new Range(new Position(1, 0), new Position(1, 10));
 		final Diagnostic pos1Info1 = createDiagnostic("1", "message1", range1, DiagnosticSeverity.Error, "source1");
 		final Diagnostic pos1Info2 = createDiagnostic("2", "message2", range1, DiagnosticSeverity.Error, "source2");
 		final Diagnostic pos2Info2 = createDiagnostic("2", "message2", range2, DiagnosticSeverity.Error, "source2");
@@ -284,12 +284,12 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 		File file = TestUtils.createTempFile("testDiagnosticsOnExternalFile", ".lspt");
 		Font font = null;
 		try {
-			try (FileOutputStream out = new FileOutputStream(file);) {
+			try (var out = new FileOutputStream(file);) {
 				out.write('a');
 			}
 			ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI())));
 			StyledText widget = viewer.getTextWidget();
-			FontData biggerFont = new FontData(); // bigger font to keep color intact in some pixel (not altered by anti-aliasing)
+			final var biggerFont = new FontData(); // bigger font to keep color intact in some pixel (not altered by anti-aliasing)
 			biggerFont.setHeight(40);
 			biggerFont.setLocale(widget.getFont().getFontData()[0].getLocale());
 			biggerFont.setName(widget.getFont().getFontData()[0].getName());
@@ -331,7 +331,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 
 	private void confirmResourceChanges(IFile file, Diagnostic diagnostic, int expectedChanges) {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
-		MarkerRedrawCountListener redrawCountListener = new MarkerRedrawCountListener();
+		final var redrawCountListener = new MarkerRedrawCountListener();
 		workspace.addResourceChangeListener(redrawCountListener);
 		try {
 			diagnosticsToMarkers.accept(new PublishDiagnosticsParams(file.getLocationURI().toString(),
@@ -357,7 +357,7 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 
 	private Diagnostic createDiagnostic(String code, String message, Range range, DiagnosticSeverity severity,
 			String source) {
-		Diagnostic diagnostic = new Diagnostic();
+		final var diagnostic = new Diagnostic();
 		diagnostic.setCode(code);
 		diagnostic.setMessage(message);
 		diagnostic.setRange(range);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
@@ -15,7 +15,6 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
@@ -50,7 +49,7 @@ public class DocumentLinkTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDocumentLink() throws Exception {
-		List<DocumentLink> links = new ArrayList<>();
+		final var links = new ArrayList<DocumentLink>();
 		links.add(new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file://test0"));
 		MockLanguageServer.INSTANCE.setDocumentLinks(links);
 
@@ -64,12 +63,12 @@ public class DocumentLinkTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDocumentLinkExternalFile() throws Exception {
-		List<DocumentLink> links = new ArrayList<>();
+		final var links = new ArrayList<DocumentLink>();
 		links.add(new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file://test0"));
 		MockLanguageServer.INSTANCE.setDocumentLinks(links);
 
 		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
-		ITextEditor editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+		final var editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		viewer.getDocument().set("Long enough dummy content to match ranges");
 
@@ -80,7 +79,7 @@ public class DocumentLinkTest extends AbstractTestWithProject {
 
 	@Test
 	public void testDocumentLinkWrongRegion() throws Exception {
-		List<DocumentLink> links = new ArrayList<>();
+		final var links = new ArrayList<DocumentLink>();
 		links.add(new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file://test0"));
 		MockLanguageServer.INSTANCE.setDocumentLinks(links);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
@@ -13,8 +13,7 @@
 package org.eclipse.lsp4e.test.edit;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.util.List;
@@ -111,7 +110,7 @@ public class DocumentDidChangeTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
 				.setTextDocumentSync(TextDocumentSyncKind.Incremental);
 
-		String multiLineText = "line1\nline2\nline3\n";
+		final var multiLineText = "line1\nline2\nline3\n";
 		IFile testFile = TestUtils.createUniqueTestFile(project, multiLineText);
 		ITextViewer viewer = TestUtils.openTextViewer(testFile);
 		LanguageServers.forDocument(viewer.getDocument()).withFilter(new Predicate<ServerCapabilities>() {
@@ -171,7 +170,7 @@ public class DocumentDidChangeTest extends AbstractTestWithProject {
 			}
 		}).anyMatching();
 		// Test initial insert
-		String text = "Hello";
+		final var text = "Hello";
 		viewer.getDocument().replace(0, 0, text);
 		waitForAndAssertCondition(1_000,  numberOfChangesIs(1));
 		DidChangeTextDocumentParams lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(0);
@@ -207,7 +206,7 @@ public class DocumentDidChangeTest extends AbstractTestWithProject {
 			}
 		}).anyMatching();
 		// Test initial insert
-		String text = "Hello";
+		final var text = "Hello";
 		viewer.getDocument().replace(0, 0, text);
 		waitForAndAssertCondition(1_000,  numberOfChangesIs(1));
 		DidChangeTextDocumentParams lastChange = MockLanguageServer.INSTANCE.getDidChangeEvents().get(0);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 public class DocumentWillSaveWaitUntilTest extends AbstractTestWithProject {
 
 	private List<TextEdit> createSingleTextEditAtFileStart(String newText) {
-		TextEdit textEdit = new TextEdit();
+		final var textEdit = new TextEdit();
 		textEdit.setRange(new Range(new Position(0, 0), new Position(0, newText.length())));
 		textEdit.setNewText(newText);
 		return Collections.singletonList(textEdit);
@@ -44,8 +44,8 @@ public class DocumentWillSaveWaitUntilTest extends AbstractTestWithProject {
 
 	@Test
 	public void testSave() throws Exception {
-		String oldText = "Hello";
-		String newText = "hello";
+		final var oldText = "Hello";
+		final var newText = "hello";
 
 		MockLanguageServer.INSTANCE.setWillSaveWaitUntil(createSingleTextEditAtFileStart(newText));
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentWillSaveWaitUntilTest.java
@@ -14,7 +14,6 @@ package org.eclipse.lsp4e.test.edit;
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
@@ -39,7 +38,7 @@ public class DocumentWillSaveWaitUntilTest extends AbstractTestWithProject {
 		final var textEdit = new TextEdit();
 		textEdit.setRange(new Range(new Position(0, 0), new Position(0, newText.length())));
 		textEdit.setNewText(newText);
-		return Collections.singletonList(textEdit);
+		return List.of(textEdit);
 	}
 
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -79,13 +79,13 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	@Test
 	public void testOpenInEditorExternalFile() throws Exception {
 		File externalFile = TestUtils.createTempFile("externalFile", ".txt");
-		Location location = new Location(LSPEclipseUtils.toUri(externalFile).toString(), new Range(new Position(0, 0), new Position(0, 0)));
+		final var location = new Location(LSPEclipseUtils.toUri(externalFile).toString(), new Range(new Position(0, 0), new Position(0, 0)));
 		LSPEclipseUtils.openInEditor(location, UI.getActivePage());
 	}
 
 	@Test
 	public void testWorkspaceEdit_insertText() throws Exception {
-		TextEdit textEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), "insert");
+		final var textEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), "insert");
 		AbstractTextEditor editor = applyWorkspaceTextEdit(textEdit);
 		Assert.assertEquals("insertHere", ((StyledText)editor.getAdapter(Control.class)).getText());
 		Assert.assertEquals("insertHere", editor.getDocumentProvider().getDocument(editor.getEditorInput()).get());
@@ -93,7 +93,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 
 	@Test
 	public void testWorkspaceEdit_WithExaggeratedRange() throws Exception {
-		TextEdit textEdit = new TextEdit(new Range(new Position(0, 0), new Position(Integer.MAX_VALUE, Integer.MAX_VALUE)), "insert");
+		final var textEdit = new TextEdit(new Range(new Position(0, 0), new Position(Integer.MAX_VALUE, Integer.MAX_VALUE)), "insert");
 		AbstractTextEditor editor = applyWorkspaceTextEdit(textEdit);
 		Assert.assertEquals("insert", ((StyledText)editor.getAdapter(Control.class)).getText());
 		Assert.assertEquals("insert", editor.getDocumentProvider().getDocument(editor.getEditorInput()).get());
@@ -101,8 +101,8 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 
 	private AbstractTextEditor applyWorkspaceTextEdit(TextEdit textEdit) throws CoreException, PartInitException {
 		IFile f = TestUtils.createFile(project, "dummy" + new Random().nextInt(), "Here");
-		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
-		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonMap(
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
+		final var workspaceEdit = new WorkspaceEdit(Collections.singletonMap(
 			LSPEclipseUtils.toUri(f).toString(),
 			Collections.singletonList(textEdit)));
 		LSPEclipseUtils.applyWorkspaceEdit(workspaceEdit);
@@ -112,12 +112,12 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	@Test
 	public void testWorkspaceEditMultipleChanges() throws Exception {
 		IFile f = TestUtils.createFile(project, "dummy", "Here\nHere2");
-		AbstractTextEditor editor = (AbstractTextEditor)TestUtils.openEditor(f);
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(f);
 		final var edits = new LinkedList<TextEdit>();
 		// order the TextEdits from the top of the document to the bottom
 		edits.add(new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), "abc"));
 		edits.add(new TextEdit(new Range(new Position(1, 0), new Position(1, 0)), "abc"));
-		WorkspaceEdit workspaceEdit = new WorkspaceEdit(Collections.singletonMap(
+		final var workspaceEdit = new WorkspaceEdit(Collections.singletonMap(
 			LSPEclipseUtils.toUri(f).toString(), edits));
 		// they should be applied from bottom to top
 		LSPEclipseUtils.applyWorkspaceEdit(workspaceEdit);
@@ -129,14 +129,14 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	@Test
 	public void testWorkspaceEdit_CreateAndPopulateFile() throws Exception {
 		IFile file = project.getFile("test-file.test");
-		LinkedList<Either<TextDocumentEdit, ResourceOperation>> edits = new LinkedList<>();
+		final var edits = new LinkedList<Either<TextDocumentEdit, ResourceOperation>>();
 		// order the TextEdits from the top of the document to the bottom
 		String uri = file.getLocation().toFile().toURI().toString();
 		edits.add(Either.forRight(new CreateFile(uri)));
 		edits.add(Either.forLeft(
 				new TextDocumentEdit(new VersionedTextDocumentIdentifier(uri, null), Collections.singletonList(
 						new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), "abcHere\nabcHere2")))));
-		WorkspaceEdit workspaceEdit = new WorkspaceEdit(edits);
+		final var workspaceEdit = new WorkspaceEdit(edits);
 		// they should be applied from bottom to top
 		LSPEclipseUtils.applyWorkspaceEdit(workspaceEdit);
 		assertTrue(file.exists());
@@ -248,7 +248,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	public void testApplyTextEditLongerThanOrigin() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineInsertHere");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
-		TextEdit textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "InsertHere".length())), "Inserted");
+		final var textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "InsertHere".length())), "Inserted");
 		IDocument document = viewer.getDocument();
 		LSPEclipseUtils.applyEdit(textEdit, document);
 		Assert.assertEquals("line1\nlineInserted", document.get());
@@ -258,7 +258,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	public void testApplyTextEditShorterThanOrigin() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\nlineHERE");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
-		TextEdit textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "HERE".length())), "Inserted");
+		final var textEdit = new TextEdit(new Range(new Position(1, 4), new Position(1, 4 + "HERE".length())), "Inserted");
 		IDocument document = viewer.getDocument();
 		LSPEclipseUtils.applyEdit(textEdit, document);
 		Assert.assertEquals("line1\nlineInserted", document.get());
@@ -268,7 +268,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	public void testTextEditInsertSameOffset() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
-		TextEdit[] edits = new TextEdit[] {
+		final var edits = new TextEdit[] {
 				new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), " throws "),
 				new TextEdit(new Range(new Position(0, 0), new Position(0, 0)), "Exception") };
 		IDocument document = viewer.getDocument();
@@ -281,7 +281,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 		IFile file = TestUtils.createUniqueTestFile(project, "line1\r\nline2\r\nline3\r\n");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 		// GIVEN a TextEdit which splits the '\r\n' line ending in the third line:
-		TextEdit[] edits = new TextEdit[] { new TextEdit(new Range(new Position(0, 0), new Position(2, 6)), "line3\r\nline2\r\nline1\r") };
+		final var edits = new TextEdit[] { new TextEdit(new Range(new Position(0, 0), new Position(2, 6)), "line3\r\nline2\r\nline1\r") };
 		IDocument document = viewer.getDocument();
 		int linesBeforeApplyEdits = document.getNumberOfLines();
 		// WHEN the TextEdit gets applied to the document:
@@ -310,7 +310,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testToWorkspaceFolder() throws Exception {
+	public void testToWorkspaceFolder() {
 		WorkspaceFolder folder = LSPEclipseUtils.toWorkspaceFolder(project);
 		Assert.assertEquals(project.getName(), folder.getName());
 		Assert.assertEquals("file://", folder.getUri().substring(0, "file://".length()));
@@ -340,7 +340,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 		File file = TestUtils.createTempFile(getClass() + "editExternalFile", ".whatever");
 		file.delete();
 		assertFalse(file.exists());
-		WorkspaceEdit we = new WorkspaceEdit(
+		final var we = new WorkspaceEdit(
 				Collections.singletonList(Either.forRight(new CreateFile(file.toURI().toString()))));
 		LSPEclipseUtils.applyWorkspaceEdit(we);
 		assertTrue(file.isFile());
@@ -349,13 +349,13 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	@Test
 	public void editExternalFile() throws Exception {
 		File file = TestUtils.createTempFile(getClass() + "editExternalFile", ".whatever");
-		TextEdit te = new TextEdit();
+		final var te = new TextEdit();
 		te.setRange(new Range(new Position(0, 0), new Position(0, 0)));
 		te.setNewText("abc\ndef");
-		TextDocumentEdit docEdit = new TextDocumentEdit(
+		final var docEdit = new TextDocumentEdit(
 				new VersionedTextDocumentIdentifier(file.toURI().toString(), null),
 				Collections.singletonList(te));
-		WorkspaceEdit we = new WorkspaceEdit(Collections.singletonList(Either.forLeft(docEdit)));
+		final var we = new WorkspaceEdit(Collections.singletonList(Either.forLeft(docEdit)));
 		LSPEclipseUtils.applyWorkspaceEdit(we);
 		assertTrue(file.isFile());
 		assertEquals("abc\ndef", new String(Files.readAllBytes(file.toPath())));
@@ -366,7 +366,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 		File oldFile = TestUtils.createTempFile(getClass() + "editExternalFile", ".whatever");
 		File newFile = new File(oldFile.getAbsolutePath() + "_renamed");
 		TestUtils.addManagedTempFile(newFile);
-		WorkspaceEdit we = new WorkspaceEdit(Collections.singletonList(
+		final var we = new WorkspaceEdit(Collections.singletonList(
 				Either.forRight(new RenameFile(oldFile.toURI().toString(), newFile.toURI().toString()))));
 		LSPEclipseUtils.applyWorkspaceEdit(we);
 		assertFalse(oldFile.isFile());
@@ -374,7 +374,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	}
 
 	private String readContent(IFile targetFile) throws IOException, CoreException {
-		try (ByteArrayOutputStream stream = new ByteArrayOutputStream(
+		try (var stream = new ByteArrayOutputStream(
 				(int) targetFile.getLocation().toFile().length());
 				InputStream contentStream = targetFile.getContents();) {
 			contentStream.transferTo(stream);
@@ -389,13 +389,13 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 		IEditorPart editor = IDE.openEditor(UI.getActivePage(),
 				targetFile,
 				"org.eclipse.ui.genericeditor.GenericEditor");
-		TextEdit te = new TextEdit();
+		final var te = new TextEdit();
 		te.setRange(new Range(new Position(0, 0), new Position(0, 0)));
 		te.setNewText("abc\ndef");
-		TextDocumentEdit docEdit = new TextDocumentEdit(
+		final var docEdit = new TextDocumentEdit(
 				new VersionedTextDocumentIdentifier(LSPEclipseUtils.toUri(targetFile).toString(), null),
 				Collections.singletonList(te));
-		WorkspaceEdit we = new WorkspaceEdit(Collections.singletonList(Either.forLeft(docEdit)));
+		final var we = new WorkspaceEdit(Collections.singletonList(Either.forLeft(docEdit)));
 		LSPEclipseUtils.applyWorkspaceEdit(we);
 		assertEquals("abc\ndef", ((StyledText) ((AbstractTextEditor) editor).getAdapter(Control.class)).getText());
 		assertTrue(editor.isDirty());
@@ -405,13 +405,13 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	public void testTextEditDoesntAutomaticallySaveOpenExternalFiles() throws Exception {
 		File file = TestUtils.createTempFile("testTextEditDoesntAutomaticallySaveOpenExternalFiles", ".whatever");
 		IEditorPart editor = IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
-		TextEdit te = new TextEdit();
+		final var te = new TextEdit();
 		te.setRange(new Range(new Position(0, 0), new Position(0, 0)));
 		te.setNewText("abc\ndef");
-		TextDocumentEdit docEdit = new TextDocumentEdit(
+		final var docEdit = new TextDocumentEdit(
 				new VersionedTextDocumentIdentifier(file.toURI().toString(), null),
 				Collections.singletonList(te));
-		WorkspaceEdit we = new WorkspaceEdit(Collections.singletonList(Either.forLeft(docEdit)));
+		final var we = new WorkspaceEdit(Collections.singletonList(Either.forLeft(docEdit)));
 		LSPEclipseUtils.applyWorkspaceEdit(we);
 		assertEquals("abc\ndef", ((StyledText) ((AbstractTextEditor) editor).getAdapter(Control.class)).getText());
 		assertTrue(editor.isDirty());
@@ -468,7 +468,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	@Test
 	public void testGetOpenEditorExternalFile() throws Exception {
 		File file = TestUtils.createTempFile("testDiagnosticsOnExternalFile", ".lspt");
-		try (FileOutputStream out = new FileOutputStream(file)) {
+		try (var out = new FileOutputStream(file)) {
 			out.write('a');
 		}
 		IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/folding/FoldingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/folding/FoldingTest.java
@@ -60,7 +60,7 @@ public class FoldingTest extends AbstractTest {
 
 	private IEditorPart createEditor() throws CoreException, PartInitException {
 		IFile file = TestUtils.createUniqueTestFile(null, CONTENT);
-		FoldingRange foldingRange = new FoldingRange(0, 2);
+		final var foldingRange = new FoldingRange(0, 2);
 		foldingRange.setKind(FoldingRangeKind.Imports);
 		MockLanguageServer.INSTANCE.setFoldingRanges(List.of(foldingRange));
 		IEditorPart editor = TestUtils.openEditor(file);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatTest.java
@@ -12,15 +12,11 @@
 package org.eclipse.lsp4e.test.format;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -49,7 +45,7 @@ public class FormatTest extends AbstractTestWithProject {
 
 	@Test
 	public void testFormattingInvalidDocument() throws Exception {
-		LSPFormatter formatter = new LSPFormatter();
+		final var formatter = new LSPFormatter();
 		ITextSelection selection = TextSelection.emptySelection();
 
 		Optional<VersionedEdits> edits = formatter.requestFormatting(new Document(), selection).get();
@@ -64,7 +60,7 @@ public class FormatTest extends AbstractTestWithProject {
 		IEditorPart editor = TestUtils.openEditor(file);
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
-		LSPFormatter formatter = new LSPFormatter();
+		final var formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
 
 		Optional<VersionedEdits> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection).get();
@@ -76,7 +72,7 @@ public class FormatTest extends AbstractTestWithProject {
 				fail(e.getMessage());
 			}
 		});
-		ITextEditor textEditor = (ITextEditor) editor;
+		final var textEditor = (ITextEditor) editor;
 		textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
 		assertEquals("Formatting Other Text", viewer.getDocument().get());
 
@@ -86,7 +82,7 @@ public class FormatTest extends AbstractTestWithProject {
 	@Test
 	public void testFormatting()
 			throws Exception {
-		List<TextEdit> formattingTextEdits = new ArrayList<>();
+		final var formattingTextEdits = new ArrayList<TextEdit>();
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 0), new Position(0, 1)), "MyF"));
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 10), new Position(0, 11)), ""));
 		formattingTextEdits.add(new TextEdit(new Range(new Position(0, 21), new Position(0, 21)), " Second"));
@@ -96,7 +92,7 @@ public class FormatTest extends AbstractTestWithProject {
 		IEditorPart editor = TestUtils.openEditor(file);
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
-		LSPFormatter formatter = new LSPFormatter();
+		final var formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
 
 		Optional<VersionedEdits> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection).get();
@@ -109,7 +105,7 @@ public class FormatTest extends AbstractTestWithProject {
 			}
 		});
 
-		ITextEditor textEditor = (ITextEditor) editor;
+		final var textEditor = (ITextEditor) editor;
 		textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
 		assertEquals("MyFormattingOther Text Second", viewer.getDocument().get());
 
@@ -125,7 +121,7 @@ public class FormatTest extends AbstractTestWithProject {
 		IEditorPart editor = TestUtils.openEditor(file);
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
-		LSPFormatter formatter = new LSPFormatter();
+		final var formatter = new LSPFormatter();
 		ISelection selection = viewer.getSelectionProvider().getSelection();
 
 		Optional<VersionedEdits> edits = formatter.requestFormatting(viewer.getDocument(), (ITextSelection) selection).get();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/highlight/HighlightTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/highlight/HighlightTest.java
@@ -122,7 +122,7 @@ public class HighlightTest extends AbstractTestWithProject{
 				))));
 
 		// Open the first viewer
-		final ISourceViewer viewer1 = (ISourceViewer) TestUtils.openTextViewer(testFile);
+		final var viewer1 = (ISourceViewer) TestUtils.openTextViewer(testFile);
 		final var annotationModel1 = viewer1.getAnnotationModel();
 
 		// Set the caret offset to activate the first set of highlights
@@ -140,7 +140,7 @@ public class HighlightTest extends AbstractTestWithProject{
 		ISourceViewer viewer2 = null;
 		IEditorReference editorToClose = null;
 		for (IEditorReference editorReference : editorReferences) {
-			ISourceViewer viewer = (ISourceViewer) LSPEclipseUtils.getTextViewer(editorReference.getEditor(false));
+			final var viewer = (ISourceViewer) LSPEclipseUtils.getTextViewer(editorReference.getEditor(false));
 			if (viewer != viewer1) {
 				editorToClose = editorReference;
 				viewer2 = viewer;

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.filesystem.EFS;
@@ -60,7 +61,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverRegion() throws CoreException {
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -81,7 +82,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverInfo() throws CoreException {
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -114,7 +115,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverEmptyContentItem() throws CoreException {
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(List.of(Either.forLeft("")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -125,7 +126,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverOnExternalFile() throws CoreException, IOException {
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("blah")),
+		final var hoverResponse = new Hover(List.of(Either.forLeft("blah")),
 				new Range(new Position(0, 0), new Position(0, 0)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
@@ -137,7 +138,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testMultipleHovers() throws Exception {
-		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFileMultiLS(project, "HoverRange Other Text");
@@ -155,7 +156,7 @@ public class HoverTest extends AbstractTestWithProject {
 	@Test
 	public void testIntroUrlLink() throws Exception {
 		final var hoverResponse = new Hover(
-				Collections.singletonList(Either.forLeft(
+				List.of(Either.forLeft(
 						"[My intro URL link](http://org.eclipse.ui.intro/execute?command=org.eclipse.ui.file.close)")),
 				new Range(new Position(0, 0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
@@ -60,7 +60,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverRegion() throws CoreException {
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -81,7 +81,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverInfo() throws CoreException {
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -93,7 +93,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverInfoEmptyContentList() throws CoreException {
-		Hover hoverResponse = new Hover(Collections.emptyList(), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.emptyList(), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -114,7 +114,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverEmptyContentItem() throws CoreException {
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
@@ -125,7 +125,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testHoverOnExternalFile() throws CoreException, IOException {
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("blah")),
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("blah")),
 				new Range(new Position(0, 0), new Position(0, 0)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
@@ -137,7 +137,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testMultipleHovers() throws Exception {
-		Hover hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
+		final var hoverResponse = new Hover(Collections.singletonList(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
 		IFile file = TestUtils.createUniqueTestFileMultiLS(project, "HoverRange Other Text");
@@ -154,7 +154,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 	@Test
 	public void testIntroUrlLink() throws Exception {
-		Hover hoverResponse = new Hover(
+		final var hoverResponse = new Hover(
 				Collections.singletonList(Either.forLeft(
 						"[My intro URL link](http://org.eclipse.ui.intro/execute?command=org.eclipse.ui.file.close)")),
 				new Range(new Position(0, 0), new Position(0, 10)));
@@ -165,13 +165,13 @@ public class HoverTest extends AbstractTestWithProject {
 
 		String hoverContent = hover.getHoverInfo(viewer, new Region(0, 10));
 
-		LSPTextHover hoverManager = new LSPTextHover();
+		final var hoverManager = new LSPTextHover();
 
 		Display display = PlatformUI.getWorkbench().getDisplay();
-		final Shell shell = new Shell(display);
+		final var shell = new Shell(display);
 		BrowserInformationControl wrapperControl = null, control = null;
 		try {
-			final RowLayout layout = new RowLayout(SWT.VERTICAL);
+			final var layout = new RowLayout(SWT.VERTICAL);
 			layout.fill = true;
 			shell.setLayout(layout);
 			shell.setSize(320, 200);
@@ -184,10 +184,10 @@ public class HoverTest extends AbstractTestWithProject {
 			Field f = BrowserInformationControl.class.getDeclaredField("fBrowser"); //
 			f.setAccessible(true);
 
-			Browser browser = (Browser) f.get(control);
+			final var browser = (Browser) f.get(control);
 			browser.setJavascriptEnabled(true);
 
-			AtomicBoolean completed = new AtomicBoolean(false);
+			final var completed = new AtomicBoolean(false);
 
 			browser.addProgressListener(new ProgressAdapter() {
 				@Override

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/CharsInputStreamTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/CharsInputStreamTest.java
@@ -34,7 +34,7 @@ public class CharsInputStreamTest {
 	public void testAvailable() throws IOException {
 		try (var is = new CharsInputStream(TEST_ASCII)) {
 			assertEquals(TEST_ASCII.length(), is.available());
-			final byte[] buffer = new byte[4];
+			final var buffer = new byte[4];
 			is.read(buffer);
 			assertEquals(TEST_ASCII.length() - 4, is.available());
 			is.readAllBytes();
@@ -67,7 +67,7 @@ public class CharsInputStreamTest {
 				bytesRead.add((byte) b);
 			}
 
-			final byte[] byteArray = new byte[bytesRead.size()];
+			final var byteArray = new byte[bytesRead.size()];
 			for (int i = 0; i < bytesRead.size(); i++) {
 				byteArray[i] = bytesRead.get(i);
 			}
@@ -77,7 +77,7 @@ public class CharsInputStreamTest {
 
 	@Test
 	public void testReadIntoByteArray() throws IOException {
-		final byte[] buffer = new byte[1024]; // Buffer to read a portion of the text
+		final var buffer = new byte[1024]; // Buffer to read a portion of the text
 
 		try (var is = new CharsInputStream(TEST_UNICODE)) {
 			final int bytesRead = is.read(buffer, 0, buffer.length);
@@ -93,7 +93,7 @@ public class CharsInputStreamTest {
 			final long skipped = is.skip(EMOJI_BYTES_LEN);
 			assertEquals(EMOJI_BYTES_LEN, skipped);
 
-			final byte[] japanese = new byte[TEST_UNICODE_BYTES_LEN];
+			final var japanese = new byte[TEST_UNICODE_BYTES_LEN];
 			final int bytesRead = is.read(japanese);
 
 			assertEquals(JAPANESE, new String(japanese, 0, bytesRead, UTF_8));
@@ -105,7 +105,7 @@ public class CharsInputStreamTest {
 		final char[] invalidSequence = { 'A', '\uD800' }; // valid char followed by an isolated high surrogate
 		try (var is = new CharsInputStream(new String(invalidSequence), UTF_8)) {
 			final byte[] result = is.readAllBytes();
-			final String output = new String(result, UTF_8);
+			final var output = new String(result, UTF_8);
 
 			// the high surrogate at the end should be replaced by the
 			// Unicode replacement char
@@ -118,7 +118,7 @@ public class CharsInputStreamTest {
 		final char[] invalidSequence = { '\uD800', 'A' }; // \uD800 is a high surrogate, followed by 'A'
 		try (var is = new CharsInputStream(new String(invalidSequence), UTF_8)) {
 			final byte[] result = is.readAllBytes();
-			final String output = new String(result, UTF_8);
+			final var output = new String(result, UTF_8);
 
 			// the invalid surrogate pair should be replaced by the Unicode replacement char
 			assertEquals(CharsInputStream.UNICODE_REPLACEMENT_CHAR + "A", output);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/DocumentInputStreamTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/DocumentInputStreamTest.java
@@ -51,7 +51,7 @@ public class DocumentInputStreamTest extends AbstractTestWithProject {
 		try (var is = new DocumentInputStream(document)) {
 			assertEquals(UTF_8, is.getCharset());
 			assertEquals(TEST_ASCII.length(), is.available());
-			final byte[] buffer = new byte[4];
+			final var buffer = new byte[4];
 			is.read(buffer);
 			assertEquals(TEST_ASCII.length() - 4, is.available());
 			is.readAllBytes();
@@ -88,7 +88,7 @@ public class DocumentInputStreamTest extends AbstractTestWithProject {
 				bytesRead.add((byte) b);
 			}
 
-			final byte[] byteArray = new byte[bytesRead.size()];
+			final var byteArray = new byte[bytesRead.size()];
 			for (int i = 0; i < bytesRead.size(); i++) {
 				byteArray[i] = bytesRead.get(i);
 			}
@@ -98,7 +98,7 @@ public class DocumentInputStreamTest extends AbstractTestWithProject {
 
 	@Test
 	public void testReadIntoByteArray() throws IOException {
-		final byte[] buffer = new byte[1024]; // Buffer to read a portion of the text
+		final var buffer = new byte[1024]; // Buffer to read a portion of the text
 
 		try (var is = new DocumentInputStream(document)) {
 			assertEquals(UTF_8, is.getCharset());
@@ -116,7 +116,7 @@ public class DocumentInputStreamTest extends AbstractTestWithProject {
 			final long skipped = is.skip(EMOJI_BYTES_LEN);
 			assertEquals(EMOJI_BYTES_LEN, skipped);
 
-			final byte[] japanese = new byte[TEST_UNICODE_BYTES_LEN];
+			final var japanese = new byte[TEST_UNICODE_BYTES_LEN];
 			final int bytesRead = is.read(japanese);
 
 			assertEquals(JAPANESE, new String(japanese, 0, bytesRead, UTF_8));
@@ -129,7 +129,7 @@ public class DocumentInputStreamTest extends AbstractTestWithProject {
 		try (var is = new DocumentInputStream(document)) {
 			assertEquals(UTF_8, is.getCharset());
 			final byte[] result = is.readAllBytes();
-			final String output = new String(result, UTF_8);
+			final var output = new String(result, UTF_8);
 
 			// the high surrogate at the end should be replaced by the
 			// Unicode replacement char
@@ -143,7 +143,7 @@ public class DocumentInputStreamTest extends AbstractTestWithProject {
 		try (var is = new DocumentInputStream(document)) {
 			assertEquals(UTF_8, is.getCharset());
 			final byte[] result = is.readAllBytes();
-			final String output = new String(result, UTF_8);
+			final var output = new String(result, UTF_8);
 
 			// the invalid surrogate pair should be replaced by the Unicode replacement char
 			assertEquals(CharsInputStream.UNICODE_REPLACEMENT_CHAR + "A", output);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/linkedediting/LinkedEditingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/linkedediting/LinkedEditingTest.java
@@ -12,16 +12,12 @@
 package org.eclipse.lsp4e.test.linkedediting;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
@@ -43,11 +39,11 @@ public class LinkedEditingTest extends AbstractTestWithProject {
 
 	@Test
 	public void testLinkedEditing() throws CoreException {
-		List<Range> ranges = new ArrayList<>();
+		final var ranges = new ArrayList<Range>();
 		ranges.add(new Range(new Position(1, 3), new Position(1, 7)));
 		ranges.add(new Range(new Position(3, 4), new Position(3, 8)));
 
-		LinkedEditingRanges linkkedEditingRanges = new LinkedEditingRanges(ranges);
+		final var linkkedEditingRanges = new LinkedEditingRanges(ranges);
 		MockLanguageServer.INSTANCE.setLinkedEditingRanges(linkkedEditingRanges);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "<html>\n  <body>\n    a body text\n  </body>\n</html>");
@@ -59,11 +55,11 @@ public class LinkedEditingTest extends AbstractTestWithProject {
 			Assert.fail();
 		}
 
-		ISourceViewer sourceViewer = (ISourceViewer) viewer;
+		final var sourceViewer = (ISourceViewer) viewer;
 
 		viewer.getTextWidget().setSelection(11); // 10-14 <body|>
 
-		Map<org.eclipse.jface.text.Position, Annotation> annotations = new HashMap<>();
+		final var annotations = new HashMap<org.eclipse.jface.text.Position, Annotation>();
 
 		waitForAndAssertCondition(3_000, () -> {
 			Iterator<Annotation> iterator = sourceViewer.getAnnotationModel().getAnnotationIterator();
@@ -90,11 +86,11 @@ public class LinkedEditingTest extends AbstractTestWithProject {
 
 	@Test
 	public void testLinkedEditingExitPolicy() throws CoreException {
-		List<Range> ranges = new ArrayList<>();
+		final var ranges = new ArrayList<Range>();
 		ranges.add(new Range(new Position(1, 3), new Position(1, 7)));
 		ranges.add(new Range(new Position(3, 4), new Position(3, 8)));
 
-		LinkedEditingRanges linkkedEditingRanges = new LinkedEditingRanges(ranges, "[:A-Z_a-z]*\\Z");
+		final var linkkedEditingRanges = new LinkedEditingRanges(ranges, "[:A-Z_a-z]*\\Z");
 		MockLanguageServer.INSTANCE.setLinkedEditingRanges(linkkedEditingRanges);
 
 		IFile testFile = TestUtils.createUniqueTestFile(project, "<html>\n  <body class=\"test\">\n    a body text\n  </body>\n</html>");
@@ -104,7 +100,7 @@ public class LinkedEditingTest extends AbstractTestWithProject {
 			Assert.fail();
 		}
 
-		ISourceViewer sourceViewer = (ISourceViewer) viewer;
+		final var sourceViewer = (ISourceViewer) viewer;
 
 		// Test linked editing annotation in a tag name position
 		viewer.getTextWidget().setCaretOffset(14);
@@ -156,7 +152,7 @@ public class LinkedEditingTest extends AbstractTestWithProject {
 	}
 
 	private List<Annotation> findAnnotations(ISourceViewer sourceViewer, int offset) {
-		List<Annotation> annotations = new ArrayList<>();
+		final var annotations = new ArrayList<Annotation>();
 		IAnnotationModel model = sourceViewer.getAnnotationModel();
 		Iterator<Annotation> iterator = model.getAnnotationIterator();
 		while (iterator.hasNext()) {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/message/ShowMessageTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/message/ShowMessageTest.java
@@ -35,8 +35,8 @@ public class ShowMessageTest extends AbstractTestWithProject {
 	public void testShowMessage() throws CoreException {
 		IFile file = TestUtils.createUniqueTestFile(project, "");
 		IDE.openEditor(UI.getActivePage(), file);
-		String messageContent = "test notification " + System.currentTimeMillis();
-		MessageParams message = new MessageParams(MessageType.Error, messageContent);
+		final var messageContent = "test notification " + System.currentTimeMillis();
+		final var message = new MessageParams(MessageType.Error, messageContent);
 		Display display = Display.getDefault();
 		Set<Shell> currentShells = Stream.of(display.getShells()).filter(Shell::isVisible).collect(Collectors.toSet());
 		List<LanguageClient> remoteProxies = MockLanguageServer.INSTANCE.getRemoteProxies();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/codelens/LSPCodeMiningTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/codelens/LSPCodeMiningTest.java
@@ -13,7 +13,7 @@ package org.eclipse.lsp4e.test.operations.codelens;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -97,7 +97,7 @@ public class LSPCodeMiningTest extends AbstractTestWithProject {
 		Command command = lens.getCommand();
 		final var jsonObject = new JsonObject();
 		jsonObject.addProperty("bar", 42);
-		command.setArguments(Arrays.asList(new JsonPrimitive("Foo"), jsonObject));
+		command.setArguments(List.of(new JsonPrimitive("Foo"), jsonObject));
 
 		// Setup test data
 		IFile file = TestUtils.createUniqueTestFile(project, "lspt", "test content");

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/codelens/LSPCodeMiningTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/codelens/LSPCodeMiningTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.commands.IHandler;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.text.IDocument;
@@ -58,14 +57,14 @@ public class LSPCodeMiningTest extends AbstractTestWithProject {
 
 	@Test
 	public void testLSPCodeMiningActionClientSideHandling() throws Exception {
-		String commandID = "test.command";
+		final var commandID = "test.command";
 		final CodeLens lens = createCodeLens(commandID);
 
-		final AtomicReference<Command> actualCommand = new AtomicReference<>(null);
-		final AtomicReference<IPath> actualPath = new AtomicReference<>(null);
+		final var actualCommand = new AtomicReference<Command>(null);
+		final var actualPath = new AtomicReference<IPath>(null);
 
 		// Create and register handler
-		IHandler handler = new LSPCommandHandler() {
+		final var handler = new LSPCommandHandler() {
 			@Override
 			public Object execute(ExecutionEvent event, Command command, IPath context) throws ExecutionException {
 				actualCommand.set(command);
@@ -80,10 +79,10 @@ public class LSPCodeMiningTest extends AbstractTestWithProject {
 		IFile file = TestUtils.createUniqueTestFile(project, "lspt", "test content");
 		IDocument document = TestUtils.openTextViewer(file).getDocument();
 
-		CodeLensProvider provider = new CodeLensProvider();
+		final var provider = new CodeLensProvider();
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrapper(project, LanguageServersRegistry.getInstance().getDefinition(MOCK_SERVER_ID));
 
-		LSPCodeMining sut = new LSPCodeMining(lens, document, wrapper, provider);
+		final var sut = new LSPCodeMining(lens, document, wrapper, provider);
 		MouseEvent mouseEvent = createMouseEvent();
 		sut.getAction().accept(mouseEvent);
 
@@ -96,7 +95,7 @@ public class LSPCodeMiningTest extends AbstractTestWithProject {
 			throws Exception {
 		final CodeLens lens = createCodeLens(MockLanguageServer.SUPPORTED_COMMAND_ID);
 		Command command = lens.getCommand();
-		JsonObject jsonObject = new JsonObject();
+		final var jsonObject = new JsonObject();
 		jsonObject.addProperty("bar", 42);
 		command.setArguments(Arrays.asList(new JsonPrimitive("Foo"), jsonObject));
 
@@ -105,11 +104,11 @@ public class LSPCodeMiningTest extends AbstractTestWithProject {
 		IDocument document = TestUtils.openTextViewer(file).getDocument();
 
 		MockLanguageServer languageServer = MockLanguageServer.INSTANCE;
-		CodeLensProvider provider = new CodeLensProvider();
+		final var provider = new CodeLensProvider();
 
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrapper(project, LanguageServersRegistry.getInstance().getDefinition(MOCK_SERVER_ID));
 
-		LSPCodeMining sut = new LSPCodeMining(lens, document, wrapper, provider);		MouseEvent mouseEvent = createMouseEvent();
+		final var sut = new LSPCodeMining(lens, document, wrapper, provider);		MouseEvent mouseEvent = createMouseEvent();
 		sut.getAction().accept(mouseEvent);
 
 		// We expect that the language server will be called to execute the command
@@ -121,7 +120,7 @@ public class LSPCodeMiningTest extends AbstractTestWithProject {
 	}
 
 	private static MouseEvent createMouseEvent() {
-		Event event = new Event();
+		final var event = new Event();
 		event.button = SWT.BUTTON1;
 		Display display = Display.getCurrent();
 		event.widget = display.getSystemTray();
@@ -129,10 +128,10 @@ public class LSPCodeMiningTest extends AbstractTestWithProject {
 	}
 
 	private static CodeLens createCodeLens(String commandID) {
-		CodeLens lens = new CodeLens();
-		Position zero = new Position(0, 0);
+		final var lens = new CodeLens();
+		final var zero = new Position(0, 0);
 		lens.setRange(new Range(zero, zero));
-		Command command = new Command("TestCommand", commandID);
+		final var command = new Command("TestCommand", commandID);
 		lens.setCommand(command);
 		return lens;
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/inlayhint/LSPLineContentCodeMiningTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/inlayhint/LSPLineContentCodeMiningTest.java
@@ -15,6 +15,7 @@ package org.eclipse.lsp4e.test.operations.inlayhint;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.core.resources.IFile;
@@ -52,7 +53,7 @@ public class LSPLineContentCodeMiningTest extends AbstractTestWithProject {
 		Command command = inlay.getLabel().getRight().get(0).getCommand();
 		final var jsonObject = new JsonObject();
 		jsonObject.addProperty("bar", 42);
-		command.setArguments(Arrays.asList(new JsonPrimitive("Foo"), jsonObject));
+		command.setArguments(List.of(new JsonPrimitive("Foo"), jsonObject));
 
 		// Setup test data
 		IFile file = TestUtils.createUniqueTestFile(project, "lspt", "test content");

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/inlayhint/LSPLineContentCodeMiningTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/operations/inlayhint/LSPLineContentCodeMiningTest.java
@@ -50,7 +50,7 @@ public class LSPLineContentCodeMiningTest extends AbstractTestWithProject {
 	public void singleLabelPartCommand() throws Exception {
 		final InlayHint inlay = createMultiLabelInlayHint(createInlayLabelPart("Label-Text", MockLanguageServer.SUPPORTED_COMMAND_ID));
 		Command command = inlay.getLabel().getRight().get(0).getCommand();
-		JsonObject jsonObject = new JsonObject();
+		final var jsonObject = new JsonObject();
 		jsonObject.addProperty("bar", 42);
 		command.setArguments(Arrays.asList(new JsonPrimitive("Foo"), jsonObject));
 
@@ -60,11 +60,11 @@ public class LSPLineContentCodeMiningTest extends AbstractTestWithProject {
 		IDocument document = textViewer.getDocument();
 
 		MockLanguageServer languageServer = MockLanguageServer.INSTANCE;
-		InlayHintProvider provider = new InlayHintProvider();
+		final var provider = new InlayHintProvider();
 
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrapper(project, LanguageServersRegistry.getInstance().getDefinition(MOCK_SERVER_ID));
 
-		LSPLineContentCodeMining sut = new LSPLineContentCodeMining(inlay, document, wrapper, provider);
+		final var sut = new LSPLineContentCodeMining(inlay, document, wrapper, provider);
 		MouseEvent mouseEvent = createMouseEvent();
 		sut.getAction().accept(mouseEvent);
 
@@ -77,21 +77,21 @@ public class LSPLineContentCodeMiningTest extends AbstractTestWithProject {
 	}
 
 	private static InlayHintLabelPart createInlayLabelPart(String text, String commandID) {
-		InlayHintLabelPart labelPart = new InlayHintLabelPart(text);
-		Command command = new Command(text, commandID);
+		final var labelPart = new InlayHintLabelPart(text);
+		final var command = new Command(text, commandID);
 		labelPart.setCommand(command);
 		return labelPart;
 	}
 
 	private static InlayHint createMultiLabelInlayHint(InlayHintLabelPart... parts) {
-		InlayHint inlay = new InlayHint();
+		final var inlay = new InlayHint();
 		inlay.setLabel(Arrays.asList(parts));
 		inlay.setPosition(new Position(0, 0));
 		return inlay;
 	}
 
 	private static MouseEvent createMouseEvent() {
-		Event event = new Event();
+		final var event = new Event();
 		event.button = SWT.BUTTON1;
 		Display display = Display.getCurrent();
 		event.widget = display.getSystemTray();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertFalse;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
@@ -138,7 +138,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.setDocumentSymbols(
 				new DocumentSymbol("a", SymbolKind.Constant, new Range(new Position(0, 0), new Position(0, 6)),
 						new Range(new Position(0, 0), new Position(0, 1)), "",
-						Collections.singletonList(new DocumentSymbol("b", SymbolKind.Constant,
+						List.of(new DocumentSymbol("b", SymbolKind.Constant,
 								new Range(new Position(0, 2), new Position(0, 5)),
 								new Range(new Position(0, 2), new Position(0, 3))))));
 		final var editor = (ITextEditor) TestUtils.openEditor(testFile);
@@ -173,7 +173,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.setDocumentSymbols(
 				new DocumentSymbol("a", SymbolKind.Constant, new Range(new Position(0, 0), new Position(0, 6)),
 						new Range(new Position(0, 0), new Position(0, 1)), "",
-						Collections.singletonList(new DocumentSymbol("b", SymbolKind.Constant,
+						List.of(new DocumentSymbol("b", SymbolKind.Constant,
 								new Range(new Position(0, 2), new Position(0, 5)),
 								new Range(new Position(0, 2), new Position(0, 3))))));
 		final var editor = (ITextEditor) TestUtils.openEditor(testFile);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
@@ -55,20 +55,20 @@ public class OutlineContentTest extends AbstractTestWithProject {
 			fileWriter.write("content\n does\n not\n matter\n but needs to cover the ranges described below");
 		}
 
-		DocumentSymbol symbolCow = new DocumentSymbol("cow", SymbolKind.Constant,
+		final var symbolCow = new DocumentSymbol("cow", SymbolKind.Constant,
 				new Range(new Position(0, 0), new Position(0, 2)),
 				new Range(new Position(0, 0), new Position(0, 2)));
 
 		MockLanguageServer.INSTANCE.setDocumentSymbols(symbolCow);
 
-		ITextEditor editor = (ITextEditor) TestUtils.openExternalFileInEditor(testFile);
+		final var editor = (ITextEditor) TestUtils.openExternalFileInEditor(testFile);
 
-		CNFOutlinePage outlinePage = (CNFOutlinePage) new EditorToOutlineAdapterFactory().getAdapter(editor, IContentOutlinePage.class);
-		Shell shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
+		final var outlinePage = (CNFOutlinePage) new EditorToOutlineAdapterFactory().getAdapter(editor, IContentOutlinePage.class);
+		final var shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
 		shell.setLayout(new FillLayout());
 		outlinePage.createControl(shell);
 		shell.open();
-		Tree tree = (Tree) outlinePage.getControl();
+		final var tree = (Tree) outlinePage.getControl();
 
 		// wait for tree to render
 		waitForAndAssertCondition(5_000, tree.getDisplay(), //
@@ -82,15 +82,15 @@ public class OutlineContentTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testOutlineSorting() throws CoreException, IOException {
+	public void testOutlineSorting() throws CoreException {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "content\n does\n not\n matter\n but needs to cover the ranges described below");
-		DocumentSymbol symbolCow = new DocumentSymbol("cow", SymbolKind.Constant,
+		final var symbolCow = new DocumentSymbol("cow", SymbolKind.Constant,
 				new Range(new Position(0, 0), new Position(0, 2)),
 				new Range(new Position(0, 0), new Position(0, 2)));
-		DocumentSymbol symbolFox = new DocumentSymbol("fox", SymbolKind.Constant,
+		final var symbolFox = new DocumentSymbol("fox", SymbolKind.Constant,
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)));
-		DocumentSymbol symbolCat = new DocumentSymbol("cat", SymbolKind.Constant,
+		final var symbolCat = new DocumentSymbol("cat", SymbolKind.Constant,
 				new Range(new Position(2, 0), new Position(2, 2)),
 				new Range(new Position(2, 0), new Position(2, 2)));
 
@@ -100,15 +100,15 @@ public class OutlineContentTest extends AbstractTestWithProject {
 		IEclipsePreferences prefs = InstanceScope.INSTANCE.getNode(LanguageServerPlugin.PLUGIN_ID);
 		prefs.putBoolean(CNFOutlinePage.SORT_OUTLINE_PREFERENCE, false);
 
-		ITextEditor editor = (ITextEditor) TestUtils.openEditor(testFile);
+		final var editor = (ITextEditor) TestUtils.openEditor(testFile);
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile, request -> true).iterator().next();
 
-		CNFOutlinePage outlinePage = new CNFOutlinePage(wrapper, editor);
-		Shell shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
+		final var outlinePage = new CNFOutlinePage(wrapper, editor);
+		final var shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
 		shell.setLayout(new FillLayout());
 		outlinePage.createControl(shell);
 		shell.open();
-		Tree tree = (Tree) outlinePage.getControl();
+		final var tree = (Tree) outlinePage.getControl();
 
 		// wait for tree to render
 		waitForAndAssertCondition(5_000, tree.getDisplay(), //
@@ -133,7 +133,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testNodeRemainExpandedUponSelection() throws CoreException, IOException {
+	public void testNodeRemainExpandedUponSelection() throws CoreException {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "a(b())");
 		MockLanguageServer.INSTANCE.setDocumentSymbols(
 				new DocumentSymbol("a", SymbolKind.Constant, new Range(new Position(0, 0), new Position(0, 6)),
@@ -141,11 +141,11 @@ public class OutlineContentTest extends AbstractTestWithProject {
 						Collections.singletonList(new DocumentSymbol("b", SymbolKind.Constant,
 								new Range(new Position(0, 2), new Position(0, 5)),
 								new Range(new Position(0, 2), new Position(0, 3))))));
-		ITextEditor editor = (ITextEditor) TestUtils.openEditor(testFile);
+		final var editor = (ITextEditor) TestUtils.openEditor(testFile);
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile, request -> true).iterator().next();
 
-		CNFOutlinePage outlinePage = new CNFOutlinePage(wrapper, editor);
-		Shell shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
+		final var outlinePage = new CNFOutlinePage(wrapper, editor);
+		final var shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
 		shell.setLayout(new FillLayout());
 		outlinePage.createControl(shell);
 		shell.open();
@@ -168,7 +168,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testNodeRemainExpandedUponModification() throws CoreException, BadLocationException, IOException {
+	public void testNodeRemainExpandedUponModification() throws CoreException, BadLocationException {
 		IFile testFile = TestUtils.createUniqueTestFile(project, "a(b())");
 		MockLanguageServer.INSTANCE.setDocumentSymbols(
 				new DocumentSymbol("a", SymbolKind.Constant, new Range(new Position(0, 0), new Position(0, 6)),
@@ -176,15 +176,15 @@ public class OutlineContentTest extends AbstractTestWithProject {
 						Collections.singletonList(new DocumentSymbol("b", SymbolKind.Constant,
 								new Range(new Position(0, 2), new Position(0, 5)),
 								new Range(new Position(0, 2), new Position(0, 3))))));
-		ITextEditor editor = (ITextEditor) TestUtils.openEditor(testFile);
+		final var editor = (ITextEditor) TestUtils.openEditor(testFile);
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(testFile, request -> true).iterator().next();
 
-		CNFOutlinePage outlinePage = new CNFOutlinePage(wrapper, editor);
-		Shell shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
+		final var outlinePage = new CNFOutlinePage(wrapper, editor);
+		final var shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
 		shell.setLayout(new FillLayout());
 		outlinePage.createControl(shell);
 		shell.open();
-		Tree tree = (Tree) outlinePage.getControl();
+		final var tree = (Tree) outlinePage.getControl();
 		DisplayHelper.sleep(tree.getDisplay(), 500);
 
 		editor.getSelectionProvider().setSelection(new TextSelection(4, 0));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
@@ -72,7 +72,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 
 		// wait for tree to render
 		waitForAndAssertCondition(5_000, tree.getDisplay(), //
-				() -> Arrays.asList(symbolCow) //
+				() -> List.of(symbolCow) //
 						.equals(Arrays.stream(tree.getItems())
 								.map(e -> ((DocumentSymbolWithURI) e.getData()).symbol)
 								.toList()) //
@@ -112,7 +112,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 
 		// wait for tree to render
 		waitForAndAssertCondition(5_000, tree.getDisplay(), //
-				() -> Arrays.asList(symbolCow, symbolFox, symbolCat) //
+				() -> List.of(symbolCow, symbolFox, symbolCat) //
 						.equals(Arrays.stream(tree.getItems())
 								.map(e -> ((DocumentSymbolWithURI) e.getData()).symbol)
 								.toList()) //
@@ -123,7 +123,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 
 		// wait for tree being sorted
 		waitForAndAssertCondition(5_000, tree.getDisplay(), //
-				() -> Arrays.asList(symbolCat, symbolCow, symbolFox) //
+				() -> List.of(symbolCat, symbolCow, symbolFox) //
 						.equals(Arrays.stream(tree.getItems())
 								.map(e -> ((DocumentSymbolWithURI) e.getData()).symbol)
 								.toList()) //

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsLabelProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsLabelProviderTest.java
@@ -31,43 +31,43 @@ public class SymbolsLabelProviderTest extends AbstractTest {
 
 	@Test
 	public void testShowKind() {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, true);
-		SymbolInformation info = new SymbolInformation("Foo", SymbolKind.Class, LOCATION);
+		final var labelProvider = new SymbolsLabelProvider(false, true);
+		final var info = new SymbolInformation("Foo", SymbolKind.Class, LOCATION);
 		assertEquals("Foo :Class", labelProvider.getText(info));
 	}
 
 	@Test
 	public void testShowKindLocation() {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(true, true);
-		SymbolInformation info = new SymbolInformation("Foo", SymbolKind.Class, LOCATION);
+		final var labelProvider = new SymbolsLabelProvider(true, true);
+		final var info = new SymbolInformation("Foo", SymbolKind.Class, LOCATION);
 		assertEquals("Foo :Class path/to/foo", labelProvider.getText(info));
 	}
 
 	@Test
 	public void testShowLocation() {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(true, false);
-		SymbolInformation info = new SymbolInformation("Foo", SymbolKind.Class, LOCATION);
+		final var labelProvider = new SymbolsLabelProvider(true, false);
+		final var info = new SymbolInformation("Foo", SymbolKind.Class, LOCATION);
 		assertEquals("Foo path/to/foo", labelProvider.getText(info));
 	}
 
 	@Test
 	public void testShowNeither() {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
-		SymbolInformation info = new SymbolInformation("Foo", SymbolKind.Class, LOCATION);
+		final var labelProvider = new SymbolsLabelProvider(false, false);
+		final var info = new SymbolInformation("Foo", SymbolKind.Class, LOCATION);
 		assertEquals("Foo", labelProvider.getText(info));
 	}
 
 	@Test
 	public void testGetStyledTextInalidLocationURI() {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
-		SymbolInformation info = new SymbolInformation("Foo", SymbolKind.Class, INVALID_LOCATION);
+		final var labelProvider = new SymbolsLabelProvider(false, false);
+		final var info = new SymbolInformation("Foo", SymbolKind.Class, INVALID_LOCATION);
 		assertEquals("Foo", labelProvider.getStyledText(info).getString());
 	}
 
 	@Test
 	public void testDocumentSymbolDetail () {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
-		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+		final var labelProvider = new SymbolsLabelProvider(false, false);
+		final var info = new DocumentSymbol("Foo", SymbolKind.Class,
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
@@ -76,8 +76,8 @@ public class SymbolsLabelProviderTest extends AbstractTest {
 
 	@Test
 	public void testDocumentSymbolDetailWithKind () {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, true);
-		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+		final var labelProvider = new SymbolsLabelProvider(false, true);
+		final var info = new DocumentSymbol("Foo", SymbolKind.Class,
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
@@ -86,8 +86,8 @@ public class SymbolsLabelProviderTest extends AbstractTest {
 
 	@Test
 	public void testDocumentSymbolWithUriDetail () {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, false);
-		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+		final var labelProvider = new SymbolsLabelProvider(false, false);
+		final var info = new DocumentSymbol("Foo", SymbolKind.Class,
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
@@ -97,8 +97,8 @@ public class SymbolsLabelProviderTest extends AbstractTest {
 
 	@Test
 	public void testDocumentSymbolDetailWithFileWithKind () {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, true);
-		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+		final var labelProvider = new SymbolsLabelProvider(false, true);
+		final var info = new DocumentSymbol("Foo", SymbolKind.Class,
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");
@@ -108,8 +108,8 @@ public class SymbolsLabelProviderTest extends AbstractTest {
 
 	@Test
 	public void testDocumentSymbolDetailWithFileWithKindDeprecated () {
-		SymbolsLabelProvider labelProvider = new SymbolsLabelProvider(false, true);
-		DocumentSymbol info = new DocumentSymbol("Foo", SymbolKind.Class,
+		final var labelProvider = new SymbolsLabelProvider(false, true);
+		final var info = new DocumentSymbol("Foo", SymbolKind.Class,
 				new Range(new Position(1, 0), new Position(1, 2)),
 				new Range(new Position(1, 0), new Position(1, 2)),
 				": additional detail");

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
@@ -11,8 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.rename;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -28,7 +27,6 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
-import org.eclipse.ltk.core.refactoring.TextChange;
 import org.junit.Test;
 
 public class LSPTextChangeTest extends AbstractTestWithProject {
@@ -36,8 +34,8 @@ public class LSPTextChangeTest extends AbstractTestWithProject {
 	@Test
 	public void testPerformOperationWorkspaceFile() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
-		TextEdit edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
-		PerformChangeOperation operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
+		final var edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
+		final var operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
 		operation.run(new NullProgressMonitor());
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
@@ -47,8 +45,8 @@ public class LSPTextChangeTest extends AbstractTestWithProject {
 	@Test
 	public void testRefactoringPreview() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
-		TextEdit edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
-		TextChange change = new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit);
+		final var edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
+		final var change = new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit);
 		IDocument preview = change.getPreviewDocument(new NullProgressMonitor());
 		assertEquals(preview.get(), "new");
 	}
@@ -57,8 +55,8 @@ public class LSPTextChangeTest extends AbstractTestWithProject {
 	public void testPerformOperationExternalFile() throws Exception {
 		File file = TestUtils.createTempFile("testPerformOperationExternalFile", ".lspt");
 		Files.write(file.toPath(), "old".getBytes());
-		TextEdit edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
-		PerformChangeOperation operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
+		final var edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
+		final var operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
 		operation.run(new NullProgressMonitor());
 		assertEquals(edit.getNewText(), new String(Files.readAllBytes(file.toPath())));
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
@@ -14,10 +14,7 @@
 package org.eclipse.lsp4e.test.rename;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -26,7 +23,6 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.commands.Command;
@@ -71,7 +67,7 @@ public class RenameTest extends AbstractTestWithProject {
 	@Test
 	public void testRenameHandlerEnablement() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
-		ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
+		final var editor = (ITextEditor) TestUtils.openEditor(file);
 		editor.selectAndReveal(1, 0);
 		ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
 		Command command = commandService.getCommand(IWorkbenchCommandConstants.FILE_RENAME);
@@ -90,7 +86,7 @@ public class RenameTest extends AbstractTestWithProject {
 
 		try {
 			IFile file = TestUtils.createUniqueTestFile(project, "old");
-			ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
+			final var editor = (ITextEditor) TestUtils.openEditor(file);
 			editor.selectAndReveal(1, 0);
 
 			ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
@@ -111,10 +107,10 @@ public class RenameTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
+		final var processor = new LSPRenameProcessor(document, 0);
 		processor.setNewName("new");
 		try {
-			ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
+			final var processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
 			processorBasedRefactoring.checkAllConditions(new NullProgressMonitor());
 			processorBasedRefactoring.createChange(new NullProgressMonitor()).perform(new NullProgressMonitor());
 		} catch (CoreException e) {
@@ -129,10 +125,10 @@ public class RenameTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
+		final var processor = new LSPRenameProcessor(document, 0);
 		processor.setNewName("new");
 		try {
-			ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
+			final var processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
 			processorBasedRefactoring.checkAllConditions(new NullProgressMonitor());
 			processorBasedRefactoring.createChange(new NullProgressMonitor()).perform(new NullProgressMonitor());
 		} catch (CoreException e) {
@@ -148,11 +144,11 @@ public class RenameTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setPrepareRenameResult(null);
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
+		final var processor = new LSPRenameProcessor(document, 0);
 		processor.setNewName("new");
 
 		try {
-			ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
+			final var processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
 			RefactoringStatus status = processorBasedRefactoring.checkAllConditions(new NullProgressMonitor());
 			assertEquals(RefactoringStatus.FATAL, status.getSeverity());
 		} catch (CoreException e) {
@@ -170,10 +166,10 @@ public class RenameTest extends AbstractTestWithProject {
 			manager.connectFileStore(store, new NullProgressMonitor());
 			IDocument document = ((ITextFileBuffer)manager.getFileStoreFileBuffer(store)).getDocument();
 			document.set("old");
-			LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
+			final var processor = new LSPRenameProcessor(document, 0);
 			processor.setNewName("new");
 			try {
-				ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
+				final var processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
 				processorBasedRefactoring.checkAllConditions(new NullProgressMonitor());
 				processorBasedRefactoring.createChange(new NullProgressMonitor()).perform(new NullProgressMonitor());
 			} catch (CoreException e) {
@@ -190,16 +186,16 @@ public class RenameTest extends AbstractTestWithProject {
 		IFile workspaceFile = TestUtils.createUniqueTestFile(project, "old");
 		File externalFile = TestUtils.createTempFile("testRenameChangeAlsoExternalFile", ".lspt");
 		Files.write(externalFile.toPath(), "old".getBytes());
-		Map<String, List<TextEdit>> edits = new HashMap<>(2, 1.f);
+		final var edits = new HashMap<String, List<TextEdit>>(2, 1.f);
 		edits.put(LSPEclipseUtils.toUri(workspaceFile).toString(), Collections.singletonList(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new")));
 		edits.put(LSPEclipseUtils.toUri(externalFile).toString(), Collections.singletonList(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new")));
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(new WorkspaceEdit(edits));
 		IDocument document = LSPEclipseUtils.getDocument(workspaceFile);
 		assertNotNull(document);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
+		final var processor = new LSPRenameProcessor(document, 0);
 		processor.setNewName("new");
 		try {
-			ProcessorBasedRefactoring processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
+			final var processorBasedRefactoring = new ProcessorBasedRefactoring(processor);
 			processorBasedRefactoring.checkAllConditions(new NullProgressMonitor());
 			processorBasedRefactoring.createChange(new NullProgressMonitor()).perform(new NullProgressMonitor());
 		} catch (CoreException e) {
@@ -213,18 +209,18 @@ public class RenameTest extends AbstractTestWithProject {
 	public void testRenameHandlerExecution() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
-		ITextEditor editor = (ITextEditor) TestUtils.openEditor(file);
+		final var editor = (ITextEditor) TestUtils.openEditor(file);
 		editor.selectAndReveal(1, 0);
 		ICommandService commandService = PlatformUI.getWorkbench().getService(ICommandService.class);
 		IHandlerService handlerService = PlatformUI.getWorkbench().getService(IHandlerService.class);
 		Command command = commandService.getCommand(IWorkbenchCommandConstants.FILE_RENAME);
 		assertTrue(command.isEnabled() && command.isHandled());
-		Event e = new Event();
+		final var e = new Event();
 		e.widget = editor.getAdapter(Control.class);
 		Shell ideShell = editor.getSite().getShell();
 		Display display = ideShell.getDisplay();
 		e.display = display;
-		AtomicBoolean renameDialogOkPressed = new AtomicBoolean();
+		final var renameDialogOkPressed = new AtomicBoolean();
 		Listener pressOKonRenameDialogPaint = event -> {
 			if (renameDialogOkPressed.get()) {
 				return;
@@ -256,7 +252,7 @@ public class RenameTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
+		final var processor = new LSPRenameProcessor(document, 0);
 
 		try {
 			processor.checkInitialConditions(new NullProgressMonitor());
@@ -270,11 +266,11 @@ public class RenameTest extends AbstractTestWithProject {
 	public void testPlaceholderUsingRangeFromPrepareRenameResult() throws Exception {
 		IFile file = TestUtils.createUniqueTestFile(project, "old");
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(createSimpleMockRenameEdit(LSPEclipseUtils.toUri(file)));
-		Range range = new Range(new Position(0, 1), new Position(0, 3)); // Two last letters of "old".
+		final var range = new Range(new Position(0, 1), new Position(0, 3)); // Two last letters of "old".
 		MockLanguageServer.INSTANCE.getTextDocumentService().setPrepareRenameResult(Either.forLeft(range));
 		IDocument document = LSPEclipseUtils.getDocument(file);
 		assertNotNull(document);
-		LSPRenameProcessor processor = new LSPRenameProcessor(document, 0);
+		final var processor = new LSPRenameProcessor(document, 0);
 
 		try {
 			processor.checkInitialConditions(new NullProgressMonitor());
@@ -286,7 +282,7 @@ public class RenameTest extends AbstractTestWithProject {
 
 	private void pressOk(Shell dialogShell) {
 		try {
-			Dialog dialog = (Dialog)dialogShell.getData();
+			final var dialog = (Dialog)dialogShell.getData();
 			Method okPressedMethod = Dialog.class.getDeclaredMethod("okPressed");
 			okPressedMethod.setAccessible(true);
 			okPressedMethod.invoke(dialog);
@@ -296,8 +292,8 @@ public class RenameTest extends AbstractTestWithProject {
 	}
 
 	private static WorkspaceEdit createSimpleMockRenameEdit(URI fileUri) {
-		WorkspaceEdit res = new WorkspaceEdit();
-		File f = new File(fileUri);
+		final var res = new WorkspaceEdit();
+		final var f = new File(fileUri);
 		res.setChanges(Collections.singletonMap(LSPEclipseUtils.toUri(f).toString(),
 				Collections.singletonList(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new"))));
 		return res;

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/RenameTest.java
@@ -187,8 +187,8 @@ public class RenameTest extends AbstractTestWithProject {
 		File externalFile = TestUtils.createTempFile("testRenameChangeAlsoExternalFile", ".lspt");
 		Files.write(externalFile.toPath(), "old".getBytes());
 		final var edits = new HashMap<String, List<TextEdit>>(2, 1.f);
-		edits.put(LSPEclipseUtils.toUri(workspaceFile).toString(), Collections.singletonList(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new")));
-		edits.put(LSPEclipseUtils.toUri(externalFile).toString(), Collections.singletonList(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new")));
+		edits.put(LSPEclipseUtils.toUri(workspaceFile).toString(), List.of(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new")));
+		edits.put(LSPEclipseUtils.toUri(externalFile).toString(), List.of(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new")));
 		MockLanguageServer.INSTANCE.getTextDocumentService().setRenameEdit(new WorkspaceEdit(edits));
 		IDocument document = LSPEclipseUtils.getDocument(workspaceFile);
 		assertNotNull(document);
@@ -295,7 +295,7 @@ public class RenameTest extends AbstractTestWithProject {
 		final var res = new WorkspaceEdit();
 		final var f = new File(fileUri);
 		res.setChanges(Collections.singletonMap(LSPEclipseUtils.toUri(f).toString(),
-				Collections.singletonList(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new"))));
+				List.of(new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new"))));
 		return res;
 	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticHighlightReconcilerStrategyTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticHighlightReconcilerStrategyTest.java
@@ -10,7 +10,6 @@ package org.eclipse.lsp4e.test.semanticTokens;
 
 import static org.junit.Assert.*;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
@@ -36,8 +35,8 @@ public class SemanticHighlightReconcilerStrategyTest extends AbstractTestWithPro
 		shell = new Shell();
 
 		// Setup Server Capabilities
-		List<String> tokenTypes = Arrays.asList("keyword");
-		List<String> tokenModifiers = Arrays.asList("obsolete");
+		List<String> tokenTypes = List.of("keyword");
+		List<String> tokenModifiers = List.of("obsolete");
 		SemanticTokensTestUtil.setSemanticTokensLegend(tokenTypes, tokenModifiers);
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticHighlightReconcilerStrategyTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticHighlightReconcilerStrategyTest.java
@@ -8,8 +8,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.semanticTokens;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -44,7 +43,7 @@ public class SemanticHighlightReconcilerStrategyTest extends AbstractTestWithPro
 
 	@Test
 	public void testKeyword() throws CoreException {
-		SemanticTokens semanticTokens = new SemanticTokens();
+		final var semanticTokens = new SemanticTokens();
 		semanticTokens.setData(SemanticTokensTestUtil.keywordSemanticTokens());
 
 		MockLanguageServer.INSTANCE.getTextDocumentService().setSemanticTokens(semanticTokens);
@@ -59,27 +58,27 @@ public class SemanticHighlightReconcilerStrategyTest extends AbstractTestWithPro
 		var backgroundColor = textViewer.getTextWidget().getBackground();
 
 		assertEquals(6, styleRanges.length);
-		
+
 		assertEquals(0, styleRanges[0].start);
 		assertEquals(4, styleRanges[0].length);
 		assertNotEquals(styleRanges[0].foreground, backgroundColor);
-		
+
 		assertEquals(4, styleRanges[1].start);
 		assertEquals(11, styleRanges[1].length);
 		assertNotEquals(styleRanges[1].foreground, backgroundColor);
-		
+
 		assertEquals(15, styleRanges[2].start);
 		assertEquals(4, styleRanges[2].length);
 		assertNotEquals(styleRanges[2].foreground, backgroundColor);
-		
+
 		assertEquals(19, styleRanges[3].start);
 		assertEquals(5, styleRanges[3].length);
 		assertNotEquals(styleRanges[3].foreground, backgroundColor);
-		
+
 		assertEquals(24, styleRanges[4].start);
 		assertEquals(7, styleRanges[4].length);
 		assertNotEquals(styleRanges[4].foreground, backgroundColor);
-		
+
 		assertEquals(31, styleRanges[5].start);
 		assertEquals(11, styleRanges[5].length);
 		assertNotEquals(styleRanges[5].foreground, backgroundColor);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensDataStreamProcessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensDataStreamProcessorTest.java
@@ -10,7 +10,6 @@ package org.eclipse.lsp4e.test.semanticTokens;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jface.text.Document;
@@ -30,7 +29,7 @@ public class SemanticTokensDataStreamProcessorTest extends AbstractTest {
 				.keywordTokenTypeMapper(SemanticTokensTestUtil.RED_TOKEN), SemanticTokensTestUtil.offsetMapper(document));
 
 		List<Integer> expectedStream = SemanticTokensTestUtil.keywordSemanticTokens();
-		List<StyleRange> expectedStyleRanges = Arrays.asList(//
+		List<StyleRange> expectedStyleRanges = List.of(//
 				new StyleRange(0, 4, SemanticTokensTestUtil.RED, null), //
 				new StyleRange(15, 4, SemanticTokensTestUtil.RED, null), //
 				new StyleRange(24, 7, SemanticTokensTestUtil.RED, null)//
@@ -43,8 +42,8 @@ public class SemanticTokensDataStreamProcessorTest extends AbstractTest {
 
 	private SemanticTokensLegend getSemanticTokensLegend() {
 		final var semanticTokensLegend = new SemanticTokensLegend();
-		semanticTokensLegend.setTokenTypes(Arrays.asList("keyword","other"));
-		semanticTokensLegend.setTokenModifiers(Arrays.asList("obsolete"));
+		semanticTokensLegend.setTokenTypes(List.of("keyword","other"));
+		semanticTokensLegend.setTokenModifiers(List.of("obsolete"));
 		return semanticTokensLegend;
 	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensDataStreamProcessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensDataStreamProcessorTest.java
@@ -24,9 +24,9 @@ public class SemanticTokensDataStreamProcessorTest extends AbstractTest {
 
 	@Test
 	public void testKeyword() {
-		Document document = new Document(SemanticTokensTestUtil.keywordText);
+		final var document = new Document(SemanticTokensTestUtil.keywordText);
 
-		SemanticTokensDataStreamProcessor processor = new SemanticTokensDataStreamProcessor(SemanticTokensTestUtil
+		final var processor = new SemanticTokensDataStreamProcessor(SemanticTokensTestUtil
 				.keywordTokenTypeMapper(SemanticTokensTestUtil.RED_TOKEN), SemanticTokensTestUtil.offsetMapper(document));
 
 		List<Integer> expectedStream = SemanticTokensTestUtil.keywordSemanticTokens();
@@ -42,7 +42,7 @@ public class SemanticTokensDataStreamProcessorTest extends AbstractTest {
 	}
 
 	private SemanticTokensLegend getSemanticTokensLegend() {
-		SemanticTokensLegend semanticTokensLegend = new SemanticTokensLegend();
+		final var semanticTokensLegend = new SemanticTokensLegend();
 		semanticTokensLegend.setTokenTypes(Arrays.asList("keyword","other"));
 		semanticTokensLegend.setTokenModifiers(Arrays.asList("obsolete"));
 		return semanticTokensLegend;

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensLegendProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensLegendProviderTest.java
@@ -8,8 +8,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.semanticTokens;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -22,7 +21,6 @@ import org.eclipse.lsp4e.LanguageServiceAccessor;
 import org.eclipse.lsp4e.operations.semanticTokens.SemanticHighlightReconcilerStrategy;
 import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
-import org.eclipse.lsp4j.SemanticTokensLegend;
 import org.junit.Test;
 
 public class SemanticTokensLegendProviderTest extends AbstractTestWithProject {
@@ -40,7 +38,7 @@ public class SemanticTokensLegendProviderTest extends AbstractTestWithProject {
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(file, c -> Boolean.TRUE).iterator()
 		.next();
 
-		SemanticTokensLegend semanticTokensLegend = new SemanticHighlightReconcilerStrategy().getSemanticTokensLegend(wrapper);
+		final var semanticTokensLegend = new SemanticHighlightReconcilerStrategy().getSemanticTokensLegend(wrapper);
 		assertNotNull(semanticTokensLegend);
 		assertEquals(tokenTypes, semanticTokensLegend.getTokenTypes());
 		assertEquals(tokenModifiers, semanticTokensLegend.getTokenModifiers());

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensLegendProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensLegendProviderTest.java
@@ -11,7 +11,6 @@ package org.eclipse.lsp4e.test.semanticTokens;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
@@ -28,8 +27,8 @@ public class SemanticTokensLegendProviderTest extends AbstractTestWithProject {
 	@Test
 	public void testSemanticTokensLegendProvider() throws CoreException, IOException {
 		// Setup Server Capabilities
-		List<String> tokenTypes = Arrays.asList("keyword","other");
-		List<String> tokenModifiers = Arrays.asList("obsolete");
+		List<String> tokenTypes = List.of("keyword","other");
+		List<String> tokenModifiers = List.of("obsolete");
 		SemanticTokensTestUtil.setSemanticTokensLegend(tokenTypes, tokenModifiers);
 
 		// Setup test data

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensTestUtil.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensTestUtil.java
@@ -9,7 +9,6 @@
 package org.eclipse.lsp4e.test.semanticTokens;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
@@ -36,9 +35,9 @@ public class SemanticTokensTestUtil {
 
 	public static List<Integer> keywordSemanticTokens() {
 		final var expectedTokens = new ArrayList<List<Integer>>();
-		expectedTokens.add(Arrays.asList(0,0,4,0,0));
-		expectedTokens.add(Arrays.asList(3,0,4,0,0));
-		expectedTokens.add(Arrays.asList(0,9,7,0,0));
+		expectedTokens.add(List.of(0,0,4,0,0));
+		expectedTokens.add(List.of(3,0,4,0,0));
+		expectedTokens.add(List.of(0,9,7,0,0));
 
 		return expectedTokens.stream().flatMap(List::stream).toList();
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensTestUtil.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensTestUtil.java
@@ -35,7 +35,7 @@ public class SemanticTokensTestUtil {
 			"}\n";
 
 	public static List<Integer> keywordSemanticTokens() {
-		List<List<Integer>> expectedTokens = new ArrayList<>();
+		final var expectedTokens = new ArrayList<List<Integer>>();
 		expectedTokens.add(Arrays.asList(0,0,4,0,0));
 		expectedTokens.add(Arrays.asList(3,0,4,0,0));
 		expectedTokens.add(Arrays.asList(0,9,7,0,0));
@@ -119,8 +119,8 @@ public class SemanticTokensTestUtil {
 		};
 	}
 	public static void setSemanticTokensLegend(final List<String> tokenTypes, List<String> tokenModifiers) {
-		SemanticTokensLegend legend = new SemanticTokensLegend(tokenTypes, tokenModifiers);
-		SemanticTokensWithRegistrationOptions semanticTokensWithRegistrationOptions = new SemanticTokensWithRegistrationOptions(legend);
+		final var legend = new SemanticTokensLegend(tokenTypes, tokenModifiers);
+		final var semanticTokensWithRegistrationOptions = new SemanticTokensWithRegistrationOptions(legend);
 		semanticTokensWithRegistrationOptions.setFull(true);
 		semanticTokensWithRegistrationOptions.setRange(false);
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/StyleRangeHolderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/StyleRangeHolderTest.java
@@ -10,7 +10,6 @@ package org.eclipse.lsp4e.test.semanticTokens;
 
 import static org.junit.Assert.*;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jface.text.DocumentEvent;
@@ -25,7 +24,7 @@ import org.junit.Test;
 public class StyleRangeHolderTest extends AbstractTest {
 
 	private static final Color RED = new Color(255, 0, 0);
-	private List<StyleRange> originalStyleRanges = Arrays.asList(new StyleRange(0, 4, RED, null), new StyleRange(15, 4, RED, null), new StyleRange(24, 7, RED, null));
+	private List<StyleRange> originalStyleRanges = List.of(new StyleRange(0, 4, RED, null), new StyleRange(15, 4, RED, null), new StyleRange(24, 7, RED, null));
 
 	@Test
 	public void testAllDocumentRanges() {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/StyleRangeHolderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/StyleRangeHolderTest.java
@@ -8,8 +8,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.semanticTokens;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,7 +29,7 @@ public class StyleRangeHolderTest extends AbstractTest {
 
 	@Test
 	public void testAllDocumentRanges() {
-		StyleRangeHolder holder = new StyleRangeHolder();
+		final var holder = new StyleRangeHolder();
 		holder.saveStyles(originalStyleRanges);
 
 		StyleRange[] allDocumentRanges = holder.overlappingRanges(new Region(0, 50));
@@ -41,7 +40,7 @@ public class StyleRangeHolderTest extends AbstractTest {
 
 	@Test
 	public void testPartialDocumentRanges() {
-		StyleRangeHolder holder = new StyleRangeHolder();
+		final var holder = new StyleRangeHolder();
 		holder.saveStyles(originalStyleRanges);
 
 		StyleRange[] allDocumentRanges = holder.overlappingRanges(new Region(0, 20)); // only two ranges overlap this region
@@ -51,10 +50,10 @@ public class StyleRangeHolderTest extends AbstractTest {
 
 	@Test
 	public void testDocumentChange() {
-		StyleRangeHolder holder = new StyleRangeHolder();
+		final var holder = new StyleRangeHolder();
 		holder.saveStyles(originalStyleRanges);
 
-		TextEvent textEvent = new TextEvent(0, 1, " ", null, new DocumentEvent(), false) {};
+		final var textEvent = new TextEvent(0, 1, " ", null, new DocumentEvent(), false) {};
 
 		// this will remove the first style and shift the last two
 		holder.textChanged(textEvent);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/symbols/SymbolsModelTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/symbols/SymbolsModelTest.java
@@ -11,13 +11,10 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.symbols;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 import org.eclipse.lsp4e.outline.SymbolsModel;
 import org.eclipse.lsp4e.test.utils.AbstractTest;
@@ -34,8 +31,8 @@ public class SymbolsModelTest extends AbstractTest {
 
 	@Test
 	public void test() {
-		List<SymbolInformation> items = new ArrayList<>();
-		Range range = new Range(new Position(0, 0), new Position(10, 0));
+		final var items = new ArrayList<SymbolInformation>();
+		var range = new Range(new Position(0, 0), new Position(10, 0));
 		items.add(createSymbolInformation("Namespace", SymbolKind.Namespace, range));
 
 		range = new Range(new Position(1, 0), new Position(9, 0));
@@ -44,8 +41,8 @@ public class SymbolsModelTest extends AbstractTest {
 		range = new Range(new Position(2, 0), new Position(8, 0));
 		items.add(createSymbolInformation("Method", SymbolKind.Method, range));
 
-		SymbolsModel symbolsModel = new SymbolsModel();
-		List<Either<SymbolInformation, DocumentSymbol>> eitherItems = new ArrayList<>(items.size());
+		final var symbolsModel = new SymbolsModel();
+		final var eitherItems = new ArrayList<Either<SymbolInformation, DocumentSymbol>>(items.size());
 		items.forEach(item -> eitherItems.add(Either.forLeft(item)));
 		symbolsModel.update(eitherItems);
 
@@ -70,8 +67,8 @@ public class SymbolsModelTest extends AbstractTest {
 	 */
 	@Test
 	public void testSymbolsMatchingStartingPositions() {
-		List<SymbolInformation> items = new ArrayList<>();
-		Range range = new Range(new Position(0, 0), new Position(10, 0));
+		final var items = new ArrayList<SymbolInformation>();
+		var range = new Range(new Position(0, 0), new Position(10, 0));
 		items.add(createSymbolInformation("Namespace", SymbolKind.Namespace, range));
 
 		range = new Range(new Position(0, 0), new Position(9, 0));
@@ -80,8 +77,8 @@ public class SymbolsModelTest extends AbstractTest {
 		range = new Range(new Position(1, 0), new Position(8, 0));
 		items.add(createSymbolInformation("Method", SymbolKind.Method, range));
 
-		SymbolsModel symbolsModel = new SymbolsModel();
-		List<Either<SymbolInformation, DocumentSymbol>> eitherItems = new ArrayList<>(items.size());
+		final var symbolsModel = new SymbolsModel();
+		final var eitherItems = new ArrayList<Either<SymbolInformation, DocumentSymbol>>(items.size());
 		items.forEach(item -> eitherItems.add(Either.forLeft(item)));
 		symbolsModel.update(eitherItems);
 
@@ -107,13 +104,13 @@ public class SymbolsModelTest extends AbstractTest {
 	 */
 	@Test
 	public void testDuplicateSymbols() {
-		List<SymbolInformation> items = new ArrayList<>();
-		Range range = new Range(new Position(0, 0), new Position(0, 0));
+		final var items = new ArrayList<SymbolInformation>();
+		final var range = new Range(new Position(0, 0), new Position(0, 0));
 		items.add(createSymbolInformation("Duplicate", SymbolKind.Namespace, range));
 		items.add(createSymbolInformation("Duplicate", SymbolKind.Namespace, range));
 
-		SymbolsModel symbolsModel = new SymbolsModel();
-		List<Either<SymbolInformation, DocumentSymbol>> eitherItems = new ArrayList<>(items.size());
+		final var symbolsModel = new SymbolsModel();
+		final var eitherItems = new ArrayList<Either<SymbolInformation, DocumentSymbol>>(items.size());
 		items.forEach(item -> eitherItems.add(Either.forLeft(item)));
 		symbolsModel.update(eitherItems);
 
@@ -126,10 +123,10 @@ public class SymbolsModelTest extends AbstractTest {
 
 	@Test
 	public void testGetElementsEmptyResponse() {
-		List<SymbolInformation> items = new ArrayList<>();
+		final var items = new ArrayList<SymbolInformation>();
 
-		SymbolsModel symbolsModel = new SymbolsModel();
-		List<Either<SymbolInformation, DocumentSymbol>> eitherItems = new ArrayList<>(items.size());
+		final var symbolsModel = new SymbolsModel();
+		final var eitherItems = new ArrayList<Either<SymbolInformation, DocumentSymbol>>(items.size());
 		items.forEach(item -> eitherItems.add(Either.forLeft(item)));
 		symbolsModel.update(eitherItems);
 
@@ -138,7 +135,7 @@ public class SymbolsModelTest extends AbstractTest {
 
 	@Test
 	public void testGetElementsNullResponse() {
-		SymbolsModel symbolsModel = new SymbolsModel();
+		final var symbolsModel = new SymbolsModel();
 		symbolsModel.update(null);
 
 		assertEquals(0, symbolsModel.getElements().length);
@@ -146,7 +143,7 @@ public class SymbolsModelTest extends AbstractTest {
 
 	@Test
 	public void testGetParentEmptyResponse() {
-		SymbolsModel symbolsModel = new SymbolsModel();
+		final var symbolsModel = new SymbolsModel();
 		symbolsModel.update(Collections.emptyList());
 
 		assertEquals(null, symbolsModel.getParent(null));
@@ -154,14 +151,14 @@ public class SymbolsModelTest extends AbstractTest {
 
 	@Test
 	public void testGetParentNullResponse() {
-		SymbolsModel symbolsModel = new SymbolsModel();
+		final var symbolsModel = new SymbolsModel();
 		symbolsModel.update(null);
 
 		assertEquals(null, symbolsModel.getParent(null));
 	}
 
 	private SymbolInformation createSymbolInformation(String name, SymbolKind kind, Range range) {
-		SymbolInformation symbolInformation = new SymbolInformation();
+		final var symbolInformation = new SymbolInformation();
 		symbolInformation.setName(name);
 		symbolInformation.setKind(kind);
 		symbolInformation.setLocation(new Location("file://test", range));

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/CreateAndRegisterContentTypeLSPLaunchConfigMapping.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/CreateAndRegisterContentTypeLSPLaunchConfigMapping.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.externaltools.internal.IExternalToolConstants;
@@ -51,7 +50,7 @@ public class CreateAndRegisterContentTypeLSPLaunchConfigMapping implements IStar
 		ILaunchConfigurationType externalType = launchManager.getLaunchConfigurationType(IExternalToolConstants.ID_PROGRAM_LAUNCH_CONFIGURATION_TYPE);
 		LanguageServersRegistry registry = LanguageServersRegistry.getInstance();
 		try {
-			String externalProcessLaunchName = "Mock external LS";
+			final var externalProcessLaunchName = "Mock external LS";
 			ILaunchConfiguration mockServerLauch = null;
 			for (ILaunchConfiguration launch : launchManager.getLaunchConfigurations(externalType)) {
 				if (launch.getName().equals(externalProcessLaunchName)) {
@@ -66,7 +65,7 @@ public class CreateAndRegisterContentTypeLSPLaunchConfigMapping implements IStar
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_SHOW_CONSOLE, false);
 				workingCopy.setAttribute(IExternalToolConstants.ATTR_BUILD_SCOPE, "${none}");
 				workingCopy.setAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, true);
-				String exe = "";
+				var exe = "";
 				if (Platform.OS_WIN32.equals(Platform.getOS())) {
 					exe = ".exe";
 				}
@@ -90,8 +89,8 @@ public class CreateAndRegisterContentTypeLSPLaunchConfigMapping implements IStar
 		if (loader instanceof URLClassLoader urlClassLoader) {
 			return Arrays.asList(urlClassLoader.getURLs()).stream().map(url -> url.getFile()).collect(Collectors.joining(System.getProperty("path.separator")));
 		}
-		LinkedList<Bundle> toProcess = new LinkedList<>();
-		Set<Bundle> processed = new HashSet<>();
+		final var toProcess = new LinkedList<Bundle>();
+		final var processed = new HashSet<Bundle>();
 		Bundle current = FrameworkUtil.getBundle(clazz);
 		if (current != null) {
 			toProcess.add(current);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/OtherFileStore.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/OtherFileStore.java
@@ -42,7 +42,7 @@ public class OtherFileStore  extends FileStore {
 
 	@Override
 	public IFileInfo fetchInfo(int options, IProgressMonitor monitor) throws CoreException {
-		FileInfo result = new FileInfo();
+		final var result = new FileInfo();
 		result.setDirectory(false);
 		result.setExists(true);
 		result.setLastModified(1);//last modified of zero indicates non-existence

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
@@ -45,7 +45,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Widget;
-import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
@@ -80,7 +79,7 @@ public class TestUtils {
 	public static IEditorPart openEditor(IFile file) throws PartInitException {
 		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
 		IWorkbenchPage page = workbenchWindow.getActivePage();
-		IEditorInput input = new FileEditorInput(file);
+		final var input = new FileEditorInput(file);
 
 		IEditorPart part = page.openEditor(input, "org.eclipse.ui.genericeditor.GenericEditor", false);
 		part.setFocus();
@@ -111,7 +110,7 @@ public class TestUtils {
 	public static IEditorPart getEditor(IFile file) {
 		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
 		IWorkbenchPage page = workbenchWindow.getActivePage();
-		IEditorInput input = new FileEditorInput(file);
+		final var input = new FileEditorInput(file);
 
 		return Arrays.asList(page.getEditorReferences()).stream()
 			.filter(r -> {

--- a/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mock Language Server to test LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.tests.mock
-Bundle-Version: 0.16.10.qualifier
+Bundle-Version: 0.16.11.qualifier
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.lsp4j;bundle-version="[0.23.0,0.24.0)",

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -155,9 +155,9 @@ public final class MockLanguageServer implements LanguageServer {
 	}
 
 	public static ServerCapabilities defaultServerCapabilities() {
-		ServerCapabilities capabilities = new ServerCapabilities();
+		final var capabilities = new ServerCapabilities();
 		capabilities.setTextDocumentSync(TextDocumentSyncKind.Full);
-		CompletionOptions completionProvider = new CompletionOptions(false, null);
+		final var completionProvider = new CompletionOptions(false, null);
 		capabilities.setCompletionProvider(completionProvider);
 		capabilities.setHoverProvider(true);
 		capabilities.setDefinitionProvider(true);
@@ -171,7 +171,7 @@ public final class MockLanguageServer implements LanguageServer {
 		capabilities.setDocumentHighlightProvider(Boolean.TRUE);
 		capabilities
 				.setExecuteCommandProvider(new ExecuteCommandOptions(Collections.singletonList(SUPPORTED_COMMAND_ID)));
-		RenameOptions prepareRenameProvider = new RenameOptions();
+		final var prepareRenameProvider = new RenameOptions();
 		prepareRenameProvider.setPrepareProvider(true);
 		Either<Boolean, RenameOptions> renameEither = Either.forRight(prepareRenameProvider);
 		capabilities.setRenameProvider(renameEither);
@@ -259,7 +259,7 @@ public final class MockLanguageServer implements LanguageServer {
 	}
 
 	public void setWillSaveWaitUntil(List<TextEdit> edits) {
-		TextDocumentSyncOptions textDocumentSyncOptions = new TextDocumentSyncOptions();
+	   final var textDocumentSyncOptions = new TextDocumentSyncOptions();
 		textDocumentSyncOptions.setWillSaveWaitUntil(true);
 		textDocumentSyncOptions.setSave(true);
 		textDocumentSyncOptions.setChange(TextDocumentSyncKind.Full);

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -118,7 +118,8 @@ public final class MockLanguageServer implements LanguageServer {
 	 * @throws InterruptedException
 	 */
 	public static void main(String[] args) throws InterruptedException, ExecutionException {
-		Launcher<LanguageClient> l = LSPLauncher.createServerLauncher(MockLanguageServer.INSTANCE, System.in, System.out);
+		Launcher<LanguageClient> l = LSPLauncher.createServerLauncher(MockLanguageServer.INSTANCE, System.in,
+				System.out);
 		Future<?> f = l.startListening();
 		MockLanguageServer.INSTANCE.addRemoteProxy(l.getRemoteProxy());
 		f.get();
@@ -129,7 +130,13 @@ public final class MockLanguageServer implements LanguageServer {
 			try {
 				future.join();
 			} catch (CancellationException | CompletionException e) {
-				System.err.println("Error waiting for in flight requests prior to teardown: " + e.getMessage());
+				System.err.println("Error waiting for in flight requests prior to teardown: " //
+						+ e.getClass().getSimpleName() + " with message "
+						+ (e.getMessage() == null ? "<null>" : '"' + e.getMessage()) //
+						+ (e.getCause() instanceof Throwable cause //
+								? " caused by " + cause.getClass().getSimpleName() + " with message "
+										+ (cause.getMessage() == null ? "<null>" : '"' + cause.getMessage()) //
+								: ""));
 			}
 		});
 	}
@@ -169,8 +176,7 @@ public final class MockLanguageServer implements LanguageServer {
 		capabilities.setDocumentLinkProvider(new DocumentLinkOptions());
 		capabilities.setSignatureHelpProvider(new SignatureHelpOptions());
 		capabilities.setDocumentHighlightProvider(Boolean.TRUE);
-		capabilities
-				.setExecuteCommandProvider(new ExecuteCommandOptions(List.of(SUPPORTED_COMMAND_ID)));
+		capabilities.setExecuteCommandProvider(new ExecuteCommandOptions(List.of(SUPPORTED_COMMAND_ID)));
 		final var prepareRenameProvider = new RenameOptions();
 		prepareRenameProvider.setPrepareProvider(true);
 		Either<Boolean, RenameOptions> renameEither = Either.forRight(prepareRenameProvider);
@@ -214,7 +220,7 @@ public final class MockLanguageServer implements LanguageServer {
 		this.textDocumentService.setMockCodeLenses(codeLens);
 	}
 
-	public void setDefinition(List<? extends Location> definitionLocations){
+	public void setDefinition(List<? extends Location> definitionLocations) {
 		this.textDocumentService.setMockDefinitionLocations(definitionLocations);
 	}
 

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -79,13 +79,13 @@ import org.eclipse.lsp4j.services.NotebookDocumentService;
 
 public final class MockLanguageServer implements LanguageServer {
 
-	public static MockLanguageServer INSTANCE = new MockLanguageServer(MockLanguageServer::defaultServerCapabilities);
-
 	/**
 	 * This command will be reported on initialization to be supported for execution
 	 * by the server
 	 */
-	public static String SUPPORTED_COMMAND_ID = "mock.command";
+	public static final String SUPPORTED_COMMAND_ID = "mock.command";
+
+	public static MockLanguageServer INSTANCE = new MockLanguageServer(MockLanguageServer::defaultServerCapabilities);
 
 	private volatile MockTextDocumentService textDocumentService = new MockTextDocumentService(
 			this::buildMaybeDelayedFuture);
@@ -170,7 +170,7 @@ public final class MockLanguageServer implements LanguageServer {
 		capabilities.setSignatureHelpProvider(new SignatureHelpOptions());
 		capabilities.setDocumentHighlightProvider(Boolean.TRUE);
 		capabilities
-				.setExecuteCommandProvider(new ExecuteCommandOptions(Collections.singletonList(SUPPORTED_COMMAND_ID)));
+				.setExecuteCommandProvider(new ExecuteCommandOptions(List.of(SUPPORTED_COMMAND_ID)));
 		final var prepareRenameProvider = new RenameOptions();
 		prepareRenameProvider.setPrepareProvider(true);
 		Either<Boolean, RenameOptions> renameEither = Either.forRight(prepareRenameProvider);
@@ -259,7 +259,7 @@ public final class MockLanguageServer implements LanguageServer {
 	}
 
 	public void setWillSaveWaitUntil(List<TextEdit> edits) {
-	   final var textDocumentSyncOptions = new TextDocumentSyncOptions();
+		final var textDocumentSyncOptions = new TextDocumentSyncOptions();
 		textDocumentSyncOptions.setWillSaveWaitUntil(true);
 		textDocumentSyncOptions.setSave(true);
 		textDocumentSyncOptions.setChange(TextDocumentSyncKind.Full);
@@ -316,7 +316,7 @@ public final class MockLanguageServer implements LanguageServer {
 	}
 
 	public void setDocumentSymbols(DocumentSymbol documentSymbol) {
-		this.textDocumentService.setDocumentSymbols(Collections.singletonList(documentSymbol));
+		this.textDocumentService.setDocumentSymbols(List.of(documentSymbol));
 	}
 
 	public void setDocumentSymbols(DocumentSymbol... documentSymbols) {

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServerMultiRootFolders.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServerMultiRootFolders.java
@@ -97,9 +97,9 @@ public final class MockLanguageServerMultiRootFolders implements LanguageServer 
 	}
 
 	private void resetInitializeResult() {
-		ServerCapabilities capabilities = new ServerCapabilities();
+		final var capabilities = new ServerCapabilities();
 		capabilities.setTextDocumentSync(TextDocumentSyncKind.Full);
-		CompletionOptions completionProvider = new CompletionOptions(false, null);
+		final var completionProvider = new CompletionOptions(false, null);
 		capabilities.setCompletionProvider(completionProvider);
 		capabilities.setHoverProvider(true);
 		capabilities.setDefinitionProvider(true);
@@ -111,8 +111,8 @@ public final class MockLanguageServerMultiRootFolders implements LanguageServer 
 		capabilities.setSignatureHelpProvider(new SignatureHelpOptions());
 		capabilities.setDocumentHighlightProvider(Boolean.TRUE);
 
-		WorkspaceServerCapabilities workspace = new WorkspaceServerCapabilities();
-		WorkspaceFoldersOptions workspaceFolders = new WorkspaceFoldersOptions();
+		final var workspace = new WorkspaceServerCapabilities();
+		final var workspaceFolders = new WorkspaceFoldersOptions();
 		workspaceFolders.setSupported(Boolean.TRUE);
 
 		workspace.setWorkspaceFolders(workspaceFolders);

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -123,7 +123,7 @@ public class MockTextDocumentService implements TextDocumentService {
 	public <U> MockTextDocumentService(Function<U, CompletableFuture<U>> futureFactory) {
 		this._futureFactory = futureFactory;
 		// Some default values for mocks, can be overriden
-		CompletionItem item = new CompletionItem();
+		final var item = new CompletionItem();
 		item.setLabel("Mock completion item");
 		mockCompletionList = new CompletionList(false, Collections.singletonList(item));
 		mockHover = new Hover(Collections.singletonList(Either.forLeft("Mock hover")), null);

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -125,8 +125,8 @@ public class MockTextDocumentService implements TextDocumentService {
 		// Some default values for mocks, can be overriden
 		final var item = new CompletionItem();
 		item.setLabel("Mock completion item");
-		mockCompletionList = new CompletionList(false, Collections.singletonList(item));
-		mockHover = new Hover(Collections.singletonList(Either.forLeft("Mock hover")), null);
+		mockCompletionList = new CompletionList(false, List.of(item));
+		mockHover = new Hover(List.of(Either.forLeft("Mock hover")), null);
 		mockPrepareRenameResult = Either3
 				.forSecond(new PrepareRenameResult(new Range(new Position(0, 0), new Position(0, 0)), "placeholder"));
 		this.documentSymbols = Collections.emptyList();
@@ -208,7 +208,7 @@ public class MockTextDocumentService implements TextDocumentService {
 		}
 		File file = new File(URI.create(params.getTextDocument().getUri()));
 		if (file.exists() && file.length() > 100) {
-			return CompletableFuture.completedFuture(Collections.singletonList(new CodeLens(
+			return CompletableFuture.completedFuture(List.of(new CodeLens(
 					new Range(new Position(1, 0), new Position(1, 1)), new Command("Hi, I'm a CodeLens", null), null)));
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ContentTypeToLSPLaunchConfigEntry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ContentTypeToLSPLaunchConfigEntry.java
@@ -11,9 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
@@ -75,7 +73,7 @@ public class ContentTypeToLSPLaunchConfigEntry extends ContentTypeToLanguageServ
 		String launchName = launchParts[1];
 		Set<String> launchModes = Collections.singleton(ILaunchManager.RUN_MODE);
 		if (launchParts.length > 2) {
-			launchModes = new HashSet<>(Arrays.asList(launchParts[2].split("\\+"))); //$NON-NLS-1$
+			launchModes = Set.of(launchParts[2].split("\\+")); //$NON-NLS-1$
 		}
 		IContentType contentType = Platform.getContentTypeManager().getContentType(contentTypeId);
 		if (contentType == null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -17,7 +17,6 @@ import static org.eclipse.lsp4e.internal.NullSafetyHelper.castNonNull;
 
 import java.io.File;
 import java.net.URI;
-import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Map;
@@ -179,7 +178,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private boolean createChangeEvent(DocumentEvent event) {
 		Assert.isTrue(changeParams == null);
 		final var changeParams = this.changeParams = new DidChangeTextDocumentParams(new VersionedTextDocumentIdentifier(),
-				Collections.singletonList(new TextDocumentContentChangeEvent()));
+				List.of(new TextDocumentContentChangeEvent()));
 		changeParams.getTextDocument().setUri(fileUri.toASCIIString());
 
 		IDocument document = event.getDocument();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -342,7 +342,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		long modificationStamp = DocumentUtil.getDocumentModificationStamp(document);
 
 		FormattingOptions formatOptions = LSPFormatter.getFormatOptions();
-		TextDocumentIdentifier docId = new TextDocumentIdentifier(fileUri.toString());
+		final var docId = new TextDocumentIdentifier(fileUri.toString());
 
 		final ServerCapabilities capabilities = languageServerWrapper.getServerCapabilities();
 		if (capabilities != null

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -948,7 +948,7 @@ public final class LSPEclipseUtils {
 			}
 
 			// multiple documents or some ResourceChanges => create a refactoring
-			Map<URI, Range> changedURIs = new HashMap<>();
+			final var changedURIs = new HashMap<URI, Range>();
 			CompositeChange change = toCompositeChange(wsEdit, name, changedURIs);
 
 			final var changeOperation = new PerformChangeOperation(change);
@@ -973,7 +973,7 @@ public final class LSPEclipseUtils {
 	}
 
 	private static void runRefactorWizardOperation(Change change) {
-		Refactoring refactoring = new Refactoring() {
+		final var refactoring = new Refactoring() {
 
 			@Override
 			public String getName() {
@@ -998,7 +998,7 @@ public final class LSPEclipseUtils {
 			}
 
 		};
-		RefactoringWizard wizard = new RefactoringWizard(refactoring,
+		final var wizard = new RefactoringWizard(refactoring,
 				RefactoringWizard.DIALOG_BASED_USER_INTERFACE |
 				RefactoringWizard.NO_BACK_BUTTON_ON_STATUS_DIALOG
 		) {
@@ -1023,8 +1023,8 @@ public final class LSPEclipseUtils {
 	 *         <code>false</code> otherwise, thus the wsEdit needs to be performed differently.
 	 */
 	private static boolean applyWorkspaceEditIfSingleOpenFile(WorkspaceEdit wsEdit) {
-		Set<URI> documentUris = new HashSet<>();
-		final List<TextEdit> firstDocumentEdits = new ArrayList<>(); // collect edits
+		final var documentUris = new HashSet<URI>();
+		final var firstDocumentEdits = new ArrayList<TextEdit>(); // collect edits
 		if (wsEdit.getChanges() != null && !wsEdit.getChanges().isEmpty()) {
 			wsEdit.getChanges().entrySet().stream()
 				.map(Entry::getKey)
@@ -1261,8 +1261,7 @@ public final class LSPEclipseUtils {
 				Comparator.comparingInt(Position::getLine).thenComparingInt(Position::getCharacter).reversed()));
 		LSPTextChange[] changes = textEdits.stream().map(te -> new LSPTextChange("Line: %d".formatted(te.getRange().getStart().getLine() + 1), uri, te)) //$NON-NLS-1$
 				.toArray(LSPTextChange[]::new);
-		CompositeChange cc = new CompositeChange(uri.toString(), changes);
-		return cc;
+		return new CompositeChange(uri.toString(), changes);
 	}
 
 	public static URI toUri(IPath absolutePath) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -1257,9 +1257,10 @@ public final class LSPEclipseUtils {
 	 *            CompositeChange with LSP text edits
 	 */
 	private static Change toChanges(URI uri, List<TextEdit> textEdits) {
-		Collections.sort(textEdits, Comparator.comparing(edit -> edit.getRange().getStart(),
-				Comparator.comparingInt(Position::getLine).thenComparingInt(Position::getCharacter).reversed()));
-		LSPTextChange[] changes = textEdits.stream().map(te -> new LSPTextChange("Line: %d".formatted(te.getRange().getStart().getLine() + 1), uri, te)) //$NON-NLS-1$
+		LSPTextChange[] changes = textEdits.stream()
+				.sorted(Comparator.comparing((TextEdit edit) -> edit.getRange().getStart(),
+						Comparator.comparingInt(Position::getLine).thenComparingInt(Position::getCharacter).reversed()))
+				.map(te -> new LSPTextChange("Line: %d".formatted(te.getRange().getStart().getLine() + 1), uri, te)) //$NON-NLS-1$
 				.toArray(LSPTextChange[]::new);
 		return new CompositeChange(uri.toString(), changes);
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -76,7 +76,7 @@ public class LanguageClientImpl implements LanguageClient {
 	@Override
 	public CompletableFuture<List<@Nullable Object>> configuration(ConfigurationParams configurationParams) {
 		// override as needed
-		List<@Nullable Object> list = new ArrayList<>(configurationParams.getItems().size());
+		final var list = new ArrayList<@Nullable Object>(configurationParams.getItems().size());
 		for (int i = 0; i < configurationParams.getItems().size(); i++) {
 			list.add(null);
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -195,14 +195,14 @@ public class LanguageServerWrapper {
 		this.serverDefinition = serverDefinition;
 		this.connectedDocuments = new HashMap<>();
 		String projectName = (project != null && project.getName() != null && !serverDefinition.isSingleton) ? ("@" + project.getName()) : "";  //$NON-NLS-1$//$NON-NLS-2$
-		String dispatcherThreadNameFormat = "LS-" + serverDefinition.id + projectName + "#dispatcher"; //$NON-NLS-1$ //$NON-NLS-2$
+		final var dispatcherThreadNameFormat = "LS-" + serverDefinition.id + projectName + "#dispatcher"; //$NON-NLS-1$ //$NON-NLS-2$
 		this.dispatcher = Executors
 				.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(dispatcherThreadNameFormat).build());
 
 		// Executor service passed through to the LSP4j layer when we attempt to start the LS. It will be used
 		// to create a listener that sits on the input stream and processes inbound messages (responses, or server-initiated
 		// requests).
-		String listenerThreadNameFormat = "LS-" + serverDefinition.id + projectName + "#listener-%d"; //$NON-NLS-1$ //$NON-NLS-2$
+		final var listenerThreadNameFormat = "LS-" + serverDefinition.id + projectName + "#listener-%d"; //$NON-NLS-1$ //$NON-NLS-2$
 		this.listener = Executors
 				.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat(listenerThreadNameFormat).build());
 	}
@@ -609,7 +609,7 @@ public class LanguageServerWrapper {
 		new WorkspaceJob("Setting watch projects on server " + serverDefinition.label) { //$NON-NLS-1$
 			@Override
 			public IStatus runInWorkspace(@Nullable IProgressMonitor monitor) throws CoreException {
-				WorkspaceFoldersChangeEvent wsFolderEvent = new WorkspaceFoldersChangeEvent();
+				final var wsFolderEvent = new WorkspaceFoldersChangeEvent();
 				wsFolderEvent.getAdded().addAll(getRelevantWorkspaceFolders());
 				if (currentLS != null && currentLS == LanguageServerWrapper.this.languageServer) {
 					currentLS.getWorkspaceService()
@@ -860,7 +860,7 @@ public class LanguageServerWrapper {
 		// Note this doesn't get the .thenApplyAsync(Function.identity()) chained on additionally, unlike
 		// the public-facing version of this method, because we trust the LSPExecutor implementations to
 		// make sure the server response thread doesn't get blocked by any further work
-		AtomicReference<@Nullable CompletableFuture<T>> request = new AtomicReference<>();
+		final var request = new AtomicReference<@Nullable CompletableFuture<T>>();
 		Function<LanguageServer, CompletableFuture<T>> cancelWrapper = ls -> {
 			CompletableFuture<T> res = fn.apply(ls);
 			request.set(res);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -160,7 +160,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * non-empty response, and with an empty <code>Optional</code> if none of the servers returned a non-empty result.
 	 */
 	public <T> CompletableFuture<Optional<T>> computeFirst(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> queryLS) {
-		final CompletableFuture<Optional<T>> result = new CompletableFuture<>();
+		final var result = new CompletableFuture<Optional<T>>();
 
 		// Dispatch the request to the servers, appending a step to each such that
 		// the first to return a non-null result will be the overall result.
@@ -334,7 +334,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 		protected List<CompletableFuture<@Nullable LanguageServerWrapper>> getServers() {
 			// Compute list of servers from project & filter
 			Collection<LanguageServerWrapper> startedWrappers = order(LanguageServiceAccessor.getStartedWrappers(project, getFilter(), !restartStopped));
-			List<CompletableFuture<@Nullable LanguageServerWrapper>> wrappers = new ArrayList<>(startedWrappers.size());
+			final var wrappers = new ArrayList<CompletableFuture<@Nullable LanguageServerWrapper>>(startedWrappers.size());
 			for (LanguageServerWrapper wrapper :  startedWrappers) {
 				wrappers.add(wrapper.getInitializedServer().thenApply(ls -> wrapper));
 			}
@@ -348,7 +348,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 
 	protected Collection<LanguageServerWrapper> order(Collection<LanguageServerWrapper> wrappers) {
 		if (serverDefinition != null && wrappers.size() > 1) {
-			List<LanguageServerWrapper> temp = new ArrayList<>(wrappers);
+			final var temp = new ArrayList<LanguageServerWrapper>(wrappers);
 			for (int i = 0; i < temp.size(); i++) {
 				LanguageServerWrapper wrapper = temp.get(i);
 				if (Objects.equals(serverDefinition, wrapper.serverDefinition)) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -378,7 +378,7 @@ public class LanguageServiceAccessor {
 		synchronized (startedServers) {
 			LanguageServerWrapper wrapper = startedServers.stream().filter(w -> w.serverDefinition == serverDefinition)
 					.findFirst().orElseGet(() -> {
-						LanguageServerWrapper w = new LanguageServerWrapper(serverDefinition, null);
+						final var w = new LanguageServerWrapper(serverDefinition, null);
 						startedServers.add(w);
 						return w;
 					});
@@ -406,7 +406,7 @@ public class LanguageServiceAccessor {
 
 	private static List<LanguageServerWrapper> getStartedWrappers(Predicate<LanguageServerWrapper> canOperatePredicate,
 			@Nullable Predicate<ServerCapabilities> capabilitiesPredicate, boolean onlyActiveLS) {
-		List<LanguageServerWrapper> result = new ArrayList<>();
+		final var result = new ArrayList<LanguageServerWrapper>();
 		for (LanguageServerWrapper wrapper : startedServers) {
 			if ((!onlyActiveLS || wrapper.isActive()) && canOperatePredicate.test(wrapper)
 					&& capabilitiesComply(wrapper, capabilitiesPredicate)) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyContentProvider.java
@@ -163,17 +163,17 @@ public class CallHierarchyContentProvider implements ITreeContentProvider {
 				.callHierarchyIncomingCalls(incomingCallParams)).thenApply(incomingCalls -> {
 					if (incomingCalls == null)
 						return new ArrayList<CallHierarchyViewTreeNode>(0);
-					List<CallHierarchyViewTreeNode> children = new ArrayList<>(incomingCalls.size());
+					final var children = new ArrayList<CallHierarchyViewTreeNode>(incomingCalls.size());
 					for (CallHierarchyIncomingCall call : incomingCalls) {
 						CallHierarchyItem callContainer = call.getFrom();
 						List<Range> callSites = call.getFromRanges();
 						for (Range callSite : callSites) {
-							CallHierarchyViewTreeNode child = new CallHierarchyViewTreeNode(callContainer, callSite);
+							final var child = new CallHierarchyViewTreeNode(callContainer, callSite);
 							child.setParent(callee);
 							children.add(child);
 						}
 						if (callSites.isEmpty()) {
-							CallHierarchyViewTreeNode child = new CallHierarchyViewTreeNode(callContainer);
+							final var child = new CallHierarchyViewTreeNode(callContainer);
 							child.setParent(callee);
 							children.add(child);
 						}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyLabelProvider.java
@@ -41,7 +41,7 @@ public class CallHierarchyLabelProvider extends LabelProvider implements IStyled
 	public @Nullable StyledString getStyledText(final @Nullable Object element) {
 		if (element instanceof CallHierarchyViewTreeNode treeNode) {
 			CallHierarchyItem callContainer = treeNode.getCallContainer();
-			StyledString styledString = new StyledString();
+			final var styledString = new StyledString();
 			appendName(styledString, callContainer.getName());
 			if (callContainer.getDetail() != null) {
 				appendDetail(styledString, callContainer.getDetail());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyView.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyView.java
@@ -77,7 +77,7 @@ public class CallHierarchyView extends ViewPart {
 	 *            the offset into the document of the current selection.
 	 */
 	public void initialize(final IDocument document, final int offset) {
-		HierarchyViewInput viewInput = new HierarchyViewInput(document, offset);
+		final var viewInput = new HierarchyViewInput(document, offset);
 		treeViewer.setInput(viewInput);
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/format/IFormatRegionsProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/format/IFormatRegionsProvider.java
@@ -12,10 +12,8 @@
 package org.eclipse.lsp4e.format;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.eclipse.compare.internal.DocLineComparator;
-import org.eclipse.compare.rangedifferencer.IRangeComparator;
 import org.eclipse.compare.rangedifferencer.RangeDifference;
 import org.eclipse.compare.rangedifferencer.RangeDifferencer;
 import org.eclipse.core.filebuffers.FileBuffers;
@@ -92,7 +90,7 @@ public interface IFormatRegionsProvider {
 	 *
 	 */
 	public static IRegion @Nullable [] calculateEditedLineRegions(final IDocument document, final IProgressMonitor monitor) {
-		final IRegion[] @Nullable [] result = new IRegion[1][];
+		final var result = new IRegion[1] @Nullable [];
 
 		SafeRunner.run(new ISafeRunnable() {
 			@Override
@@ -139,11 +137,11 @@ public interface IFormatRegionsProvider {
 				 * here in order to prevent loading of the Compare plug-in at load
 				 * time of this class.
 				 */
-				Object leftSide = new DocLineComparator(oldDocument, null, false);
-				Object rightSide = new DocLineComparator(currentDocument, null, false);
+				final var leftSide = new DocLineComparator(oldDocument, null, false);
+				final var rightSide = new DocLineComparator(currentDocument, null, false);
 
-				RangeDifference[] differences = RangeDifferencer.findDifferences((IRangeComparator) leftSide,
-						(IRangeComparator) rightSide);
+				RangeDifference[] differences = RangeDifferencer.findDifferences(leftSide,
+						rightSide);
 
 				// It holds that:
 				// 1. Ranges are sorted:
@@ -151,7 +149,7 @@ public interface IFormatRegionsProvider {
 				// 2. Successive changed lines are merged into on RangeDifference
 				//     forAll r1,r2 element differences: r1.rightStart() < r2.rightStart() -> r1.rightEnd() < r2.rightStart
 
-				List<IRegion> regions = new ArrayList<>();
+				final var regions = new ArrayList<IRegion>();
 				final int numberOfLines = currentDocument.getNumberOfLines();
 				for (RangeDifference curr : differences) {
 					if (curr.kind() == RangeDifference.CHANGE) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.internal;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.lsp4j.CodeActionCapabilities;
@@ -65,7 +64,7 @@ public class SupportedFeatures {
 	public static TextDocumentClientCapabilities getTextDocumentClientCapabilities() {
 		final var textDocumentClientCapabilities = new TextDocumentClientCapabilities();
 		final var codeAction = new CodeActionCapabilities(new CodeActionLiteralSupportCapabilities(
-				new CodeActionKindCapabilities(Arrays.asList(CodeActionKind.QuickFix, CodeActionKind.Refactor,
+				new CodeActionKindCapabilities(List.of(CodeActionKind.QuickFix, CodeActionKind.Refactor,
 						CodeActionKind.RefactorExtract, CodeActionKind.RefactorInline,
 						CodeActionKind.RefactorRewrite, CodeActionKind.Source,
 						CodeActionKind.SourceOrganizeImports))),
@@ -79,7 +78,7 @@ public class SupportedFeatures {
 		textDocumentClientCapabilities.setPublishDiagnostics(new PublishDiagnosticsCapabilities());
 		final var completionItemCapabilities = new CompletionItemCapabilities(Boolean.TRUE);
 		completionItemCapabilities
-				.setDocumentationFormat(Arrays.asList(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
+				.setDocumentationFormat(List.of(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
 		completionItemCapabilities.setInsertTextModeSupport(new CompletionItemInsertTextModeSupportCapabilities(List.of(InsertTextMode.AsIs, InsertTextMode.AdjustIndentation)));
 		completionItemCapabilities.setResolveSupport(new CompletionItemResolveSupportCapabilities(List.of("documentation", "detail", "additionalTextEdits"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		final var completionCapabilities = new CompletionCapabilities(completionItemCapabilities);
@@ -99,7 +98,7 @@ public class SupportedFeatures {
 		textDocumentClientCapabilities.setDocumentLink(new DocumentLinkCapabilities());
 		final var documentSymbol = new DocumentSymbolCapabilities();
 		documentSymbol.setHierarchicalDocumentSymbolSupport(true);
-		documentSymbol.setSymbolKind(new SymbolKindCapabilities(Arrays.asList(SymbolKind.Array,
+		documentSymbol.setSymbolKind(new SymbolKindCapabilities(List.of(SymbolKind.Array,
 				SymbolKind.Boolean, SymbolKind.Class, SymbolKind.Constant, SymbolKind.Constructor,
 				SymbolKind.Enum, SymbolKind.EnumMember, SymbolKind.Event, SymbolKind.Field, SymbolKind.File,
 				SymbolKind.Function, SymbolKind.Interface, SymbolKind.Key, SymbolKind.Method, SymbolKind.Module,
@@ -110,7 +109,7 @@ public class SupportedFeatures {
 		textDocumentClientCapabilities.setFoldingRange(new FoldingRangeCapabilities());
 		textDocumentClientCapabilities.setFormatting(new FormattingCapabilities(Boolean.TRUE));
 		final var hoverCapabilities = new HoverCapabilities();
-		hoverCapabilities.setContentFormat(Arrays.asList(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
+		hoverCapabilities.setContentFormat(List.of(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
 		textDocumentClientCapabilities.setHover(hoverCapabilities);
 		textDocumentClientCapabilities.setOnTypeFormatting(null); // TODO
 		textDocumentClientCapabilities.setRangeFormatting(new RangeFormattingCapabilities());
@@ -135,7 +134,7 @@ public class SupportedFeatures {
 		workspaceClientCapabilities.setWorkspaceFolders(Boolean.TRUE);
 		final var editCapabilities = new WorkspaceEditCapabilities();
 		editCapabilities.setDocumentChanges(Boolean.TRUE);
-		editCapabilities.setResourceOperations(Arrays.asList(ResourceOperationKind.Create,
+		editCapabilities.setResourceOperations(List.of(ResourceOperationKind.Create,
 				ResourceOperationKind.Delete, ResourceOperationKind.Rename));
 		editCapabilities.setFailureHandling(FailureHandlingKind.Undo);
 		editCapabilities.setChangeAnnotationSupport(new WorkspaceEditChangeAnnotationSupportCapabilities(true));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
@@ -121,7 +121,7 @@ public class SupportedFeatures {
 		textDocumentClientCapabilities.setSignatureHelp(new SignatureHelpCapabilities());
 		textDocumentClientCapabilities
 				.setSynchronization(new SynchronizationCapabilities(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE));
-		SelectionRangeCapabilities selectionRange = new SelectionRangeCapabilities();
+		final var selectionRange = new SelectionRangeCapabilities();
 		textDocumentClientCapabilities.setSelectionRange(selectionRange);
 		return textDocumentClientCapabilities;
 	}
@@ -133,14 +133,14 @@ public class SupportedFeatures {
 		workspaceClientCapabilities.setExecuteCommand(new ExecuteCommandCapabilities(Boolean.TRUE));
 		workspaceClientCapabilities.setSymbol(new SymbolCapabilities(Boolean.TRUE));
 		workspaceClientCapabilities.setWorkspaceFolders(Boolean.TRUE);
-		WorkspaceEditCapabilities editCapabilities = new WorkspaceEditCapabilities();
+		final var editCapabilities = new WorkspaceEditCapabilities();
 		editCapabilities.setDocumentChanges(Boolean.TRUE);
 		editCapabilities.setResourceOperations(Arrays.asList(ResourceOperationKind.Create,
 				ResourceOperationKind.Delete, ResourceOperationKind.Rename));
 		editCapabilities.setFailureHandling(FailureHandlingKind.Undo);
 		editCapabilities.setChangeAnnotationSupport(new WorkspaceEditChangeAnnotationSupportCapabilities(true));
 		workspaceClientCapabilities.setWorkspaceEdit(editCapabilities);
-		CodeLensWorkspaceCapabilities codeLensWorkspaceCapabilities = new CodeLensWorkspaceCapabilities(true);
+		final var codeLensWorkspaceCapabilities = new CodeLensWorkspaceCapabilities(true);
 		workspaceClientCapabilities.setCodeLens(codeLensWorkspaceCapabilities);
 		return workspaceClientCapabilities;
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
@@ -116,8 +116,8 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 	}
 
 	private ShowMessageRequestParams reportServerError(LanguageServerDefinition serverDefinition, Throwable t) {
-		ShowMessageRequestParams params = new ShowMessageRequestParams();
-		String title = "Error Executing Quick Fix"; //$NON-NLS-1$
+		final var params = new ShowMessageRequestParams();
+		final var title = "Error Executing Quick Fix"; //$NON-NLS-1$
 		params.setType(MessageType.Error);
 		params.setMessage("Failed to fetch quick fix edit for '" //$NON-NLS-1$
 				+ codeAction.getTitle()

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
@@ -131,7 +131,7 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 					.withPreferredServer(LanguageServersRegistry.getInstance().getDefinition((String) attributes[0]));
 			if (executor.anyMatching()) {
 				final var diagnostic = (Diagnostic) attributes[1];
-				final var context = new CodeActionContext(Collections.singletonList(diagnostic));
+				final var context = new CodeActionContext(List.of(diagnostic));
 				final var params = new CodeActionParams();
 				params.setContext(context);
 				params.setTextDocument(castNonNull(LSPEclipseUtils.toTextDocumentIdentifier(res)));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/LSPCodeActionMarkerResolution.java
@@ -176,7 +176,7 @@ public class LSPCodeActionMarkerResolution implements IMarkerResolutionGenerator
 					final var ca = (ContentAssistant) f.get(quickAssistant);
 					Method m = ContentAssistant.class.getDeclaredMethod("isProposalPopupActive"); //$NON-NLS-1$
 					m.setAccessible(true);
-					boolean isProposalPopupActive = (Boolean) castNonNull(m.invoke(ca));
+					final var isProposalPopupActive = (Boolean) castNonNull(m.invoke(ca));
 					if (isProposalPopupActive) {
 						quickAssistant.showPossibleQuickAssists();
 					}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/ColorInformationMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/color/ColorInformationMining.java
@@ -74,7 +74,7 @@ public class ColorInformationMining extends LineContentCodeMining {
 			Rectangle location = Geometry.toDisplay(styledText, new Rectangle(event.x, event.y, 1, 1));
 			shell.setLocation(location.x, location.y);
 			// Open color dialog
-			ColorDialog dialog = new ColorDialog(shell);
+			final var dialog = new ColorDialog(shell);
 			dialog.setRGB(LSPEclipseUtils.toRGBA(colorInformation.getColor()).rgb);
 			RGB rgb = dialog.open();
 			if (rgb != null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionSnippetParser.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionSnippetParser.java
@@ -58,7 +58,7 @@ class CompletionSnippetParser {
 	 * @return the text to apply to the editor
 	 */
 	public String parse() {
-		StringBuilder insertTextBuilder = new StringBuilder(snippetText.length());
+		final var insertTextBuilder = new StringBuilder(snippetText.length());
 		while (hasRemaining()) {
 			char current = readChar();
 			switch (current) {
@@ -105,7 +105,7 @@ class CompletionSnippetParser {
 			// A tabstop position like $1
 			String key = readNumberKey();
 			snippetToDocumentOffset += key.length() + 1;
-			LinkedPosition position = new LinkedPosition(document, insertionOffset + snippetOffset - snippetToDocumentOffset, 0);
+			final var position = new LinkedPosition(document, insertionOffset + snippetOffset - snippetToDocumentOffset, 0);
 			addLinkedPosition(key, position);
 			return ""; //$NON-NLS-1$
 		} else if (isCharacterForVariableName(firstChar)) {
@@ -217,8 +217,8 @@ class CompletionSnippetParser {
 	}
 
 	private List<String> readChoiceValues() throws DollarExpressionParseException {
-		List<String> valueList = new ArrayList<>();
-		StringBuilder valueBuilder = new StringBuilder();
+		final var valueList = new ArrayList<String>();
+		final var valueBuilder = new StringBuilder();
 		while (true) {
 			if (!hasRemaining()) {
 				throw new DollarExpressionParseException();
@@ -252,7 +252,7 @@ class CompletionSnippetParser {
 	}
 
 	private String readTextValue() throws DollarExpressionParseException {
-		StringBuilder valueBuilder = new StringBuilder();
+		final var valueBuilder = new StringBuilder();
 		while (true) {
 			if (!hasRemaining()) {
 				throw new DollarExpressionParseException();
@@ -312,7 +312,7 @@ class CompletionSnippetParser {
 	}
 
 	private String readNumberKey() {
-		StringBuilder keyBuilder = new StringBuilder();
+		final var keyBuilder = new StringBuilder();
 		while (hasRemaining() && Character.isDigit(peekChar())) {
 			keyBuilder.append(readChar());
 		}
@@ -320,7 +320,7 @@ class CompletionSnippetParser {
 	}
 
 	private String readVariableKey() {
-		StringBuilder keyBuilder = new StringBuilder();
+		final var keyBuilder = new StringBuilder();
 		while (hasRemaining() && isCharacterForVariableName(peekChar())) {
 			keyBuilder.append(readChar());
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -502,7 +502,7 @@ public class LSCompletionProposal
 			}
 			insertionOffset = computeNewOffset(item.getAdditionalTextEdits(), insertionOffset, document);
 			if (item.getInsertTextFormat() == InsertTextFormat.Snippet) {
-				var completionSnippetParser = new CompletionSnippetParser(document, insertText, insertionOffset, this::getVariableValue);
+				final var completionSnippetParser = new CompletionSnippetParser(document, insertText, insertionOffset, this::getVariableValue);
 				insertText = completionSnippetParser.parse();
 				regions = completionSnippetParser.getLinkedPositions();
 				if (!regions.isEmpty() && firstPosition == null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
@@ -126,8 +126,8 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 			return createErrorProposal(offset, e);
 		}
 
-		List<ICompletionProposal> proposals = Collections.synchronizedList(new ArrayList<>());
-		AtomicBoolean anyIncomplete = new AtomicBoolean(false);
+		final var proposals = Collections.synchronizedList(new ArrayList<ICompletionProposal>());
+		final var anyIncomplete = new AtomicBoolean(false);
 		try {
 			// Cancel the previous LSP requests 'textDocument/completions' and
 			// completionLanguageServersFuture
@@ -136,7 +136,7 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 			// Initialize a new cancel support to register:
 			// - LSP requests 'textDocument/completions'
 			// - completionLanguageServersFuture
-			CancellationSupport cancellationSupport = new CancellationSupport();
+			final var cancellationSupport = new CancellationSupport();
 			final var completionLanguageServersFuture = this.completionLanguageServersFuture = LanguageServers
 					.forDocument(document).withFilter(capabilities -> capabilities.getCompletionProvider() != null) //
 					.collectAll((w, ls) -> cancellationSupport.execute(ls.getTextDocumentService().completion(param)) //
@@ -379,7 +379,7 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 		}
 		additionalTriggers.stream().filter(s -> !Strings.isNullOrEmpty(s)).map(triggerChar -> triggerChar.charAt(0))
 				.forEach(triggers::add);
-		char[] res = new char[triggers.size()];
+		final var res = new char[triggers.size()];
 		int i = 0;
 		for (Character c : triggers) {
 			res[i] = c;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -142,7 +142,7 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 	}
 
 	private WorkspaceJob updateMarkers(PublishDiagnosticsParams diagnostics, IResource resource) {
-		WorkspaceJob job = new WorkspaceJob("Update markers from diagnostics") { //$NON-NLS-1$
+		final var job = new WorkspaceJob("Update markers from diagnostics") { //$NON-NLS-1$
 			@Override
 			public boolean belongsTo(@Nullable Object family) {
 				return LanguageServerPlugin.FAMILY_UPDATE_MARKERS == family;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -14,7 +14,6 @@ import static org.eclipse.lsp4e.internal.NullSafetyHelper.castNonNull;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -159,16 +158,18 @@ public class LSPFoldingReconcilingStrategy
 		// find and mark all folding annotations with length 0 for deletion
 		markInvalidAnnotationsForDeletion(deletions, existing);
 
-		try {
-			if (ranges != null) {
-				Collections.sort(ranges, Comparator.comparing(FoldingRange::getEndLine));
-				for (FoldingRange foldingRange : ranges) {
-					updateAnnotation(deletions, existing, additions, foldingRange.getStartLine(),
-							foldingRange.getEndLine(), collapseImports && FoldingRangeKind.Imports.equals(foldingRange.getKind()));
-				}
-			}
-		} catch (BadLocationException e) {
-			// should never occur
+		if (ranges != null) {
+			ranges.stream() //
+					.sorted(Comparator.comparing(FoldingRange::getEndLine)) //
+					.forEach(foldingRange -> {
+						try {
+							updateAnnotation(deletions, existing, additions, foldingRange.getStartLine(),
+									foldingRange.getEndLine(),
+									collapseImports && FoldingRangeKind.Imports.equals(foldingRange.getKind()));
+						} catch (BadLocationException e) {
+							// should never occur
+						}
+					});
 		}
 
 		// be sure projection has not been disabled

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -44,7 +44,7 @@ public class LSPFormatter {
 		}
 		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document).withFilter(LSPFormatter::supportsFormatting);
 		FormattingOptions formatOptions = getFormatOptions();
-		TextDocumentIdentifier docId = new TextDocumentIdentifier(uri.toString());
+		final var docId = new TextDocumentIdentifier(uri.toString());
 
 		DocumentRangeFormattingParams rangeParams = getRangeFormattingParams(document, textSelection, formatOptions,
 				docId);
@@ -69,7 +69,7 @@ public class LSPFormatter {
 
 	public static DocumentFormattingParams getFullFormatParams(FormattingOptions formatOptions,
 			TextDocumentIdentifier docId) {
-		DocumentFormattingParams params = new DocumentFormattingParams();
+		final var params = new DocumentFormattingParams();
 		params.setTextDocument(docId);
 		params.setOptions(formatOptions);
 		return params;
@@ -77,7 +77,7 @@ public class LSPFormatter {
 
 	public static DocumentRangeFormattingParams getRangeFormattingParams(IDocument document, ITextSelection textSelection,
 			FormattingOptions formatOptions, TextDocumentIdentifier docId) throws BadLocationException {
-		DocumentRangeFormattingParams rangeParams = new DocumentRangeFormattingParams();
+		final var rangeParams = new DocumentRangeFormattingParams();
 		rangeParams.setTextDocument(docId);
 		rangeParams.setOptions(formatOptions);
 		boolean fullFormat = textSelection.getLength() == 0;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
@@ -158,7 +158,7 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 		ColorRegistry colorRegistry = JFaceResources.getColorRegistry();
 		Color foreground = colorRegistry.get("org.eclipse.ui.workbench.HOVER_FOREGROUND"); //$NON-NLS-1$
 		Color background = colorRegistry.get("org.eclipse.ui.workbench.HOVER_BACKGROUND"); //$NON-NLS-1$
-		String style = "<style TYPE='text/css'>html { " + //$NON-NLS-1$
+		final var style = "<style TYPE='text/css'>html { " + //$NON-NLS-1$
 				"font-family: " + JFaceResources.getDefaultFontDescriptor().getFontData()[0].getName() + "; " + //$NON-NLS-1$ //$NON-NLS-2$
 				"font-size: " + Integer.toString(JFaceResources.getDefaultFontDescriptor().getFontData()[0].getHeight()) //$NON-NLS-1$
 				+ "pt; " + //$NON-NLS-1$

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -143,9 +143,9 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 			if (document == null) {
 				return null;
 			}
-			boolean[] oneHoverAtLeast = new boolean[] { false };
-			int[] regionStartOffset = new int[] { 0 };
-			int[] regionEndOffset = new int[] { document.getLength() };
+			final var oneHoverAtLeast = new boolean[] { false };
+			final var regionStartOffset = new int[] { 0 };
+			final var regionEndOffset = new int[] { document.getLength() };
 			castNonNull(this.request).get(GET_TIMEOUT_MS, TimeUnit.MILLISECONDS).stream()
 				.filter(Objects::nonNull)
 				.map(Hover::getRange)

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/InlayHintProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/InlayHintProvider.java
@@ -45,8 +45,8 @@ public class InlayHintProvider extends AbstractCodeMiningProvider {
 			} catch (BadLocationException e) {
 				LanguageServerPlugin.logWarning("Unable to compute end of document", e); //$NON-NLS-1$
 			}
-			Range viewPortRange = new Range(new Position(0,0), end);
-			InlayHintParams param = new InlayHintParams(LSPEclipseUtils.toTextDocumentIdentifier(docURI), viewPortRange);
+			final var viewPortRange = new Range(new Position(0,0), end);
+			final var param = new InlayHintParams(LSPEclipseUtils.toTextDocumentIdentifier(docURI), viewPortRange);
 			List<LSPLineContentCodeMining> inlayHintResults = Collections.synchronizedList(new ArrayList<>());
 			return LanguageServers.forDocument(document).withCapability(ServerCapabilities::getInlayHintProvider)
 					.collectAll((w, ls) -> ls.getTextDocumentService().inlayHint(param).thenAcceptAsync(inlayHints -> {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/LSPLineContentCodeMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/LSPLineContentCodeMining.java
@@ -171,10 +171,10 @@ public class LSPLineContentCodeMining extends LineContentCodeMining {
 				gc = new GC(image);
 				font = new Font(display, fontData);
 				gc.setFont(font);
-				Point origin = new Point(0, 0);
+				final var origin = new Point(0, 0);
 				for (InlayHintLabelPart labelPart : labelParts) {
 					Point size = gc.stringExtent(labelPart.getValue());
-					Rectangle bounds = new Rectangle(origin.x, origin.y, size.x, size.y);
+					final var bounds = new Rectangle(origin.x, origin.y, size.x, size.y);
 					if (bounds.contains(relativeLocation)) {
 						return Optional.of(labelPart);
 					} else {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
@@ -30,7 +30,6 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.ITextViewerLifecycle;
 import org.eclipse.jface.text.link.ILinkedModeListener;
 import org.eclipse.jface.text.link.LinkedModeModel;
-import org.eclipse.jface.text.link.LinkedModeUI;
 import org.eclipse.jface.text.link.LinkedModeUI.ExitFlags;
 import org.eclipse.jface.text.link.LinkedPosition;
 import org.eclipse.jface.text.link.LinkedPositionGroup;
@@ -194,8 +193,8 @@ public class LSPLinkedEditingReconcilingStrategy extends LSPLinkedEditingBase
 					linkedModel.addGroup(toJFaceGroup(ranges));
 					linkedModel.forceInstall();
 					final var sourceViewer = castNonNull(LSPLinkedEditingReconcilingStrategy.this.sourceViewer);
-					ITextSelection selectionBefore = (ITextSelection) sourceViewer.getSelectionProvider().getSelection();
-					LinkedModeUI linkedMode = new EditorLinkedModeUI(linkedModel, sourceViewer);
+					final var selectionBefore = (ITextSelection) sourceViewer.getSelectionProvider().getSelection();
+					final var linkedMode = new EditorLinkedModeUI(linkedModel, sourceViewer);
 					linkedMode.setExitPolicy((model, event, offset, length) -> {
 						if (event.character == 0 || event.character == '\b') {
 							return null;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/FileAndURIMatchContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/FileAndURIMatchContentProvider.java
@@ -11,7 +11,6 @@ package org.eclipse.lsp4e.operations.references;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.viewers.ITreeContentProvider;
@@ -49,7 +48,7 @@ public class FileAndURIMatchContentProvider implements ITreeContentProvider {
 
 	@Override
 	public Object[] getElements(@Nullable Object inputElement) {
-		List<Object> res = new ArrayList<>();
+		final var res = new ArrayList<>();
 		res.addAll(Arrays.asList(delegate.getElements(inputElement == this.searchResult ? this.filteredFileSearchResult : inputElement)));
 		if (inputElement instanceof AbstractTextSearchResult searchResult) {
 			res.addAll(Arrays.stream(searchResult.getElements()).filter(URI.class::isInstance).toList());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/FileAndURIMatchLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/FileAndURIMatchLabelProvider.java
@@ -63,12 +63,12 @@ public class FileAndURIMatchLabelProvider extends DecoratingStyledCellLabelProvi
 					return new StyledString(uri.getPath());
 				} else {
 					try {
-						URI trimmedURI = new URI(uri.getScheme(),
+						final var trimmedURI = new URI(uri.getScheme(),
 							uri.getAuthority(),
 							uri.getPath(),
 							null, // Ignore the query part of the input url
 							uri.getFragment());
-						StyledString res = new StyledString(trimmedURI.toString());
+						final var res = new StyledString(trimmedURI.toString());
 						if (uri.getQuery() != null) {
 							res.append("?" + uri.getRawQuery(), StyledString.QUALIFIER_STYLER); //$NON-NLS-1$
 						}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchResultPage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/references/LSSearchResultPage.java
@@ -35,11 +35,11 @@ public class LSSearchResultPage extends FileSearchPage {
 	@Override
 	public void configureTreeViewer(TreeViewer viewer) {
 		super.configureTreeViewer(viewer);
-		FileTreeContentProvider fileMatchContentProvider = (FileTreeContentProvider)viewer.getContentProvider();
+		final var fileMatchContentProvider = (FileTreeContentProvider)viewer.getContentProvider();
 		final var contentProvider = new FileAndURIMatchContentProvider(fileMatchContentProvider);
 		viewer.setContentProvider(contentProvider);
-		DecoratingFileSearchLabelProvider fileMatchDecoratingLabelProvider = (DecoratingFileSearchLabelProvider)viewer.getLabelProvider();
-		FileAndURIMatchBaseLabelProvider baseLabelProvider = new FileAndURIMatchBaseLabelProvider(fileMatchDecoratingLabelProvider.getStyledStringProvider());
+		final var fileMatchDecoratingLabelProvider = (DecoratingFileSearchLabelProvider)viewer.getLabelProvider();
+		final var baseLabelProvider = new FileAndURIMatchBaseLabelProvider(fileMatchDecoratingLabelProvider.getStyledStringProvider());
 		viewer.setLabelProvider(new FileAndURIMatchLabelProvider(baseLabelProvider, fileMatchDecoratingLabelProvider));
 		viewer.setComparator(new ViewerComparator() {
 			@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/selectionRange/LSPSelectionRangeAbstractHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/selectionRange/LSPSelectionRangeAbstractHandler.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.selectionRange;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -214,7 +213,7 @@ public abstract class LSPSelectionRangeAbstractHandler extends LSPDocumentAbstra
 			if (identifier == null) {
 				return CompletableFuture.completedFuture(null);
 			}
-			List<Position> positions = Collections.singletonList(position);
+			List<Position> positions = List.of(position);
 			final var params = new SelectionRangeParams(identifier, positions);
 			return LanguageServers.forDocument(document).withCapability(ServerCapabilities::getSelectionRangeProvider)
 					.computeFirst(languageServer -> languageServer.getTextDocumentService().selectionRange(params))

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/selectionRange/LSPSelectionRangeAbstractHandler.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/selectionRange/LSPSelectionRangeAbstractHandler.java
@@ -70,7 +70,7 @@ public abstract class LSPSelectionRangeAbstractHandler extends LSPDocumentAbstra
 		}
 
 		public static SelectionRangeHandler getSelectionRangeHandler(StyledText styledText) {
-			SelectionRangeHandler handler = (SelectionRangeHandler) styledText.getData(KEY);
+			var handler = (SelectionRangeHandler) styledText.getData(KEY);
 			if (handler == null) {
 				handler = new SelectionRangeHandler(styledText);
 			}
@@ -215,7 +215,7 @@ public abstract class LSPSelectionRangeAbstractHandler extends LSPDocumentAbstra
 				return CompletableFuture.completedFuture(null);
 			}
 			List<Position> positions = Collections.singletonList(position);
-			SelectionRangeParams params = new SelectionRangeParams(identifier, positions);
+			final var params = new SelectionRangeParams(identifier, positions);
 			return LanguageServers.forDocument(document).withCapability(ServerCapabilities::getSelectionRangeProvider)
 					.computeFirst(languageServer -> languageServer.getTextDocumentService().selectionRange(params))
 					.thenApply(ranges -> ranges.stream().filter(Objects::nonNull).findFirst());

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticTokensDataStreamProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticTokensDataStreamProcessor.java
@@ -154,7 +154,7 @@ public class SemanticTokensDataStreamProcessor {
 		if (attr != null) {
 			final int style = attr.getStyle();
 			final int fontStyle = style & (SWT.ITALIC | SWT.BOLD | SWT.NORMAL);
-			final StyleRange styleRange = new StyleRange(offset, length, attr.getForeground(), attr.getBackground(), fontStyle);
+			final var styleRange = new StyleRange(offset, length, attr.getForeground(), attr.getBackground(), fontStyle);
 			styleRange.strikeout = (style & TextAttribute.STRIKETHROUGH) != 0;
 			styleRange.underline = (style & TextAttribute.UNDERLINE) != 0;
 			styleRange.font = attr.getFont();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyContentProvider.java
@@ -52,7 +52,7 @@ public class TypeHierarchyContentProvider implements ITreeContentProvider {
 					return new Object[0];
 				}
 				Position position = LSPEclipseUtils.toPosition(textSelection.getOffset(), document);
-				TypeHierarchyPrepareParams prepare = new TypeHierarchyPrepareParams(identifier, position);
+				final var prepare = new TypeHierarchyPrepareParams(identifier, position);
 				return LanguageServers.forDocument(document).withPreferredServer(lsDefinition)
 					.computeFirst((wrapper, ls) -> ls.getTextDocumentService().prepareTypeHierarchy(prepare).thenApply(items -> new SimpleEntry<>(wrapper, items)))
 					.thenApply(entry -> {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyDialog.java
@@ -57,8 +57,8 @@ public class TypeHierarchyDialog extends PopupDialog {
 		final var filteredTree = new FilteredTree(parent, SWT.BORDER, new PatternFilter(), true, false) {
 			@Override
 			protected Composite createFilterControls(Composite parent) {
-				Composite composite = new Composite(parent, SWT.NONE);
-				GridLayout layout = new GridLayout(2, false);
+				final var composite = new Composite(parent, SWT.NONE);
+				final var layout = new GridLayout(2, false);
 				layout.horizontalSpacing=0;
 				layout.marginWidth=0;
 				layout.marginHeight=0;
@@ -73,8 +73,8 @@ public class TypeHierarchyDialog extends PopupDialog {
 			}
 
 			private void createToolBar(Composite composite) {
-				ToolBar toolbar = new ToolBar(composite, HOVER_SHELLSTYLE);
-				ToolItem hierchyModeItem = new ToolItem(toolbar, SWT.PUSH);
+				final var toolbar = new ToolBar(composite, HOVER_SHELLSTYLE);
+				final var hierchyModeItem = new ToolItem(toolbar, SWT.PUSH);
 				updateHierarchyModeItem(hierchyModeItem, showSuperTypes);
 
 				hierchyModeItem.addSelectionListener(new SelectionAdapter() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyView.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyView.java
@@ -331,8 +331,8 @@ public class TypeHierarchyView extends ViewPart {
 		return new FilteredTree(parent, SWT.BORDER, new PatternFilter(), true, false) {
 			@Override
 			protected Composite createFilterControls(Composite parent) {
-				Composite composite = new Composite(parent, SWT.NONE);
-				GridLayout layout = new GridLayout(2, false);
+				final var composite = new Composite(parent, SWT.NONE);
+				final var layout = new GridLayout(2, false);
 				layout.horizontalSpacing=0;
 				layout.marginWidth=0;
 				layout.marginHeight=0;
@@ -347,8 +347,8 @@ public class TypeHierarchyView extends ViewPart {
 			}
 
 			private void createToolBar(Composite composite) {
-				ToolBar toolbar = new ToolBar(composite, org.eclipse.jface.dialogs.PopupDialog.HOVER_SHELLSTYLE);
-				ToolItem hierchyModeItem = new ToolItem(toolbar, SWT.PUSH);
+				final var toolbar = new ToolBar(composite, org.eclipse.jface.dialogs.PopupDialog.HOVER_SHELLSTYLE);
+				final var hierchyModeItem = new ToolItem(toolbar, SWT.PUSH);
 				updateHierarchyModeItem(hierchyModeItem, contentProvider.showSuperTypes);
 
 				hierchyModeItem.addSelectionListener(new SelectionAdapter() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -374,7 +374,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			return;
 		final URI documentURI = outlineViewerInput.documentURI;
 		if (documentURI == null) {
-			IllegalStateException exception = new IllegalStateException("documentURI == null");  //$NON-NLS-1$
+			final var exception = new IllegalStateException("documentURI == null");  //$NON-NLS-1$
 			lastError = exception;
 			LanguageServerPlugin.logError(exception);
 			viewer.getControl().getDisplay().asyncExec(viewer::refresh);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/CreateFileChange.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/refactoring/CreateFileChange.java
@@ -16,7 +16,6 @@ package org.eclipse.lsp4e.refactoring;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -104,7 +103,7 @@ public class CreateFileChange extends ResourceChange {
 
 		final var fEncoding = initializeEncoding();
 
-		try (InputStream is= new ByteArrayInputStream(fSource.getBytes(fEncoding))) {
+		try (var is = new ByteArrayInputStream(fSource.getBytes(fEncoding))) {
 
 			IFile ifile = LSPEclipseUtils.getFileHandle(this.uri);
 
@@ -132,7 +131,7 @@ public class CreateFileChange extends ResourceChange {
 				if (foldersToCreate.isEmpty()) {
 					return new DeleteResourceChange(ifile.getFullPath(), true);
 				} else {
-					CompositeChange undoChange = new CompositeChange("Undo " + getName()); //$NON-NLS-1$
+					final var undoChange = new CompositeChange("Undo " + getName()); //$NON-NLS-1$
 					undoChange.add(new DeleteResourceChange(ifile.getFullPath(), true));
 					Collections.reverse(foldersToCreate);
 					for (IFolder folder : foldersToCreate) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
@@ -146,7 +146,7 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 		addButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				NewContentTypeLSPLaunchDialog dialog = new NewContentTypeLSPLaunchDialog(getShell());
+				final var dialog = new NewContentTypeLSPLaunchDialog(getShell());
 				if (dialog.open() == IDialogConstants.OK_ID) {
 					workingCopy.add(new ContentTypeToLSPLaunchConfigEntry(dialog.getContentType(),
 							dialog.getLaunchConfiguration(), dialog.getLaunchMode()));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
@@ -197,7 +197,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 		logFolderLabel.setText(NLS.bind(Messages.preferencesPage_logging_fileLogsLocation, LoggingStreamConnectionProviderProxy.getLogDirectory()));
 		logFolderLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 3, 1));
 		logFolderLabel.addSelectionListener(widgetSelectedAdapter(e -> {
-			SmartImportWizard importWizard = new SmartImportWizard();
+			final var importWizard = new SmartImportWizard();
 			importWizard.setInitialImportSource(LoggingStreamConnectionProviderProxy.getLogDirectory());
 			WizardDialog dialog = new WizardDialog(logFolderLabel.getShell(), importWizard);
 			dialog.open();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/NewContentTypeLSPLaunchDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/NewContentTypeLSPLaunchDialog.java
@@ -144,8 +144,8 @@ public class NewContentTypeLSPLaunchDialog extends Dialog {
 		launchConfigViewer.setLabelProvider(new DecoratingLabelProvider(DebugUITools.newDebugModelPresentation(), PlatformUI.getWorkbench().getDecoratorManager().getLabelDecorator()));
 		launchConfigViewer.setContentProvider(new LaunchConfigurationTreeContentProvider(null, getShell()));
 		launchConfigViewer.setInput(DebugPlugin.getDefault().getLaunchManager());
-		ComboViewer launchModeViewer = new ComboViewer(res);
-		GridData comboGridData = new GridData(SWT.RIGHT, SWT.DEFAULT, true, false, 2, 1);
+		final var launchModeViewer = new ComboViewer(res);
+		final var comboGridData = new GridData(SWT.RIGHT, SWT.DEFAULT, true, false, 2, 1);
 		comboGridData.widthHint = 100;
 		launchModeViewer.getControl().setLayoutData(comboGridData);
 		launchModeViewer.setContentProvider(new ArrayContentProvider());


### PR DESCRIPTION
*Please don't squash this commit when merging for better transparency of the changes.*

This PR applies various refactorings to the code base, mainly:
1. it makes use of the `var` keyword for local variable assignment where the actual type is immediately recognizable through an implicit cast or a constructor call on the right side of the assignement
2. Replaces usage of `Collections.singletonList` and `Arrays.asList` (if beneficial) with Java 9's `List.of`
3. Replaces usage of `Collections.sort` in places where an unsafe assumption was made that the input list will always be mutable.