### PR TITLE
feat: adds Language Server ID column to LS tables in preference pages

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
@@ -213,6 +213,15 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 			}
 		});
 
+		final var idConfigColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
+		idConfigColumn.getColumn().setText(Messages.PreferencesPage_languageServerId);
+		idConfigColumn.getColumn().setWidth(300);
+		idConfigColumn.setLabelProvider(new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return ((ContentTypeToLanguageServerDefinition)element).getValue().id;
+			}
+		});
 
 		List<ContentTypeToLanguageServerDefinition> contentTypeToLanguageServerDefinitions = registry.getContentTypeToLSPExtensions();
 		if (contentTypeToLanguageServerDefinitions.stream()

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
@@ -146,6 +146,17 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 			}
 		});
 		addLoggingColumnsToViewer(languageServerViewer);
+
+		final var idConfigColumn = new TableViewerColumn(languageServerViewer, SWT.NONE);
+		idConfigColumn.getColumn().setText(Messages.PreferencesPage_languageServerId);
+		idConfigColumn.getColumn().setWidth(300);
+		idConfigColumn.setLabelProvider(new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return ((ContentTypeToLanguageServerDefinition)element).getValue().id;
+			}
+		});
+
 		languageServerViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		languageServerViewer.getTable().setHeaderVisible(true);
 		languageServerViewer.getTable().setLinesVisible(true);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/Messages.java
@@ -32,6 +32,7 @@ public final class Messages extends NLS {
 	public static String PreferencesPage_Remove;
 	public static String PreferencesPage_contentType;
 	public static String PreferencesPage_languageServer;
+	public static String PreferencesPage_languageServerId;
 	public static String PreferencesPage_Enabled;
 	public static String PreferencesPage_enablementCondition;
 	public static String PreferencePage_enablementCondition_true;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/messages.properties
@@ -26,6 +26,7 @@ PreferencesPage_contentType=Content Type
 PreferencesPage_Add=Add...
 PreferencesPage_Remove=Remove
 PreferencesPage_languageServer=Language Server
+PreferencesPage_languageServerId=Language Server ID
 PreferencesPage_Enabled=Enabled
 PreferencesPage_enablementCondition=Enablement condition
 PreferencePage_enablementCondition_true=\u2714\ufe0f


### PR DESCRIPTION
<img width="871" height="685" alt="image" src="https://github.com/user-attachments/assets/50acb06e-e041-462a-a88c-529c12a5915d" />

<img width="891" height="562" alt="image" src="https://github.com/user-attachments/assets/a35c81a3-df23-4fa6-96b2-6a59899ad379" />
