### PR TITLE
feat: send LS error stream to Eclipse log.

### DIFF
--- a/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mock Language Server to test LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.tests.mock
-Bundle-Version: 0.16.17.qualifier
+Bundle-Version: 0.16.18.qualifier
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.lsp4j,

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockConnectionProvider.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockConnectionProvider.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.tests.mock;
 
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,7 +18,6 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.nio.channels.Channels;
 import java.nio.channels.Pipe;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
@@ -49,7 +47,7 @@ public class MockConnectionProvider implements StreamConnectionProvider {
 	public void start() throws IOException {
 		Pipe serverOutputToClientInput = Pipe.open();
 		Pipe clientOutputToServerInput = Pipe.open();
-		errorStream = new ByteArrayInputStream("Error output on console".getBytes(StandardCharsets.UTF_8));
+		errorStream = InputStream.nullInputStream();
 
 		InputStream serverInputStream = Channels.newInputStream(clientOutputToServerInput.source());
 		OutputStream serverOutputStream = Channels.newOutputStream(serverOutputToClientInput.sink());

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockConnectionProviderMultiRootFolders.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockConnectionProviderMultiRootFolders.java
@@ -12,14 +12,12 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.tests.mock;
 
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.Pipe;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
@@ -72,7 +70,7 @@ public class MockConnectionProviderMultiRootFolders implements StreamConnectionP
 		try {
 			Pipe serverOutputToClientInput = Pipe.open();
 			Pipe clientOutputToServerInput = Pipe.open();
-			errorStream = new ByteArrayInputStream("Error output on console".getBytes(StandardCharsets.UTF_8));
+			errorStream = InputStream.nullInputStream();
 	
 			InputStream serverInputStream = Channels.newInputStream(clientOutputToServerInput.source());
 			OutputStream serverOutputStream = Channels.newOutputStream(serverOutputToClientInput.sink());


### PR DESCRIPTION
Forward lines written by the language server to std_err into the Eclipse log.