### PR TITLE
feat: Compare existing text case-insensitive when inserting completion without textedit

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/AbstractCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/AbstractCompletionTest.java
@@ -46,6 +46,13 @@ public abstract class AbstractCompletionTest extends AbstractTestWithProject {
 		return createCompletionItem(label, kind, new Range(new Position(0, 0), new Position(0, label.length())));
 	}
 
+	protected CompletionItem createCompletionItemWithoutTextEdit(String label, CompletionItemKind kind) {
+		final var item = new CompletionItem();
+		item.setLabel(label);
+		item.setKind(kind);
+		return item;
+	}
+	
 	protected CompletionItem createCompletionItem(String label, CompletionItemKind kind, Range range) {
 		final var item = new CompletionItem();
 		item.setLabel(label);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompleteCompletionTest.java
@@ -150,7 +150,7 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 0);
 
-		// Assert command was invoked on langauge server
+		// Assert command was invoked on language server
 		ExecuteCommandParams executedCommand = MockLanguageServer.INSTANCE.getWorkspaceService().getExecutedCommand().get(2, TimeUnit.SECONDS);
 
 		assertEquals(MockLanguageServer.SUPPORTED_COMMAND_ID, executedCommand.getCommand());
@@ -173,6 +173,40 @@ public class CompleteCompletionTest extends AbstractCompletionTest {
 		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
 		lsCompletionProposal.apply(viewer, '\n', 0, 0);
 		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
+	}
+	
+	@Test
+	public void testPrefixCaseSensitivityWithoutTextEdit() throws CoreException {
+		final var items = new ArrayList<CompletionItem>();
+		items.add(createCompletionItemWithoutTextEdit("FirstClass", CompletionItemKind.Class));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
+
+		final var content = "FIRST";
+		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
+
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
+		assertEquals(1, proposals.length);
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
+		lsCompletionProposal.apply(viewer, '\n', 0, 0);
+		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
+		assertEquals("FirstClass", viewer.getDocument().get());
+	}
+	
+	@Test
+	public void testPrefixCaseSensitivityWithoutTextEditAtOffset() throws CoreException {
+		final var items = new ArrayList<CompletionItem>();
+		items.add(createCompletionItemWithoutTextEdit("FirstClass", CompletionItemKind.Class));
+		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(false, items));
+
+		final var content = "FIRST";
+		ITextViewer viewer = TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, content));
+
+		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, content.length());
+		assertEquals(1, proposals.length);
+		final var lsCompletionProposal = (LSCompletionProposal) proposals[0];
+		lsCompletionProposal.apply(viewer, '\n', 0, 4);
+		assertEquals(new Point("FirstClass".length(), 0), lsCompletionProposal.getSelection(viewer.getDocument()));
+		assertEquals("FirstClass", viewer.getDocument().get());
 	}
 
 	@Test

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -457,9 +457,8 @@ public class LSCompletionProposal
 					Math.max(0, completionOffset - insertTextLength),
 					Math.min(insertTextLength, completionOffset));
 			for (int i = 0; i < insertTextLength && i < completionOffset; i++) {
-				String tentativeCommonString = subDoc.substring(i);
-				if (insertText.startsWith(tentativeCommonString)) {
-					return completionOffset - tentativeCommonString.length();
+				if (insertText.regionMatches(true, 0, subDoc, i, subDoc.length() - i)) {
+					return completionOffset - subDoc.substring(i).length();
 				}
 			}
 		} catch (BadLocationException e) {
@@ -514,7 +513,7 @@ public class LSCompletionProposal
 				final int insertTextLength = insertText.length();
 				while (commonSize < insertTextLength - shift
 					&& document.getLength() > offset + commonSize
-					&& document.getChar(bestOffset + shift + commonSize) == insertText.charAt(commonSize + shift)) {
+					&& Character.toLowerCase(document.getChar(bestOffset + shift + commonSize)) == Character.toLowerCase(insertText.charAt(commonSize + shift))) {
 					commonSize++;
 				}
 				textEdit.getRange().getEnd().setCharacter(textEdit.getRange().getEnd().getCharacter() + commonSize);


### PR DESCRIPTION
Consider this piece of code:
```python
MY_SUPER_DUPER_CONSTANT = 42

print(my_super|)
```
With `|` being the cursor, the server proposes a completion with `MY_SUPER_DUPER_CONSTANT`.
If we accept this proposal, we get the following result, because we compare the existing characters case-sensitive, when trying to figure out where to place the completion and what characters we can re-use:
```python
print(my_superMY_SUPER_DUPER_CONSTANT)
```

With this PR, we do the comparison case-insensitive, which instead gives us:
```python
print(MY_SUPER_DUPER_CONSTANT)
```

Note that this is only necessary for rudimentary completions which only have a label but no textedit.