### PR TITLE
fix: eliminate UI freezes in LSPTextHover via async updates

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/AsyncHtmlHoverInput.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/AsyncHtmlHoverInput.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Sebastian Thomschke (Vegard IT GmbH) - initial implementation.
+ *******************************************************************************/
+package org.eclipse.lsp4e.operations.hover;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Lightweight carrier for asynchronous hover HTML content.
+ *
+ * Holds a placeholder HTML to show immediately and a future that will
+ * eventually provide the final HTML. The {@link #token} acts as an identity to
+ * guard UI updates against races when the control input changes quickly.
+ */
+@SuppressWarnings("javadoc")
+final class AsyncHtmlHoverInput {
+
+	final UUID token = UUID.randomUUID();
+	final CompletableFuture<@Nullable String> future;
+	final String placeholderHtml;
+
+	AsyncHtmlHoverInput(CompletableFuture<@Nullable String> future, String placeholderHtml) {
+		this.future = future;
+		this.placeholderHtml = placeholderHtml;
+	}
+}


### PR DESCRIPTION
`LSPTextHover` now implements `ITextHoverExtension2` and returns an async input that shows a placeholder immediately and updates when the language server responds. 

The UI no longer waits for LS replies; getHoverRegion avoids blocking and falls back to a heuristic word-like region when data isn't ready. 

`FocusableBrowserInformationControl` swaps in the final HTML and hides/disposes the hover when the server returns no content, errors, or stalls, preventing lingering "Loading..." popups.

Addresses #1270 #972

<img width="525" height="207" alt="image" src="https://github.com/user-attachments/assets/19244a37-b387-4690-970f-b6b3792234d4" />

---

<img width="681" height="209" alt="image" src="https://github.com/user-attachments/assets/7cb9f461-428d-4eb7-adee-94b73496916e" />

