### PR TITLE
refact: improve null analysis

### DIFF
--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPBreakpointManager.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPBreakpointManager.java
@@ -68,7 +68,7 @@ public class DSPBreakpointManager implements IBreakpointManagerListener, IBreakp
 	 *
 	 * @return the completeable future to signify when the breakpoints are all sent.
 	 */
-	public CompletableFuture<Void> initialize() {
+	public CompletableFuture<@Nullable Void> initialize() {
 		platformBreakpointManager.addBreakpointListener(this);
 		platformBreakpointManager.addBreakpointManagerListener(this);
 		return resendAllTargetBreakpoints(platformBreakpointManager.isEnabled());
@@ -101,7 +101,7 @@ public class DSPBreakpointManager implements IBreakpointManagerListener, IBreakp
 		resendAllTargetBreakpoints(enabled);
 	}
 
-	private CompletableFuture<Void> resendAllTargetBreakpoints(boolean enabled) {
+	private CompletableFuture<@Nullable Void> resendAllTargetBreakpoints(boolean enabled) {
 		IBreakpoint[] breakpoints = platformBreakpointManager.getBreakpoints();
 		for (IBreakpoint breakpoint : breakpoints) {
 			if (supportsBreakpoint(breakpoint)) {
@@ -211,7 +211,7 @@ public class DSPBreakpointManager implements IBreakpointManagerListener, IBreakp
 		}
 	}
 
-	private CompletableFuture<Void> sendBreakpoints() {
+	private CompletableFuture<@Nullable Void> sendBreakpoints() {
 		final var all = new ArrayList<CompletableFuture<Void>>();
 		for (Iterator<Entry<Source, List<SourceBreakpoint>>> iterator = targetBreakpoints.entrySet()
 				.iterator(); iterator.hasNext();) {
@@ -228,7 +228,7 @@ public class DSPBreakpointManager implements IBreakpointManagerListener, IBreakp
 			arguments.setBreakpoints(sourceBps);
 			arguments.setSourceModified(false);
 			CompletableFuture<SetBreakpointsResponse> future = debugProtocolServer.setBreakpoints(arguments);
-			CompletableFuture<Void> future2 = future.thenAccept((SetBreakpointsResponse bpResponse) -> {
+			CompletableFuture<@Nullable Void> future2 = future.thenAccept((SetBreakpointsResponse bpResponse) -> {
 				// TODO update platform breakpoint with new info
 			});
 			all.add(future2);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/debugmodel/DSPDebugTarget.java
@@ -288,10 +288,8 @@ public class DSPDebugTarget extends DSPDebugElement implements IDebugTarget, IDe
 					}
 					return q;
 				});
-		CompletableFuture<Void> configurationDoneFuture = CompletableFuture.allOf(initialized, capabilitiesFuture)
-				.thenRun(() -> {
-					monitor.worked(10);
-				});
+		CompletableFuture<@Nullable Void> configurationDoneFuture = CompletableFuture
+				.allOf(initialized, capabilitiesFuture).thenRun(() -> monitor.worked(10));
 		if (ILaunchManager.DEBUG_MODE.equals(launch.getLaunchMode())) {
 			configurationDoneFuture = configurationDoneFuture.thenCompose(v -> {
 				monitor.worked(10);

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/launcher/DSPLaunchDelegate.java
@@ -193,7 +193,8 @@ public class DSPLaunchDelegate implements ILaunchConfigurationDelegate {
 		public String toString() {
 			return "DSPLaunchDelegateLaunchBuilder [configuration=" + configuration + ", mode=" + mode + ", launch="
 					+ launch + ", monitor=" + monitor + ", launchNotConnect=" + launchNotConnect + ", debugCmd="
-					+ debugCmd + ", debugCmdArgs=" + debugCmdArgs + ", debugCmdEnvVars=" + List.of(debugCmdEnvVars)
+			      + debugCmd + ", debugCmdArgs=" + debugCmdArgs //
+			      + ", debugCmdEnvVars=" + (debugCmdEnvVars == null ? null : List.of(debugCmdEnvVars))
 					+ ", monitorDebugAdapter=" + monitorDebugAdapter + ", server=" + server + ", port=" + port
 					+ ", dspParameters=" + dspParameters + "]";
 		}

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionProposalComputer.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionProposalComputer.java
@@ -105,7 +105,7 @@ public class LSJavaCompletionProposalComputer implements IJavaCompletionProposal
 	public List<IContextInformation> computeContextInformation(ContentAssistInvocationContext context,
 			IProgressMonitor monitor) {
 		IContextInformation[] contextInformation = lsContentAssistProcessor.computeContextInformation(context.getViewer(), context.getInvocationOffset());
-		return List.of(contextInformation);
+		return contextInformation == null ? List.of() : List.of(contextInformation);
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -374,7 +374,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 
 	}
 
-	public CompletableFuture<Void> documentClosed() {
+	public CompletableFuture<@Nullable Void> documentClosed() {
 	   final var identifier = LSPEclipseUtils.toTextDocumentIdentifier(fileUri);
 		WILL_SAVE_WAIT_UNTIL_TIMEOUT_MAP.remove(identifier.getUri());
 		// When LS is shut down all documents are being disconnected. No need to send

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageClientImpl.java
@@ -141,12 +141,12 @@ public class LanguageClientImpl implements LanguageClient {
 	}
 
 	@Override
-	public CompletableFuture<Void> registerCapability(RegistrationParams params) {
+	public CompletableFuture<@Nullable Void> registerCapability(RegistrationParams params) {
 		return CompletableFuture.runAsync(() -> wrapper.registerCapability(params));
 	}
 
 	@Override
-	public CompletableFuture<Void> unregisterCapability(UnregistrationParams params) {
+	public CompletableFuture<@Nullable Void> unregisterCapability(UnregistrationParams params) {
 		return CompletableFuture.runAsync(() -> wrapper.unregisterCapability(params));
 	}
 
@@ -182,12 +182,12 @@ public class LanguageClientImpl implements LanguageClient {
 	}
 
 	@Override
-	public CompletableFuture<Void> refreshCodeLenses() {
+	public CompletableFuture<@Nullable Void> refreshCodeLenses() {
 		return CompletableFuture.runAsync(() -> UI.getDisplay().syncExec(this::updateCodeMinings));
 	}
 
 	@Override
-	public CompletableFuture<Void> refreshInlayHints() {
+	public CompletableFuture<@Nullable Void> refreshInlayHints() {
 		return CompletableFuture.runAsync(() -> UI.getDisplay().syncExec(this::updateCodeMinings));
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -159,7 +159,7 @@ public class LanguageServerWrapper {
 
 	protected @Nullable StreamConnectionProvider lspStreamProvider;
 	private @Nullable Future<?> launcherFuture;
-	private @Nullable CompletableFuture<Void> initializeFuture;
+	private @Nullable CompletableFuture<@Nullable Void> initializeFuture;
 	private final AtomicReference<@Nullable IProgressMonitor> initializeFutureMonitorRef = new AtomicReference<>();
 	private final int initializeFutureNumberOfStages = 7;
 	private @Nullable LanguageServer languageServer;
@@ -389,7 +389,7 @@ public class LanguageServerWrapper {
 			protected IStatus run(IProgressMonitor monitor) {
 				final var initializeFutureMonitor = SubMonitor.convert(monitor, initializeFutureNumberOfStages);
 				initializeFutureMonitorRef.set(initializeFutureMonitor);
-				CompletableFuture<Void> currentInitializeFuture = initializeFuture;
+				CompletableFuture<@Nullable Void> currentInitializeFuture = initializeFuture;
 				try {
 					if (currentInitializeFuture != null) {
 						currentInitializeFuture.join();
@@ -714,9 +714,9 @@ public class LanguageServerWrapper {
 	 * @param uri
 	 * @return null if not disconnection has happened, a future tracking the disconnection state otherwise
 	 */
-	public @Nullable CompletableFuture<Void> disconnect(URI uri) {
+	public @Nullable CompletableFuture<@Nullable Void> disconnect(URI uri) {
 		DocumentContentSynchronizer documentListener = this.connectedDocuments.remove(uri);
-		CompletableFuture<Void> documentClosedFuture = null;
+		CompletableFuture<@Nullable Void> documentClosedFuture = null;
 		if (documentListener != null) {
 			documentListener.getDocument().removePrenotifiedDocumentListener(documentListener);
 			documentClosedFuture = documentListener.documentClosed();
@@ -778,7 +778,7 @@ public class LanguageServerWrapper {
 	protected CompletableFuture<LanguageServer> getInitializedServer() {
 		start();
 
-		final CompletableFuture<Void> currentInitializeFuture = initializeFuture;
+		final CompletableFuture<@Nullable Void> currentInitializeFuture = initializeFuture;
 		if (currentInitializeFuture != null && !currentInitializeFuture.isDone()) {
 			return currentInitializeFuture.thenApply(r -> castNonNull(this.languageServer));
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -31,7 +31,6 @@ import java.util.stream.Stream;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
@@ -267,10 +266,9 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 		CompletableFuture<@Nullable LanguageServerWrapper> connect(CompletableFuture<@Nullable LanguageServerWrapper> wrapperFuture) {
 			return wrapperFuture.thenCompose(wrapper -> {
 				if (wrapper != null) {
-					@NonNullByDefault({})
 					CompletableFuture<LanguageServerWrapper> serverFuture = wrapper.connectDocument(document);
 					if (serverFuture != null) {
-						return serverFuture;
+						return (CompletableFuture<@Nullable LanguageServerWrapper>) serverFuture;
 					}
 				}
 				return CompletableFuture.completedFuture(null);
@@ -422,7 +420,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * (not chained with other futures) so cancelling the futures in
 	 * this stream will send a cancellation event to the LSs.</p>
 	 */
-	private <T> Stream<CompletableFuture<T>> executeOnServers(
+	private <@Nullable T> Stream<CompletableFuture<T>> executeOnServers(
 			BiFunction<? super LanguageServerWrapper, LanguageServer, ? extends CompletableFuture<T>> fn) {
 		return getServers().stream().map(serverFuture -> {
 			// wrap in AtomicReference to allow dereferencing in downstream future

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
@@ -50,7 +50,7 @@ public class LSPCodeMining extends LineHeaderCodeMining {
 	}
 
 	@Override
-	protected CompletableFuture<Void> doResolve(ITextViewer viewer, IProgressMonitor monitor) {
+	protected CompletableFuture<@Nullable Void> doResolve(ITextViewer viewer, IProgressMonitor monitor) {
 		final ServerCapabilities serverCapabilities = languageServerWrapper.getServerCapabilities();
 		if (serverCapabilities == null) {
 			return CompletableFuture.completedFuture(null);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
@@ -74,9 +74,9 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 	private @Nullable IDocument currentDocument;
 	private @Nullable String errorMessage;
 	private final boolean errorAsCompletionItem;
-	private @Nullable CompletableFuture<List<Void>> completionLanguageServersFuture;
+	private @Nullable CompletableFuture<List<@Nullable Void>> completionLanguageServersFuture;
 	private volatile char[] completionTriggerChars = NO_CHARS;
-	private @Nullable CompletableFuture<List<Void>> contextInformationLanguageServersFuture;
+	private @Nullable CompletableFuture<List<@Nullable Void>> contextInformationLanguageServersFuture;
 	private volatile char[] contextTriggerChars = NO_CHARS;
 	private final boolean incompleteAsCompletionItem;
 
@@ -327,7 +327,7 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 		return new ContextInformation(information.getLabel(), signature.toString());
 	}
 
-	private void getFuture(@Nullable CompletableFuture<List<Void>> future) {
+	private void getFuture(@Nullable CompletableFuture<?> future) {
 		if (future == null) {
 			return;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
@@ -46,7 +46,7 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 	/** The target viewer. */
 	private @Nullable ITextViewer viewer;
 
-	private @Nullable CompletableFuture<Void> request;
+	private @Nullable CompletableFuture<@Nullable Void> request;
 
 	private @Nullable IDocument document;
 

--- a/target-platforms/target-platform-latest/target-platform-latest.target
+++ b/target-platforms/target-platform-latest/target-platform-latest.target
@@ -36,7 +36,7 @@
 					<!-- External Eclipse null Annotations, see https://github.com/vegardit/no-npe -->
 					<groupId>com.vegardit.no-npe</groupId>
 					<artifactId>no-npe-eea-all</artifactId>
-					<version>1.0.5</version>
+					<version>1.1.0</version>
 					<type>jar</type>
 				</dependency>
 			</dependencies>


### PR DESCRIPTION
This PR bumps no-npe to version 1.1.0 (which contains more refined external null annotation) and applies all necessary code changes to satisfy null analysis checks by the Eclipse compiler.