### PR TITLE
fix: LSCompletionProposal#getContextInformationPosition

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -83,7 +83,6 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.TextStyle;
@@ -875,6 +874,11 @@ public class LSCompletionProposal
 
 	@Override
 	public int getContextInformationPosition() {
-		return SWT.RIGHT;
+		try {
+			return LSPEclipseUtils.toOffset(getTextEditRange().getStart(), document);
+		} catch (BadLocationException e) {
+			LanguageServerPlugin.logWarning(e.getMessage(), e);
+		}
+		return bestOffset;
 	}
 }


### PR DESCRIPTION
For some odd reason `LSCompletionProposal.getContextInformationPosition` currently returns `SWT.RIGHT` hardcoded which translates to int value `131072`. I changed the information to return the beginning of the text edit range.