### PR TITLE
feat: Remove `final` modifier from *Message methods in `DefaultLanguageClient`

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/client/DefaultLanguageClient.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/client/DefaultLanguageClient.java
@@ -96,12 +96,12 @@ public class DefaultLanguageClient implements LanguageClient {
 	}
 
 	@Override
-	public final CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+	public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
 		return ServerMessageHandler.showMessageRequest(wrapper, requestParams);
 	}
 
 	@Override
-	public final void showMessage(MessageParams messageParams) {
+	public void showMessage(MessageParams messageParams) {
 		ServerMessageHandler.showMessage(wrapper.serverDefinition.label, messageParams);
 	}
 
@@ -111,7 +111,7 @@ public class DefaultLanguageClient implements LanguageClient {
 	}
 
 	@Override
-	public final void logMessage(MessageParams message) {
+	public void logMessage(MessageParams message) {
 		CompletableFuture.runAsync(() -> ServerMessageHandler.logMessage(wrapper, message));
 	}
 


### PR DESCRIPTION
This makes it easier for developers using LSP4E to create a language client with custom behavior.

Resolves #1367 