### PR TITLE
fix: Allow derived MockLanguageServer for derived servers.

### DIFF
--- a/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mock Language Server to test LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.tests.mock
-Bundle-Version: 0.16.12.qualifier
+Bundle-Version: 0.16.13.qualifier
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.lsp4j;bundle-version="[0.23.0,0.24.0)",

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockLanguageServer.java
@@ -106,7 +106,7 @@ public class MockLanguageServer implements LanguageServer {
 		INSTANCE = new MockLanguageServer(serverConfigurer);
 	}
 
-	private MockLanguageServer(final Supplier<ServerCapabilities> serverConfigurer) {
+	protected MockLanguageServer(final Supplier<ServerCapabilities> serverConfigurer) {
 		resetInitializeResult(serverConfigurer);
 	}
 


### PR DESCRIPTION
By changing the visibility of the MockLanguageServer constructor from private to protected.