### PR TITLE
fix: broken FilterInputStream in StreamConnectionProvider#forwardCopyTo

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/server/StreamConnectionProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/server/StreamConnectionProviderTest.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Sebastian Thomschke (Vegard IT GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.server;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+
+import org.eclipse.lsp4e.server.StreamConnectionProvider;
+import org.eclipse.lsp4j.jsonrpc.messages.Message;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.junit.Test;
+
+public class StreamConnectionProviderTest {
+
+	private static StreamConnectionProvider newProvider() {
+		return new StreamConnectionProvider() {
+			@Override
+			public void start() throws IOException {
+			}
+
+			@Override
+			public InputStream getInputStream() {
+				return null;
+			}
+
+			@Override
+			public OutputStream getOutputStream() {
+				return null;
+			}
+
+			@Override
+			public InputStream getErrorStream() {
+				return null;
+			}
+
+			@Override
+			public void stop() {
+			}
+
+			@Override
+			public void handleMessage(Message message, LanguageServer languageServer, URI rootURI) {
+			}
+		};
+	}
+
+	@Test
+	public void test_forwardCopy_singleByteRead_writesToProvidedOutput() throws Exception {
+		final var input = new ByteArrayInputStream("ABC".getBytes(UTF_8));
+		final var sink = new ByteArrayOutputStream();
+
+		try (InputStream forwarding = newProvider().forwardCopyTo(input, sink)) {
+			while ((forwarding.read()) != -1) {
+				// read one byte at a time to exercise single-byte read path
+			}
+		}
+		assertEquals("expected input to be forwarded to provided OutputStream", "ABC", sink.toString(UTF_8));
+	}
+
+	@Test
+	public void test_forwardCopy_readArray_onEOF_returnsMinusOne_noException() throws Exception {
+		final var emptyInput = new ByteArrayInputStream(new byte[0]);
+		final var sink = new ByteArrayOutputStream();
+
+		try (final var forwarding = newProvider().forwardCopyTo(emptyInput, sink)) {
+			final var buf = new byte[8];
+			int n = forwarding.read(buf); // should be -1 and not throw
+			assertEquals("expected EOF (-1) on empty stream", -1, n);
+		}
+		assertArrayEquals(new byte[0], sink.toByteArray());
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/StreamConnectionProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/StreamConnectionProvider.java
@@ -75,25 +75,23 @@ public interface StreamConnectionProvider {
 			@Override
 			public int read() throws IOException {
 				int res = super.read();
-				System.err.print((char) res);
+				if (res == -1) {
+					return -1;
+				}
+				output.write(res);
 				return res;
 			}
 
 			@Override
 			public int read(byte[] b, int off, int len) throws IOException {
 				int bytes = super.read(b, off, len);
-				final var payload = new byte[bytes];
-				System.arraycopy(b, off, payload, 0, bytes);
-				output.write(payload, 0, payload.length);
-				return bytes;
-			}
-
-			@Override
-			public int read(byte[] b) throws IOException {
-				int bytes = super.read(b);
-				final var payload = new byte[bytes];
-				System.arraycopy(b, 0, payload, 0, bytes);
-				output.write(payload, 0, payload.length);
+				if (bytes == -1) {
+					return -1;
+				}
+				if (bytes == 0) {
+					return 0;
+				}
+				output.write(b, off, bytes);
 				return bytes;
 			}
 		};


### PR DESCRIPTION
StreamConnectionProvider#forwardCopyTo instantiates an anonymous FilterInputStream implementation with broken read method implementations (EOF handling). The `FilterInputStream` also unnecessarily allocates new byte arrays on each array read operation. Additionally the single byte read method did not forward to the output stream but wrote the byte directly to stderr.