### PR TITLE
Render markdown with commonmark instead of wikitext

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -30,8 +30,6 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.ui.navigator;bundle-version="3.6.100",
  org.eclipse.lsp4j;bundle-version="[0.23.0,0.24.0)",
  org.eclipse.lsp4j.jsonrpc;bundle-version="[0.23.0,0.24.0)",
- org.eclipse.mylyn.wikitext;bundle-version="4.3.0",
- org.eclipse.mylyn.wikitext.markdown;bundle-version="4.3.0",
  org.eclipse.ui.console,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.core.expressions;bundle-version="3.5.0",
@@ -42,7 +40,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  com.google.guava;bundle-version="30.1.0",
  org.eclipse.e4.core.commands,
  org.eclipse.compare.core,
- org.eclipse.compare
+ org.eclipse.compare,
+ org.commonmark;bundle-version="0.23.0"
 Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -50,6 +50,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.IFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
@@ -138,8 +141,6 @@ import org.eclipse.ltk.core.refactoring.resource.MoveRenameResourceChange;
 import org.eclipse.ltk.core.refactoring.resource.RenameResourceChange;
 import org.eclipse.ltk.ui.refactoring.RefactoringWizard;
 import org.eclipse.ltk.ui.refactoring.RefactoringWizardOpenOperation;
-import org.eclipse.mylyn.wikitext.markdown.MarkdownLanguage;
-import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.RGBA;
 import org.eclipse.text.edits.MalformedTreeException;
@@ -184,7 +185,6 @@ public final class LSPEclipseUtils {
 	private static final String MARKDOWN = "markdown"; //$NON-NLS-1$
 	private static final String MD = "md"; //$NON-NLS-1$
 	private static final int MAX_BROWSER_NAME_LENGTH = 30;
-	private static final MarkupParser MARKDOWN_PARSER = new MarkupParser(new MarkdownLanguage());
 
 	private LSPEclipseUtils() {
 		// this class shouldn't be instantiated
@@ -1434,7 +1434,10 @@ public final class LSPEclipseUtils {
 				String kind = markupContent.getKind();
 				if (MARKDOWN.equalsIgnoreCase(kind) || MD.equalsIgnoreCase(kind)) {
 					try {
-						return MARKDOWN_PARSER.parseToHtml(text);
+						Parser parser = Parser.builder().build();
+						Node document = parser.parse(text);
+						HtmlRenderer renderer = HtmlRenderer.builder().build();
+						return renderer.render(document);
 					} catch (Exception e) {
 						LanguageServerPlugin.logError(e);
 						return htmlParagraph(text);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -26,6 +26,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.internal.text.html.BrowserInformationControl;
 import org.eclipse.jface.text.AbstractReusableInformationControlCreator;
@@ -48,8 +51,6 @@ import org.eclipse.lsp4j.MarkedString;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.mylyn.wikitext.markdown.MarkdownLanguage;
-import org.eclipse.mylyn.wikitext.parser.MarkupParser;
 import org.eclipse.swt.widgets.Shell;
 
 /**
@@ -59,7 +60,6 @@ import org.eclipse.swt.widgets.Shell;
 @SuppressWarnings("restriction")
 public class LSPTextHover implements ITextHover, ITextHoverExtension {
 
-	private static final MarkupParser MARKDOWN_PARSER = new MarkupParser(new MarkdownLanguage(true));
 	private static final int GET_TIMEOUT_MS = 1000;
 
 	private @Nullable IRegion lastRegion;
@@ -94,7 +94,10 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension {
 				.collect(Collectors.joining("\n\n")) //$NON-NLS-1$
 				.trim();
 			if (!result.isEmpty()) {
-				return MARKDOWN_PARSER.parseToHtml(result);
+				Parser parser = Parser.builder().build();
+				Node document = parser.parse(result);
+				HtmlRenderer renderer = HtmlRenderer.builder().build();
+				return renderer.render(document);
 			} else {
 				return null;
 			}

--- a/repository/category.xml
+++ b/repository/category.xml
@@ -50,4 +50,10 @@
    <bundle id="com.google.gson">
      <category name="deps"/>
    </bundle>
+   <bundle id="org.commonmark">
+     <category name="deps"/>
+   </bundle>
+   <bundle id="org.commonmark-gfm-tables">
+     <category name="deps"/>
+   </bundle>
 </site>

--- a/target-platforms/target-platform-latest/target-platform-latest.target
+++ b/target-platforms/target-platform-latest/target-platform-latest.target
@@ -3,12 +3,6 @@
 <target name="LSP4E Target-platform" sequenceNumber="1473749310">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.mylyn.wikitext" version="0.0.0"/>
-			<unit id="org.eclipse.mylyn.wikitext.markdown" version="0.0.0"/>
-			<unit id="org.eclipse.mylyn.wikitext.markdown.ui" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/mylyn/updates/release/latest/"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.lsp4j" version="0.0.0"/>
 			<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
 			<unit id="org.eclipse.lsp4j.debug" version="0.0.0"/>
@@ -21,14 +15,16 @@
 			<unit id="org.eclipse.sdk.ide" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/eclipse/updates/latest/"/>
 		</location>
+		<location type="InstallableUnit" includeConfigurePhase="true" includeMode="planner" includeSource="true">
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/S202409180633"/>
+			<unit id="org.commonmark" version="0.0.0"/>
+			<unit id="org.commonmark-gfm-tables" version="0.0.0"/>
+			<unit id="com.google.guava" version="33.3.0.jre"/>
+			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
+		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>
 			<repository location="https://download.eclipse.org/tm4e/releases/latest/"/>
-		</location>
-  		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="com.google.guava" version="33.3.0.jre"/>
-			<unit id="com.google.guava.failureaccess" version="1.0.2"/>
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2024-09"/>
 		</location>
 		<location includeDependencyDepth="none" includeSource="false" missingManifest="error" type="Maven">
 			<dependencies>


### PR DESCRIPTION
commonmark is the library used internally by the JDK and by JDT for markdown rendering. It's more standard and leaner than wikitext.