### PR TITLE
feat: Make `AdjustIndentation` the default `insertTextMode` for completion proposals without explicit `insertTextMode`

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.15.28.qualifier
+Bundle-Version: 0.15.29.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.15.28-SNAPSHOT</version>
+	<version>0.15.29-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -561,6 +561,20 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		((LSCompletionProposal) proposals[0]).apply(viewer, '\n', 0, invokeOffset);
 		assertEquals("a\n\tb\n\tline1\n\tline2\nc", viewer.getDocument().get());
 	}
+	
+	@Test
+	public void testAdjustIndentationIsDefault() throws Exception {
+		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, "a\n\tb\n\t\nc"));
+		final var item = new CompletionItem("line1\nline2");
+		// No insert mode specified -> fall back to default, which is AdjustIndentation
+		item.setInsertTextMode(null);
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, List.of(item)));
+		int invokeOffset = 6;
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, invokeOffset);
+		assertEquals(1, proposals.length);
+		((LSCompletionProposal) proposals[0]).apply(viewer, '\n', 0, invokeOffset);
+		assertEquals("a\n\tb\n\tline1\n\tline2\nc", viewer.getDocument().get());
+	}
 
 	@Test
 	public void testAdjustIndentationWithPrefixInLine() throws Exception {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
@@ -103,6 +103,7 @@ public class SupportedFeatures {
 				"editRange", //$NON-NLS-1$
 				"insertTextFormat", //$NON-NLS-1$
 				"insertTextMode"))); //$NON-NLS-1$
+		completionCapabilities.setInsertTextMode(InsertTextMode.AdjustIndentation);
 		textDocumentClientCapabilities.setCompletion(completionCapabilities);
 		final var definitionCapabilities = new DefinitionCapabilities();
 		definitionCapabilities.setLinkSupport(true);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -522,7 +522,7 @@ public class LSCompletionProposal
 			insertText = textEdit.getNewText();
 			Map<String, List<LinkedPosition>> regions = Collections.emptyMap();
 			int insertionOffset = LSPEclipseUtils.toOffset(textEdit.getRange().getStart(), document);
-			if (item.getInsertTextMode() == InsertTextMode.AdjustIndentation) {
+			if (item.getInsertTextMode() == InsertTextMode.AdjustIndentation || item.getInsertTextMode() == null) {
 				insertText = adjustIndentation(document, insertText, insertionOffset);
 			}
 			insertionOffset = computeNewOffset(item.getAdditionalTextEdits(), insertionOffset, document);


### PR DESCRIPTION
[VS Code](https://github.com/microsoft/vscode-languageserver-node/blob/cd32d3e505e8ec8df660bc8e328d5f650673c2d8/client/src/common/completion.ts#L90) also uses this as the default