### PR TITLE
fix: handle Windows UNC paths correctly

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -1332,7 +1332,15 @@ public final class LSPEclipseUtils {
 	public static URI toUri(File file) {
 		// URI scheme specified by language server protocol and LSP
 		try {
-			return new URI("file", "", file.getAbsoluteFile().toURI().getPath(), null); //$NON-NLS-1$ //$NON-NLS-2$
+			final var path = file.getAbsoluteFile().toURI().getPath();
+			if (path.startsWith("//")) { // UNC path like //localhost/c$/Windows/ //$NON-NLS-1$
+				// split: authority = "localhost", absPath = "/c$/Windows/"
+				final int slash = path.indexOf('/', 2);
+				final String authority = slash > 2 ? path.substring(2, slash) : path.substring(2);
+				final String absPath = slash > 2 ? path.substring(slash) : "/"; //$NON-NLS-1$
+				return new URI(FILE_SCHEME, authority, absPath, null);
+			}
+			return new URI(FILE_SCHEME, "", path, null); //$NON-NLS-1$
 		} catch (URISyntaxException e) {
 			LanguageServerPlugin.logError(e);
 			return file.getAbsoluteFile().toURI();


### PR DESCRIPTION
This PR fixes the underlying issue of https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/issues/162

When one tries to open a language server supported file on an Windows UNC Path. Currently the moment one tries to open the file the UI pops-up error dialogs in loops making it even hard to close the file again.