### PR TITLE
perf: optimize DSPLaunchDelegate OutputStream wrapper

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
 Bundle-Vendor: Eclipse LSP4E
-Bundle-Version: 0.15.15.qualifier
+Bundle-Version: 0.15.16.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,


### PR DESCRIPTION
This PR implements the `OutputStream.write(byte[] b, int off, int len)` method for the anonymous inner OutputStream wrapper class to avoid excessive string allocations on each written byte.