### PR TITLE
set sort label for quick access elements to avoid symbols get removed when they have the same label

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/WorkspaceSymbolQuickAccessElement.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/WorkspaceSymbolQuickAccessElement.java
@@ -47,6 +47,11 @@ public class WorkspaceSymbolQuickAccessElement extends QuickAccessElement {
 	}
 
 	@Override
+	public String getSortLabel() {
+		return getLabel() + " - " + this.idExtension; //$NON-NLS-1$
+	}
+
+	@Override
 	public ImageDescriptor getImageDescriptor() {
 		return ImageDescriptor.createFromImage(LABEL_PROVIDER.getImage(symbol));
 	}


### PR DESCRIPTION
When you have multiple workspace symbols with the same label, only one shows up in the workspace quick access list. The reason is that the filtering and sorting mechanism of the quick access dialog uses a comparator for a set that uses the `getSortLabel` method of the elements - which refers to `getLabel` by default.

This PR overrides the default implementation and makes sure (by adding the random extension ID to make symbols unique) that  `getSortLabel` returns different values for different symbols, even if they have the exact same label.

As a follow-up here, we should think about showing more information for a symbol on the dialog to allow users to distinguish those symbols with the same label somehow, but that is a task for a separate PR or issue.