### PR TITLE
fix: `service.ranking` must be an Integer to take effect

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.0.qualifier
+Bundle-Version: 0.19.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/OSGI-INF/org.eclipse.lsp4e.format.DefaultFormatRegionsProvider.xml
+++ b/org.eclipse.lsp4e/OSGI-INF/org.eclipse.lsp4e.format.DefaultFormatRegionsProvider.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.lsp4e.format.DefaultFormatRegionsProvider">
-   <property name="service.ranking" value="1"/>
+   <property name="service.ranking" type="Integer" value="1"/>
    <service>
       <provide interface="org.eclipse.lsp4e.format.IFormatRegionsProvider"/>
    </service>

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.0-SNAPSHOT</version>
+	<version>0.19.1-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/format/DefaultFormatRegionsProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/format/DefaultFormatRegionsProvider.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * This implementation has a 'service.ranking' of 1 so it is chosen as the default when querying
  * {@link BundleContext#getServiceReference(String)} without specifying a serverDefinitionId.
  */
-@Component(property={"service.ranking=1"})
+@Component(property={"service.ranking:Integer=1"})
 public class DefaultFormatRegionsProvider implements IFormatRegionsProvider {
 
 	@Override


### PR DESCRIPTION
Unfortunately my previous fix #1363 was faulty, because `service.ranking` must be specified as an Integer or it won't take effect.
The unit test in #1363 couldn't detect this, because services are sorted by service.ranking descending and then load order ascending and `DefaultFormatRegionsProvider` is probably always loaded first in our test setup. My local testing also did not reveal this, because the load order just happened to be correct 😞

To make sure this fix is now correct, I debugged the lookup in `ServiceRegistry.getServiceReference(BundleContextImpl, String)` to make sure the `service.ranking` of `DefaultFormatRegionsProvider` is correctly set to 1