### PR TITLE
fix: Failure to use secure URL in Maven artifact upload/download

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
 					<configuration>
 						<baselineRepositories>
 							<repository>
-								<url>http://download.eclipse.org/lsp4e/snapshots</url>
+								<url>https://download.eclipse.org/lsp4e/snapshots</url>
 							</repository>
 						</baselineRepositories>
 					</configuration>


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-lsp4e/lsp4e/security/code-scanning/1](https://github.com/eclipse-lsp4e/lsp4e/security/code-scanning/1)

To fix the problem, change the `<url>` value under `<repository>` at line 194 inside the `tycho-p2-plugin`'s `<baselineRepositories>`.  
Specifically, update it from `http://download.eclipse.org/lsp4e/snapshots` to `https://download.eclipse.org/lsp4e/snapshots`. This ensures all artifact downloads are performed over an encrypted channel, preventing interception and tampering.  
Only one line within the `<baselineRepositories>` block needs to be edited. No other configuration changes, imports, or plugin modifications are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
