### PR TITLE
refact: cleanup SupportedFeatures class

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
@@ -63,10 +63,14 @@ public class SupportedFeatures {
 
 	public static TextDocumentClientCapabilities getTextDocumentClientCapabilities() {
 		final var textDocumentClientCapabilities = new TextDocumentClientCapabilities();
-		final var codeAction = new CodeActionCapabilities(new CodeActionLiteralSupportCapabilities(
-				new CodeActionKindCapabilities(List.of(CodeActionKind.QuickFix, CodeActionKind.Refactor,
-						CodeActionKind.RefactorExtract, CodeActionKind.RefactorInline,
-						CodeActionKind.RefactorRewrite, CodeActionKind.Source,
+		final var codeAction = new CodeActionCapabilities(
+				new CodeActionLiteralSupportCapabilities(new CodeActionKindCapabilities(List.of( //
+						CodeActionKind.QuickFix, //
+						CodeActionKind.Refactor, //
+						CodeActionKind.RefactorExtract, //
+						CodeActionKind.RefactorInline, //
+						CodeActionKind.RefactorRewrite, //
+						CodeActionKind.Source, //
 						CodeActionKind.SourceOrganizeImports))),
 				true);
 		codeAction.setDataSupport(true);
@@ -76,40 +80,43 @@ public class SupportedFeatures {
 		textDocumentClientCapabilities.setInlayHint(new InlayHintCapabilities());
 		textDocumentClientCapabilities.setColorProvider(new ColorProviderCapabilities());
 		textDocumentClientCapabilities.setPublishDiagnostics(new PublishDiagnosticsCapabilities());
-		final var completionItemCapabilities = new CompletionItemCapabilities(Boolean.TRUE);
-		completionItemCapabilities
-				.setDocumentationFormat(List.of(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
-		completionItemCapabilities.setInsertTextModeSupport(new CompletionItemInsertTextModeSupportCapabilities(List.of(InsertTextMode.AsIs, InsertTextMode.AdjustIndentation)));
-		completionItemCapabilities.setResolveSupport(new CompletionItemResolveSupportCapabilities(List.of("documentation", "detail", "additionalTextEdits"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		final var completionItemCapabilities = new CompletionItemCapabilities(true);
+		completionItemCapabilities.setDocumentationFormat(List.of( //
+				MarkupKind.MARKDOWN, //
+				MarkupKind.PLAINTEXT));
+		completionItemCapabilities.setInsertTextModeSupport(new CompletionItemInsertTextModeSupportCapabilities(List.of( //
+				InsertTextMode.AsIs, //
+				InsertTextMode.AdjustIndentation)));
+		completionItemCapabilities.setResolveSupport(new CompletionItemResolveSupportCapabilities(List.of( //
+				"documentation", //$NON-NLS-1$
+				"detail", //$NON-NLS-1$
+				"additionalTextEdits"))); //$NON-NLS-1$
 		final var completionCapabilities = new CompletionCapabilities(completionItemCapabilities);
-		completionCapabilities.setContextSupport(Boolean.TRUE);
-		completionCapabilities.setCompletionList(new CompletionListCapabilities(List.of("commitCharacters", //$NON-NLS-1$
-                        "editRange", //$NON-NLS-1$
-                        "insertTextFormat", //$NON-NLS-1$
-                        "insertTextMode"))); //$NON-NLS-1$
+		completionCapabilities.setContextSupport(true);
+		completionCapabilities.setCompletionList(new CompletionListCapabilities(List.of( //
+				"commitCharacters", //$NON-NLS-1$
+				"editRange", //$NON-NLS-1$
+				"insertTextFormat", //$NON-NLS-1$
+				"insertTextMode"))); //$NON-NLS-1$
 		textDocumentClientCapabilities.setCompletion(completionCapabilities);
 		final var definitionCapabilities = new DefinitionCapabilities();
-		definitionCapabilities.setLinkSupport(Boolean.TRUE);
+		definitionCapabilities.setLinkSupport(true);
 		textDocumentClientCapabilities.setDefinition(definitionCapabilities);
 		final var typeDefinitionCapabilities = new TypeDefinitionCapabilities();
-		typeDefinitionCapabilities.setLinkSupport(Boolean.TRUE);
+		typeDefinitionCapabilities.setLinkSupport(true);
 		textDocumentClientCapabilities.setTypeDefinition(typeDefinitionCapabilities);
 		textDocumentClientCapabilities.setDocumentHighlight(new DocumentHighlightCapabilities());
 		textDocumentClientCapabilities.setDocumentLink(new DocumentLinkCapabilities());
 		final var documentSymbol = new DocumentSymbolCapabilities();
 		documentSymbol.setHierarchicalDocumentSymbolSupport(true);
-		documentSymbol.setSymbolKind(new SymbolKindCapabilities(List.of(SymbolKind.Array,
-				SymbolKind.Boolean, SymbolKind.Class, SymbolKind.Constant, SymbolKind.Constructor,
-				SymbolKind.Enum, SymbolKind.EnumMember, SymbolKind.Event, SymbolKind.Field, SymbolKind.File,
-				SymbolKind.Function, SymbolKind.Interface, SymbolKind.Key, SymbolKind.Method, SymbolKind.Module,
-				SymbolKind.Namespace, SymbolKind.Null, SymbolKind.Number, SymbolKind.Object,
-				SymbolKind.Operator, SymbolKind.Package, SymbolKind.Property, SymbolKind.String,
-				SymbolKind.Struct, SymbolKind.TypeParameter, SymbolKind.Variable)));
+		documentSymbol.setSymbolKind(new SymbolKindCapabilities(List.of(SymbolKind.values())));
 		textDocumentClientCapabilities.setDocumentSymbol(documentSymbol);
 		textDocumentClientCapabilities.setFoldingRange(new FoldingRangeCapabilities());
-		textDocumentClientCapabilities.setFormatting(new FormattingCapabilities(Boolean.TRUE));
+		textDocumentClientCapabilities.setFormatting(new FormattingCapabilities(true));
 		final var hoverCapabilities = new HoverCapabilities();
-		hoverCapabilities.setContentFormat(List.of(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
+		hoverCapabilities.setContentFormat(List.of( //
+				MarkupKind.MARKDOWN, //
+				MarkupKind.PLAINTEXT));
 		textDocumentClientCapabilities.setHover(hoverCapabilities);
 		textDocumentClientCapabilities.setOnTypeFormatting(null); // TODO
 		textDocumentClientCapabilities.setRangeFormatting(new RangeFormattingCapabilities());
@@ -118,8 +125,7 @@ public class SupportedFeatures {
 		renameCapabilities.setPrepareSupport(true);
 		textDocumentClientCapabilities.setRename(renameCapabilities);
 		textDocumentClientCapabilities.setSignatureHelp(new SignatureHelpCapabilities());
-		textDocumentClientCapabilities
-				.setSynchronization(new SynchronizationCapabilities(Boolean.TRUE, Boolean.TRUE, Boolean.TRUE));
+		textDocumentClientCapabilities.setSynchronization(new SynchronizationCapabilities(true, true, true));
 		final var selectionRange = new SelectionRangeCapabilities();
 		textDocumentClientCapabilities.setSelectionRange(selectionRange);
 		return textDocumentClientCapabilities;
@@ -127,15 +133,17 @@ public class SupportedFeatures {
 
 	public static WorkspaceClientCapabilities getWorkspaceClientCapabilities() {
 		final var workspaceClientCapabilities = new WorkspaceClientCapabilities();
-		workspaceClientCapabilities.setApplyEdit(Boolean.TRUE);
-		workspaceClientCapabilities.setConfiguration(Boolean.TRUE);
-		workspaceClientCapabilities.setExecuteCommand(new ExecuteCommandCapabilities(Boolean.TRUE));
-		workspaceClientCapabilities.setSymbol(new SymbolCapabilities(Boolean.TRUE));
-		workspaceClientCapabilities.setWorkspaceFolders(Boolean.TRUE);
+		workspaceClientCapabilities.setApplyEdit(true);
+		workspaceClientCapabilities.setConfiguration(true);
+		workspaceClientCapabilities.setExecuteCommand(new ExecuteCommandCapabilities(true));
+		workspaceClientCapabilities.setSymbol(new SymbolCapabilities(true));
+		workspaceClientCapabilities.setWorkspaceFolders(true);
 		final var editCapabilities = new WorkspaceEditCapabilities();
-		editCapabilities.setDocumentChanges(Boolean.TRUE);
-		editCapabilities.setResourceOperations(List.of(ResourceOperationKind.Create,
-				ResourceOperationKind.Delete, ResourceOperationKind.Rename));
+		editCapabilities.setDocumentChanges(true);
+		editCapabilities.setResourceOperations(List.of( //
+				ResourceOperationKind.Create, //
+				ResourceOperationKind.Delete, //
+				ResourceOperationKind.Rename));
 		editCapabilities.setFailureHandling(FailureHandlingKind.Undo);
 		editCapabilities.setChangeAnnotationSupport(new WorkspaceEditChangeAnnotationSupportCapabilities(true));
 		workspaceClientCapabilities.setWorkspaceEdit(editCapabilities);


### PR DESCRIPTION
This PR cleans up the SupportedFeatures class:
1. Format code for better readability
1. use primitive `true` instead of verbose Boolean.TRUE
1. use `SymbolKind.values()` instead of naming each symbol kind separately