### PR TITLE
feat: add ID tooltip to Language Server columns in preference pages

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LanguageServerPreferencePage.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CheckboxTableViewer;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.TableViewer;
@@ -181,9 +182,10 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 		GridDataFactory.swtDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).span(2, 1).hint(400, SWT.DEFAULT).applyTo(staticServersIntro);
 		staticServersIntro.setText(Messages.PreferencesPage_staticServers);
 		staticServersIntro.addSelectionListener(this.contentTypeLinkListener);
-		checkboxViewer = CheckboxTableViewer.newCheckList(res, SWT.NONE);
+		checkboxViewer = CheckboxTableViewer.newCheckList(res, SWT.FULL_SELECTION);
 		checkboxViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		checkboxViewer.setContentProvider(new ArrayContentProvider());
+		ColumnViewerToolTipSupport.enableFor(checkboxViewer);
 
 		final var enablementColumn = new TableViewerColumn(checkboxViewer, SWT.NONE);
 		enablementColumn.getColumn().setText(Messages.PreferencesPage_Enabled);
@@ -212,6 +214,11 @@ public class LanguageServerPreferencePage extends PreferencePage implements IWor
 			@Override
 			public String getText(Object element) {
 				return ((ContentTypeToLanguageServerDefinition)element).getValue().label;
+			}
+
+			@Override
+			public String getToolTipText(Object element) {
+				return "ID: " + ((ContentTypeToLanguageServerDefinition) element).getValue().id; //$NON-NLS-1$
 			}
 		});
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LoggingPreferencePage.java
@@ -29,12 +29,13 @@ import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.CheckboxCellEditor;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.EditingSupport;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
-import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
+import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.lsp4e.ContentTypeToLSPLaunchConfigEntry;
 import org.eclipse.lsp4e.ContentTypeToLanguageServerDefinition;
 import org.eclipse.lsp4e.LanguageServerPlugin;
@@ -137,6 +138,7 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 		languageServerViewer = new TableViewer(res, SWT.FULL_SELECTION);
 		languageServerViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		languageServerViewer.setContentProvider(new ArrayContentProvider());
+		ColumnViewerToolTipSupport.enableFor(languageServerViewer);
 
 		final var launchConfigColumn = new TableViewerColumn(languageServerViewer, SWT.NONE);
 		launchConfigColumn.getColumn().setText(Messages.PreferencesPage_languageServer);
@@ -145,6 +147,11 @@ public class LoggingPreferencePage extends PreferencePage implements IWorkbenchP
 			@Override
 			public String getText(Object element) {
 				return ((ContentTypeToLanguageServerDefinition) element).getValue().label;
+			}
+
+			@Override
+			public String getToolTipText(Object element) {
+				return "ID: " + ((ContentTypeToLanguageServerDefinition) element).getValue().id; //$NON-NLS-1$
 			}
 		});
 		addLoggingColumnsToViewer(languageServerViewer);


### PR DESCRIPTION
<img width="782" height="395" alt="image" src="https://github.com/user-attachments/assets/e50b4efd-cda9-4335-a2de-b8f2a0888e16" />
