### PR TITLE
feat: introduce LanguageServerWrapper#getServerCapabilitiesAsync

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -901,6 +901,10 @@ public class LanguageServerWrapper {
 		return this.serverCapabilities;
 	}
 
+	public CompletableFuture<ServerCapabilities> getServerCapabilitiesAsync() {
+		return getInitializedServer().thenApply(ls -> castNonNull(this.serverCapabilities));
+	}
+
 	/**
 	 * @return The language ID that this wrapper is dealing with if defined in the
 	 *         content type mapping for the language server

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
-import static org.eclipse.lsp4e.internal.NullSafetyHelper.castNonNull;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -280,10 +278,8 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 		 * Test whether this server supports the requested <code>ServerCapabilities</code>.
 		 */
 		private CompletableFuture<@Nullable LanguageServerWrapper> filter(LanguageServerWrapper wrapper) {
-			return wrapper.getInitializedServer()
-					.thenCompose(server -> CompletableFuture
-							.completedFuture(server != null && getFilter().test(castNonNull(wrapper.getServerCapabilities()))))
-					.thenApply(matches -> matches ? wrapper: null);
+			return wrapper.getServerCapabilitiesAsync() //
+					.thenApply(sc -> getFilter().test(sc) ? wrapper : null);
 		}
 
 		@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
@@ -51,22 +51,20 @@ public class LSPCodeMining extends LineHeaderCodeMining {
 
 	@Override
 	protected CompletableFuture<@Nullable Void> doResolve(ITextViewer viewer, IProgressMonitor monitor) {
-		final ServerCapabilities serverCapabilities = languageServerWrapper.getServerCapabilities();
-		if (serverCapabilities == null) {
-			return CompletableFuture.completedFuture(null);
-		}
-		final Boolean resolveProvider = serverCapabilities.getCodeLensProvider().getResolveProvider();
-		if (resolveProvider == null || !resolveProvider) {
-			return CompletableFuture.completedFuture(null);
-		}
+		return languageServerWrapper.getServerCapabilitiesAsync().thenCompose(capabilities -> {
+			final Boolean resolveProvider = capabilities.getCodeLensProvider().getResolveProvider();
+			if (resolveProvider == null || !resolveProvider) {
+				return CompletableFuture.completedFuture(null);
+			}
 
-		return languageServerWrapper.execute(languageServer -> languageServer.getTextDocumentService().resolveCodeLens(this.codeLens))
-				.thenAccept(resolvedCodeLens -> {
-					if (resolvedCodeLens != null) {
-						codeLens = resolvedCodeLens;
-						setLabel(getCodeLensString(resolvedCodeLens));
-					}
-				});
+			return languageServerWrapper.execute(languageServer -> languageServer.getTextDocumentService().resolveCodeLens(this.codeLens))
+					.thenAccept(resolvedCodeLens -> {
+						if (resolvedCodeLens != null) {
+							codeLens = resolvedCodeLens;
+							setLabel(getCodeLensString(resolvedCodeLens));
+						}
+					});
+		});
 	}
 
 	@Override


### PR DESCRIPTION
`getServerCapabilities()` can block for up to 10 seconds. In code locations where the result is a future anyways it is useful to have a `getServerCapabilitiesAsync()`

I am planning to use `getServerCapabilitiesAsync()` more in future PRs where it will play nicely with the then suggested changes.

Addresses https://github.com/eclipse/lsp4e/issues/628