### PR TITLE
fix: sort LanguageServer tables in preferences

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
@@ -28,6 +28,8 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.lsp4e.ContentTypeToLSPLaunchConfigEntry;
 import org.eclipse.lsp4e.ContentTypeToLanguageServerDefinition;
 import org.eclipse.lsp4e.LanguageServersRegistry;
@@ -252,6 +254,16 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 			});
 		}
 
+		// Sort by content type label
+		checkboxViewer.setComparator(new ViewerComparator() {
+			@Override
+			public int compare(@Nullable Viewer viewer, @Nullable Object e1, @Nullable Object e2) {
+				if(e1 instanceof ContentTypeToLanguageServerDefinition d1 && e1 instanceof ContentTypeToLanguageServerDefinition d2) {
+					return getComparator().compare(d1.getKey().getName(), d2.getKey().getName());
+				}
+				return 0;
+			}
+		});
 		checkboxViewer.setInput(contentTypeToLanguageServerDefinitions);
 		checkboxViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1));
 		checkboxViewer.getTable().setHeaderVisible(true);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
@@ -33,6 +33,8 @@ import org.eclipse.jface.viewers.EditingSupport;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.lsp4e.ContentTypeToLSPLaunchConfigEntry;
 import org.eclipse.lsp4e.ContentTypeToLanguageServerDefinition;
 import org.eclipse.lsp4e.LanguageServerPlugin;
@@ -146,6 +148,18 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 			}
 		});
 		addLoggingColumnsToViewer(languageServerViewer);
+
+		// Sort by language server label
+		languageServerViewer.setComparator(new ViewerComparator() {
+			@Override
+			public int compare(@Nullable Viewer viewer, @Nullable Object e1, @Nullable Object e2) {
+				if(e1 instanceof ContentTypeToLanguageServerDefinition d1 && e1 instanceof ContentTypeToLanguageServerDefinition d2) {
+					return getComparator().compare(d1.getValue().label, d2.getValue().label);
+				}
+				return 0;
+			}
+		});
+
 		languageServerViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		languageServerViewer.getTable().setHeaderVisible(true);
 		languageServerViewer.getTable().setLinesVisible(true);


### PR DESCRIPTION
- Sort table in LanguageServerPreferencePage by content type
- Sort table in LoggingPreferencePage by language server name

<img width="847" height="843" alt="image" src="https://github.com/user-attachments/assets/a78beddf-3d17-41ab-9ebd-81b9338e5870" />

<img width="847" height="635" alt="image" src="https://github.com/user-attachments/assets/87738375-8615-4d12-b1b6-808210f71530" />
