### PR TITLE
fix: memory leak in EditorToOutlineAdapterFactory

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/EditorToOutlineAdapterFactory.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/EditorToOutlineAdapterFactory.java
@@ -13,9 +13,9 @@
 package org.eclipse.lsp4e.outline;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +42,8 @@ public class EditorToOutlineAdapterFactory implements IAdapterFactory {
 
 	private static final String OUTLINE_VIEW_ID = "org.eclipse.ui.views.ContentOutline"; //$NON-NLS-1$
 
-	private static final Map<IEditorPart, LanguageServerWrapper> LANG_SERVER_CACHE = Collections.synchronizedMap(new HashMap<>());
+	private static final Map<IEditorPart, LanguageServerWrapper> LANG_SERVER_CACHE = Collections
+			.synchronizedMap(new WeakHashMap<>());
 
 	@Override
 	public <T> @Nullable T getAdapter(@Nullable Object adaptableObject, @Nullable Class<T> adapterType) {


### PR DESCRIPTION
EditorToOutlineAdapterFactory uses IEditorPart as cache key to cache references to slowly starting langservers. when editor parts are closed they are not removed from the hashmap. Using a WeakHashMap solves it.