### PR TITLE
fix: Adapt resolveCodeAction to handle timeout and interrupted exception

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
@@ -99,8 +99,14 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 					}
 				}
 			}
-		} catch (ExecutionException | TimeoutException | InterruptedException ex) {
-			LanguageServerPlugin.logError(ex);
+		} catch (TimeoutException e) {
+			LanguageServerPlugin.logWarning(
+					"Could resolve code actions due to timeout after 2 seconds in `textDocument/resolveCodeAction`", e); //$NON-NLS-1$
+		} catch (ExecutionException e) {
+			LanguageServerPlugin.logError(e);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			LanguageServerPlugin.logError(e);
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
@@ -74,39 +74,29 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 			LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit(), codeAction.getTitle());
 			return;
 		}
-		try {
-			LanguageServerWrapper wrapper = getLanguageServerWrapper(marker);
-			if (wrapper != null) {
-				resolveCodeAction(wrapper);
-				if (codeAction.getEdit() != null) {
-					LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit(), codeAction.getTitle());
-				}
-				if (codeAction.getCommand() != null) {
-					Command command = codeAction.getCommand();
-					ServerCapabilities cap = wrapper.getServerCapabilities();
-					ExecuteCommandOptions provider = cap == null ? null : cap.getExecuteCommandProvider();
-					if (provider != null && provider.getCommands().contains(command.getCommand())) {
-						final LanguageServerDefinition serverDefinition = wrapper.serverDefinition;
-						wrapper.execute(ls -> ls.getWorkspaceService()
-								.executeCommand(new ExecuteCommandParams(command.getCommand(), command.getArguments()))
-								.exceptionally(t -> reportServerError(serverDefinition, t))
-						);
-					} else  {
-						IResource resource = marker.getResource();
-						if (resource != null) {
-							CommandExecutor.executeCommandClientSide(command, resource);
-						}
+		LanguageServerWrapper wrapper = getLanguageServerWrapper(marker);
+		if (wrapper != null) {
+			resolveCodeAction(wrapper);
+			if (codeAction.getEdit() != null) {
+				LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit(), codeAction.getTitle());
+			}
+			if (codeAction.getCommand() != null) {
+				Command command = codeAction.getCommand();
+				ServerCapabilities cap = wrapper.getServerCapabilities();
+				ExecuteCommandOptions provider = cap == null ? null : cap.getExecuteCommandProvider();
+				if (provider != null && provider.getCommands().contains(command.getCommand())) {
+					final LanguageServerDefinition serverDefinition = wrapper.serverDefinition;
+					wrapper.execute(ls -> ls.getWorkspaceService()
+							.executeCommand(new ExecuteCommandParams(command.getCommand(), command.getArguments()))
+							.exceptionally(t -> reportServerError(serverDefinition, t))
+					);
+				} else  {
+					IResource resource = marker.getResource();
+					if (resource != null) {
+						CommandExecutor.executeCommandClientSide(command, resource);
 					}
 				}
 			}
-		} catch (TimeoutException e) {
-			LanguageServerPlugin.logWarning(
-					"Could resolve code actions due to timeout after 2 seconds in `textDocument/resolveCodeAction`", e); //$NON-NLS-1$
-		} catch (ExecutionException e) {
-			LanguageServerPlugin.logError(e);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			LanguageServerPlugin.logError(e);
 		}
 	}
 
@@ -165,15 +155,24 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 	 * @param wrapper
 	 *            the wrapper for the language server to send the resolve request to.
 	 */
-	public void resolveCodeAction(LanguageServerWrapper wrapper)
-			throws InterruptedException, ExecutionException, TimeoutException {
+	public void resolveCodeAction(LanguageServerWrapper wrapper) {
 		if (codeAction.getEdit() != null) {
 			return;
 		}
 		if (CodeActionCompletionProposal.isCodeActionResolveSupported(wrapper.getServerCapabilities())) {
-			CodeAction resolvedCodeAction = wrapper.execute(ls -> ls.getTextDocumentService().resolveCodeAction(codeAction)).get(2, TimeUnit.SECONDS);
-			if (resolvedCodeAction != null) {
-				codeAction = resolvedCodeAction;
+			try {
+				CodeAction resolvedCodeAction = wrapper.execute(ls -> ls.getTextDocumentService().resolveCodeAction(codeAction)).get(2, TimeUnit.SECONDS);
+				if (resolvedCodeAction != null) {
+					codeAction = resolvedCodeAction;
+				}
+			} catch (TimeoutException e) {
+				LanguageServerPlugin.logWarning(
+						"Could resolve code actions due to timeout after 2 seconds in `textDocument/resolveCodeAction`", e); //$NON-NLS-1$
+			} catch (ExecutionException e) {
+				LanguageServerPlugin.logError(e);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				LanguageServerPlugin.logError(e);
 			}
 		}
 	}


### PR DESCRIPTION
Adapt resolveCodeAction to handle timeout and interrupted exception to follow the usual pattern in the codebase (TimeoutException -> log warning giving the time constraint, InterruptedException -> interrupt thread and log error).