### PR TITLE
fix: merge instead of replacing style from semantic highlighting

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticHighlightReconcilerStrategy.java
@@ -314,7 +314,7 @@ public class SemanticHighlightReconcilerStrategy
 		documentTimestampAtLastAppliedTextPresentation = DocumentUtil.getDocumentModificationStamp(document);
 		IRegion extent = textPresentation.getExtent();
 		if (extent != null && styleRangeHolder != null) {
-			textPresentation.replaceStyleRanges(styleRangeHolder.overlappingRanges(extent));
+			textPresentation.mergeStyleRanges(styleRangeHolder.overlappingRanges(extent));
 		}
 	}
 }


### PR DESCRIPTION
Semantic highlighting might be applied on top of other highlighting (e.g. diff highlighting in a compare view editor) -> merge instead of replacing