### PR TITLE
fix: don't eagerly set temporary launcherFuture

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -90,7 +90,7 @@ public class LanguageServiceAccessorTest extends AbstractTestWithProject {
 		var testFile = createFile(project, "shouldUseExtension.lspt", "");
 		// Force LS to initialize and open file
 		LanguageServers.forDocument(LSPEclipseUtils.getDocument(testFile)).anyMatching();
-		assertTrue(hasActiveLanguageServers(testFile, MATCH_ALL));
+		waitForAndAssertCondition(10_000, () -> hasActiveLanguageServers(testFile, MATCH_ALL));
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class LanguageServiceAccessorTest extends AbstractTestWithProject {
 		var testFile = createFile(project, "shouldUseRunConfiguration.lspt2", "");
 		// Force LS to initialize and open file
 		LanguageServers.forDocument(LSPEclipseUtils.getDocument(testFile)).anyMatching();
-		assertTrue(hasActiveLanguageServers(testFile, MATCH_ALL));
+		waitForAndAssertCondition(10_000, () -> hasActiveLanguageServers(testFile, MATCH_ALL));
 	}
 
 	@Test

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -281,7 +281,6 @@ public class LanguageServerWrapper {
 		if (this.initializeFuture == null) {
 			final URI rootURI = getRootURI();
 			final Job job = createInitializeLanguageServerJob();
-			this.launcherFuture = new CompletableFuture<>();
 			this.initializeFuture = CompletableFuture.supplyAsync(() -> {
 				advanceInitializeFutureMonitor();
 				final StreamConnectionProvider lspStreamProvider;


### PR DESCRIPTION
Setting a temporary launcherFuture before the actual initialization results in LanguageServerWrapper#isActive to return true despite the connection to the language server process has not yet been established.