### PR TITLE
ci: only run license check if dependencies changed

### DIFF
--- a/.github/workflows/licensecheck.yml
+++ b/.github/workflows/licensecheck.yml
@@ -7,7 +7,13 @@ on:  # https://docs.github.com/en/actions/reference/workflows-and-actions/events
     - 'dependabot/**'  # prevent GHA triggered twice (once for commit to the branch and once for opening/syncing the PR)
     tags-ignore:  # don't build tags
     - '**'
+    paths:
+    - '**/pom.xml'
+    - '**/*.target'
   pull_request:
+    paths:
+    - '**/pom.xml'
+    - '**/*.target'
   workflow_dispatch:
     # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
     inputs:


### PR DESCRIPTION
This PR updates the trigger of the license-check job so the Dash License plugin is executed only when files with potential dependency changes are modified. This prevents unnecessary requests to the underlying ClearlyDefined API, which rate-limits based on the GitHub Runner’s IP and recently likes to fail with HTTP 429 errors.