### PR TITLE
fix(completion): correct $TM_CURRENT_WORD extraction and replacement

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -703,11 +703,11 @@ public class LSCompletionProposal
 				String selectedText = document.get(viewer.getSelectedRange().x, viewer.getSelectedRange().y);
 				int beforeSelection = viewer.getSelectedRange().x - 1;
 				while (beforeSelection >= 0 && Character.isUnicodeIdentifierPart(document.getChar(beforeSelection))) {
-					selectedText = beforeSelection + selectedText;
+					selectedText = document.getChar(beforeSelection) + selectedText;
 					beforeSelection--;
 				}
 				int afterSelection = viewer.getSelectedRange().x + viewer.getSelectedRange().y;
-				while (afterSelection < document.getLength() && Character.isUnicodeIdentifierPart(afterSelection)) {
+				while (afterSelection < document.getLength() && Character.isUnicodeIdentifierPart(document.getChar(afterSelection))) {
 					selectedText = selectedText + document.getChar(afterSelection);
 					afterSelection++;
 				}


### PR DESCRIPTION
In `LSCompletionProposal.getVariableValue` the TM_CURRENT_WORD value computation is wrong.

In the assignment `selectedText = beforeSelection + selectedText;` the variable `beforeSelection` does not hold text or a char but an index position. This PR corrects the assignment to `selectedText = document.getChar(beforeSelection) + selectedText;`

Same for `Character.isUnicodeIdentifierPart(afterSelection)` which is changed to `Character.isUnicodeIdentifierPart(document.getChar(afterSelection))`