### PR TITLE
ci: update workflows (add codeql, use MacOS 15 runner, re-enable Linux)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 version: 2
 updates:
 - package-ecosystem: github-actions

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
-# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
 name: Build
 
-on:
+on:  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
   push:
     branches-ignore:  # build all branches except:
     - 'dependabot/**'  # prevent GHA triggered twice (once for commit to the branch and once for opening/syncing the PR)
@@ -10,6 +10,7 @@ on:
     paths-ignore:
     - '**/*.md'
     - '.github/*.yml'
+    - '.github/workflows/codeql.yml'
     - '.github/workflows/licensecheck.yml'
     - '**/.project'
     - '**/.settings/*.prefs'
@@ -20,6 +21,7 @@ on:
     paths-ignore:
     - '**/*.md'
     - '.github/*.yml'
+    - '.github/workflows/codeql.yml'
     - '.github/workflows/licensecheck.yml'
     - '**/.project'
     - '**/.settings/*.prefs'
@@ -27,7 +29,7 @@ on:
     - '.actrc'
     - 'Jenkinsfile'
   workflow_dispatch:
-    # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
     inputs:
       additional_maven_args:
         description: 'Additional Maven Args'
@@ -63,9 +65,9 @@ jobs:
       fail-fast: false
       matrix:
         os:  # https://github.com/actions/runner-images#available-images
-        #- ubuntu-latest # TODO builds are extremely slow for no apparent reason and job currently times out after 15 minutes
-        - macos-13 # Intel
-        - macos-14 # ARM
+        - ubuntu-latest
+        - macos-15-intel # Intel
+        - macos-latest # ARM
         - windows-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
@@ -84,7 +86,7 @@ jobs:
     - name: Git Checkout
       uses: actions/checkout@v5  # https://github.com/actions/checkout
       with:
-        fetch-depth: 0 # required to prevent tycho-p2-extras-plugin:compare-version-with-baseline potentially failing the build
+        fetch-depth: 0  # required to prevent tycho-p2-extras-plugin:compare-version-with-baseline potentially failing the build
 
 
     - name: Configure fast APT repository mirror
@@ -165,7 +167,7 @@ jobs:
         timeout_minutes: 10
         shell: bash
         command: |
-          set -eu
+          set -euo pipefail
 
           MAVEN_OPTS="${MAVEN_OPTS:-}"
           if [[ "${{ runner.os }}" == "Windows" ]]; then
@@ -191,7 +193,7 @@ jobs:
             --update-snapshots \
             --batch-mode \
             --show-version \
-            -Dtycho.disableP2Mirrors=true \
+            -Declipse.p2.mirrors=false \
             -Dsurefire.rerunFailingTestsCount=3 \
             $maven_args \
             ${{ github.event.inputs.additional_maven_args }} \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,104 @@
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
+name: CodeQL
+
+on:  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
+  push:
+    branches: [ "main" ]
+    paths-ignore:
+    - '**/*.md'
+    - '.github/*.yml'
+    - '.github/workflows/build.yml'
+    - '.github/workflows/licensecheck.yml'
+    - '**/.project'
+    - '**/.settings/*.prefs'
+    - '.gitignore'
+    - '.actrc'
+    - 'Jenkinsfile'
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+    - '**/*.md'
+    - '.github/*.yml'
+    - '.github/workflows/build.yml'
+    - '.github/workflows/licensecheck.yml'
+    - '**/.project'
+    - '**/.settings/*.prefs'
+    - '.gitignore'
+    - '.actrc'
+    - 'Jenkinsfile'
+  workflow_dispatch:
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
+
+
+jobs:
+
+  ###########################################################
+  analyze:
+  ###########################################################
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # build-mode: https://github.com/github/codeql-action#build-modes
+        - language: java-kotlin
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
+        - language: python
+          build-mode: none
+
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    timeout-minutes: 15
+
+    steps:
+    - name: "Show: GitHub context"
+      env:
+        GITHUB_CONTEXT: ${{ toJSON(github) }}
+      run: echo $GITHUB_CONTEXT
+
+
+    - name: "Show: environment variables"
+      run: env | sort
+
+
+    - name: Git Checkout
+      uses: actions/checkout@v5  # https://github.com/actions/checkout
+
+
+    # CodeQL executes https://github.com/ferstl/depgraph-maven-plugin
+    - name: "Install: JDK 25 for Maven ☕"
+      uses: actions/setup-java@v5  # https://github.com/actions/setup-java
+      if: ${{ matrix.language }} == 'java'
+      with:
+        distribution: temurin
+        java-version: 25
+
+
+    # https://docs.github.com/en/code-security/code-scanning
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4  # https://github.com/github/codeql-action
+      with:
+        languages: ${{ matrix.language }}
+        # https://github.com/github/codeql-action#build-modes
+        build-mode: ${{ matrix.build-mode }}
+        # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#using-queries-in-ql-packs
+        queries: +security-and-quality
+
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4  # https://github.com/github/codeql-action
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -1,7 +1,7 @@
-# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+# https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
 name: License check
 
-on:
+on:  # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows
   push:
     branches-ignore:  # build all branches except:
     - 'dependabot/**'  # prevent GHA triggered twice (once for commit to the branch and once for opening/syncing the PR)
@@ -9,7 +9,7 @@ on:
     - '**'
   pull_request:
   workflow_dispatch:
-    # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
     inputs:
       dash-iplab-token:
         description: "Gitlab Personal Access Token (https://gitlab.eclipse.org/-/user_settings/personal_access_tokens) with 'api'' scope for Automatic IP Team Review Requests via org.eclipse.dash:license-tool-plugin, see https://github.com/eclipse/dash-licenses#automatic-ip-team-review-requests"
@@ -125,7 +125,7 @@ jobs:
           --update-snapshots \
           --batch-mode \
           --show-version \
-          -Dtycho.disableP2Mirrors=true \
+          -Declipse.p2.mirrors=false \
           $maven_args \
           org.eclipse.dash:license-tool-plugin:license-check \
           -Dtycho.target.eager=true \


### PR DESCRIPTION
- upgrade from deprecated MacOS 13 Intel runner to MacOS 15 Intel runner
- re-enable previously disabled Linux runners
- add CodeQL workflow
- update URLs to workflow reference documentation
- replace -Dtycho.disableP2Mirrors=true with -Declipse.p2.mirrors=false