### PR TITLE
refact: improve handling of futures

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/FutureUtilTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/FutureUtilTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Sebastian Thomschke (Vegard IT GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.internal;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.eclipse.lsp4e.internal.FutureUtil;
+import org.junit.Test;
+
+public class FutureUtilTest {
+
+	@Test
+	public void testJoin() throws InterruptedException, ExecutionException {
+		final var fut1 = CompletableFuture.supplyAsync(() -> List.of("a", "b"));
+		final var fut2 = CompletableFuture.supplyAsync(() -> List.of("c", "d"));
+		final var fut3 = CompletableFuture.supplyAsync(() -> List.of("e", "f"));
+		final var fut4 = CompletableFuture.supplyAsync(() -> List.of("g", "h"));
+
+		assertEquals(List.of("a", "b"), FutureUtil.join(fut1).get());
+		assertEquals(List.of("a", "b", "c", "d"), FutureUtil.join(fut1, fut2).get());
+		assertEquals(List.of("a", "b", "c", "d", "e", "f"), FutureUtil.join(fut1, fut2, fut3).get());
+		assertEquals(List.of("a", "b", "c", "d", "e", "f", "g", "h"), FutureUtil.join(fut1, fut2, fut3, fut4).get());
+	}
+
+	@Test
+	public void testJoinWithCancel() throws InterruptedException {
+		final var fut1 = CompletableFuture.supplyAsync(() -> List.of("a", "b"));
+		final var fut2 = CompletableFuture.supplyAsync(() -> {
+			try {
+				Thread.sleep(5000);
+			} catch (InterruptedException ex) {
+				throw new RuntimeException(ex);
+			}
+			return List.of("c", "d");
+		});
+		final var fut3 = CompletableFuture.supplyAsync(() -> {
+			try {
+				Thread.sleep(5000);
+			} catch (InterruptedException ex) {
+				throw new RuntimeException(ex);
+			}
+			return List.of("e", "f");
+		});
+
+		Thread.sleep(1000);
+		FutureUtil.join(fut1, fut2, fut3).cancel(true);
+		assertTrue(fut1.isDone());
+		assertTrue(fut2.isCancelled());
+		assertTrue(fut3.isCancelled());
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -483,7 +483,7 @@ public class LanguageServerWrapper {
 	 */
 	public synchronized boolean isActive() {
 		final var launcherFuture = this.launcherFuture;
-		return launcherFuture != null && !launcherFuture.isDone() && !launcherFuture.isCancelled();
+		return launcherFuture != null && !launcherFuture.isDone();
 	}
 
 	private void removeStopTimerTask() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -74,6 +74,7 @@ import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
 import org.eclipse.lsp4e.internal.ArrayUtil;
 import org.eclipse.lsp4e.internal.CancellationUtil;
 import org.eclipse.lsp4e.internal.FileBufferListenerAdapter;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4e.internal.SupportedFeatures;
 import org.eclipse.lsp4e.server.StreamConnectionProvider;
 import org.eclipse.lsp4e.ui.Messages;
@@ -531,10 +532,8 @@ public class LanguageServerWrapper {
 			this.languageClient.dispose();
 		}
 
-		if (this.initializeFuture != null) {
-			this.initializeFuture.cancel(true);
-			this.initializeFuture = null;
-		}
+		FutureUtil.cancel(this.initializeFuture);
+		this.initializeFuture = null;
 
 		this.serverCapabilities = null;
 		this.dynamicRegistrations.clear();
@@ -556,9 +555,7 @@ public class LanguageServerWrapper {
 				}
 			}
 
-			if (serverFuture != null) {
-				serverFuture.cancel(true);
-			}
+			FutureUtil.cancel(serverFuture);
 
 			if (languageServerInstance != null) {
 				languageServerInstance.exit();
@@ -869,9 +866,7 @@ public class LanguageServerWrapper {
 		res.exceptionally(e -> {
 			if (e instanceof CancellationException) {
 				CompletableFuture<T> stage = request.get();
-				if (stage != null) {
-					stage.cancel(false);
-				}
+				FutureUtil.cancel(stage);
 			}
 			return null;
 		});

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -74,7 +74,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 */
 	public <T> CompletableFuture<List<T>> collectAll(BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> fn) {
 		final CompletableFuture<List<T>> init = CompletableFuture.completedFuture(new ArrayList<T>());
-		return onCommonPool(executeOnServers(fn).reduce(init, LanguageServers::add, FutureUtil::addAll));
+		return onCommonPool(executeOnServers(fn).reduce(init, LanguageServers::add, FutureUtil::join));
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/CancellationSupport.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/CancellationSupport.java
@@ -47,11 +47,7 @@ public class CancellationSupport implements CancelChecker {
 	 */
 	public void cancel() {
 		this.cancelled = true;
-		for (CompletableFuture<?> futureToCancel : futuresToCancel) {
-			if (!futureToCancel.isDone()) {
-				futureToCancel.cancel(true);
-			}
-		}
+		FutureUtil.cancel(futuresToCancel);
 		futuresToCancel.clear();
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/FutureUtil.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/FutureUtil.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2022-3 Cocotec Ltd and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Ahmed Hussain (Cocotec Ltd) - initial implementation
+ *  Sebastian Thomschke (Vegard IT GmbH) - extracted code from LanguageServers class
+ *******************************************************************************/
+package org.eclipse.lsp4e.internal;
+
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+public class FutureUtil {
+
+	/**
+	 * Combines two async lists of results into a single list by adding all the
+	 * elements of the second list to the first one.
+	 *
+	 * @param <T>
+	 *            Result type
+	 * @param accumulator
+	 *            One async result
+	 * @param another
+	 *            Another async result
+	 * @return Async combined result
+	 */
+	public static <T> CompletableFuture<List<T>> addAll(CompletableFuture<List<T>> accumulator,
+			CompletableFuture<List<T>> another) {
+		CompletableFuture<List<T>> res = accumulator.thenCombine(another, (a, b) -> {
+			a.addAll(b);
+			return a;
+		});
+		forwardCancellation(res, accumulator, another);
+		return res;
+	}
+
+	@SuppressWarnings("null")
+	public static void forwardCancellation(CompletableFuture<?> from, CompletableFuture<?>... to) {
+		from.exceptionally(t -> {
+			if (t instanceof CancellationException) {
+				ArrayUtil.forEach(to, f -> f.cancel(true));
+			}
+			return null;
+		});
+	}
+
+	/**
+	 * creates a future that is running on the common async pool, ensuring it's not
+	 * blocking UI Thread
+	 */
+	public static <T> CompletableFuture<T> onCommonPool(CompletableFuture<T> source) {
+		CompletableFuture<T> res = source.thenApplyAsync(Function.identity());
+		forwardCancellation(res, source);
+		return res;
+	}
+
+	private FutureUtil() {
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/FutureUtil.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/FutureUtil.java
@@ -17,9 +17,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.function.Function;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 public class FutureUtil {
+
+	public static void cancel(final @Nullable Future<?> futureToCancel) {
+		if (futureToCancel != null && !futureToCancel.isDone()) {
+			futureToCancel.cancel(true);
+		}
+	}
+
+	public static void cancel(final @Nullable List<? extends Future<?>> futuresToCancel) {
+		if (futuresToCancel == null)
+			return;
+		for (final Future<?> futureToCancel : futuresToCancel) {
+			cancel(futureToCancel);
+		}
+	}
 
 	/**
 	 * Combines two async lists of results into a new single list containing all

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -69,7 +69,7 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 				.collectAll(ls -> ls.getTextDocumentService().typeDefinition(LSPEclipseUtils.toTypeDefinitionParams(params)).thenApply(l -> Pair.of(Messages.typeDefinitionHyperlinkLabel, l)));
 			var implementations = LanguageServers.forDocument(document).withCapability(ServerCapabilities::getImplementationProvider)
 				.collectAll(ls -> ls.getTextDocumentService().implementation(LSPEclipseUtils.toImplementationParams(params)).thenApply(l -> Pair.of(Messages.implementationHyperlinkLabel, l)));
-			FutureUtil.addAll(FutureUtil.addAll(FutureUtil.addAll(definitions, declarations), typeDefinitions), implementations)
+			FutureUtil.join(definitions, declarations, typeDefinitions, implementations)
 				.get(800, TimeUnit.MILLISECONDS)
 				.stream().flatMap(locations -> toHyperlinks(document, region, locations.first(), locations.second()).stream())
 				.forEach(link -> allLinks.putIfAbsent(link.getLocation(), link));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -34,6 +34,7 @@ import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4e.internal.Pair;
 import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4j.Location;
@@ -68,7 +69,7 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 				.collectAll(ls -> ls.getTextDocumentService().typeDefinition(LSPEclipseUtils.toTypeDefinitionParams(params)).thenApply(l -> Pair.of(Messages.typeDefinitionHyperlinkLabel, l)));
 			var implementations = LanguageServers.forDocument(document).withCapability(ServerCapabilities::getImplementationProvider)
 				.collectAll(ls -> ls.getTextDocumentService().implementation(LSPEclipseUtils.toImplementationParams(params)).thenApply(l -> Pair.of(Messages.implementationHyperlinkLabel, l)));
-			LanguageServers.addAll(LanguageServers.addAll(LanguageServers.addAll(definitions, declarations), typeDefinitions), implementations)
+			FutureUtil.addAll(FutureUtil.addAll(FutureUtil.addAll(definitions, declarations), typeDefinitions), implementations)
 				.get(800, TimeUnit.MILLISECONDS)
 				.stream().flatMap(locations -> toHyperlinks(document, region, locations.first(), locations.second()).stream())
 				.forEach(link -> allLinks.putIfAbsent(link.getLocation(), link));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
@@ -27,6 +27,7 @@ import org.eclipse.jface.text.reconciler.IReconcilingStrategyExtension;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4j.DocumentLink;
 import org.eclipse.lsp4j.DocumentLinkParams;
 import org.eclipse.swt.custom.StyleRange;
@@ -142,10 +143,8 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 	 * Cancel the last call of 'documenLink'.
 	 */
 	private void cancel() {
-		if (request != null) {
-			request.cancel(true);
-			request = null;
-		}
+		FutureUtil.cancel(request);
+		request = null;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -42,6 +42,7 @@ import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.internal.DocumentUtil;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeKind;
 import org.eclipse.lsp4j.FoldingRangeRequestParams;
@@ -143,7 +144,7 @@ public class LSPFoldingReconcilingStrategy
 		final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(uri);
 		final var params = new FoldingRangeRequestParams(identifier);
 		// cancel previous requests
-		requests.forEach(request -> request.cancel(true));
+		FutureUtil.cancel(requests);
 		requests = LanguageServers.forDocument(document)
 				.withCapability(ServerCapabilities::getFoldingRangeProvider)
 				.computeAll(server -> server.getTextDocumentService().foldingRange(params));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/highlight/HighlightReconcilingStrategy.java
@@ -52,6 +52,7 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentHighlightParams;
@@ -217,7 +218,7 @@ public class HighlightReconcilingStrategy
 	 * Cancel the last call of 'documentHighlight'.
 	 */
 	private void cancel() {
-		requests.forEach(request -> request.cancel(true));
+		FutureUtil.cancel(requests);
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingBase.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingBase.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4j.LinkedEditingRanges;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
@@ -81,10 +82,8 @@ public class LSPLinkedEditingBase implements IPreferenceChangeListener {
 	 * Cancel the last call of 'linkedEditing'.
 	 */
 	private void cancel() {
-		if (request != null) {
-			request.cancel(true);
-			request = null;
-		}
+		FutureUtil.cancel(request);
+		request = null;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -8,7 +8,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.semanticTokens;
 
-import static org.eclipse.lsp4e.internal.NullSafetyHelper.*;
+import static org.eclipse.lsp4e.internal.NullSafetyHelper.castNonNull;
 
 import java.net.URI;
 import java.util.List;
@@ -38,6 +38,7 @@ import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.LanguageServers.LanguageServerDocumentExecutor;
 import org.eclipse.lsp4e.internal.CancellationUtil;
 import org.eclipse.lsp4e.internal.DocumentUtil;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4e.internal.Pair;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.SemanticTokens;
@@ -246,9 +247,7 @@ public class SemanticHighlightReconcilerStrategy
 	}
 
 	private void cancelSemanticTokensFull() {
-		if (semanticTokensFullFuture != null) {
-			semanticTokensFullFuture.cancel(true);
-		}
+		FutureUtil.cancel(semanticTokensFullFuture);
 	}
 
 	private void fullReconcile() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/LSPSymbolInWorkspaceDialog.java
@@ -37,6 +37,7 @@ import org.eclipse.jface.text.contentassist.BoldStylerProvider;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4e.outline.CNFOutlinePage;
 import org.eclipse.lsp4e.outline.SymbolsLabelProvider;
 import org.eclipse.lsp4e.ui.Messages;
@@ -141,9 +142,8 @@ public class LSPSymbolInWorkspaceDialog extends FilteredItemsSelectionDialog {
 	@Override
 	protected void fillContentProvider(AbstractContentProvider contentProvider, ItemsFilter itemsFilter,
 			IProgressMonitor monitor) throws CoreException {
-		if (request != null) {
-			request.forEach(f -> f.cancel(true));
-		}
+		FutureUtil.cancel(request);
+
 		if (itemsFilter.getPattern().isEmpty()) {
 			return;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -57,6 +57,7 @@ import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.internal.ArrayUtil;
 import org.eclipse.lsp4e.internal.CancellationUtil;
+import org.eclipse.lsp4e.internal.FutureUtil;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.DocumentSymbol;
@@ -378,9 +379,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 			return;
 		}
 
-		if (symbols != null) {
-			symbols.cancel(true);
-		}
+		FutureUtil.cancel(symbols);
 
 		final var params = new DocumentSymbolParams(LSPEclipseUtils.toTextDocumentIdentifier(documentURI));
 		final var symbols = this.symbols = outlineViewerInput.wrapper.execute(ls -> ls.getTextDocumentService().documentSymbol(params));


### PR DESCRIPTION
This PR moves generic future utility functions out of the LanguageServers class into a separate internal FutureUtil class.

It also renames the `addAll()` function to `join()` and changes the implementation in the way that not the result list of the first future is extended with entries of a secondary future (which makes the unsafe assumption the first result list is modifiable) but adds all items into a new list.