### PR TITLE
fix: decode file URIs in document hyperlink labels

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
@@ -79,6 +79,20 @@ public class DocumentLinkTest extends AbstractTestWithProject {
 	}
 
 	@Test
+	public void testDocumentLinkWithEncodedUri() throws Exception {
+		final var links = new ArrayList<DocumentLink>();
+		links.add(new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file:///tmp/fi%C3%A9le.ts"));
+		MockLanguageServer.INSTANCE.setDocumentLinks(links);
+
+		IFile file = TestUtils.createUniqueTestFile(project, "not_link <link>");
+		ITextViewer viewer = TestUtils.openTextViewer(file);
+
+		IHyperlink[] hyperlinks = documentLinkDetector.detectHyperlinks(viewer, new Region(13, 0), true);
+		assertEquals(1, hyperlinks.length);
+		assertEquals("/tmp/fiéle.ts", hyperlinks[0].getHyperlinkText());
+	}
+
+	@Test
 	public void testDocumentLinkWrongRegion() throws Exception {
 		final var links = new ArrayList<DocumentLink>();
 		links.add(new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file://test0"));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/DocumentLinkDetector.java
@@ -39,10 +39,12 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 	public static class DocumentHyperlink implements IHyperlink {
 
 		private final String uri;
+		private final String label;
 		private final IRegion highlightRegion;
 
 		public DocumentHyperlink(String uri, IRegion highlightRegion) {
 			this.uri = uri;
+			this.label = toLabel(uri);
 			this.highlightRegion = highlightRegion;
 		}
 
@@ -53,12 +55,12 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 
 		@Override
 		public String getTypeLabel() {
-			return uri;
+			return label;
 		}
 
 		@Override
 		public String getHyperlinkText() {
-			return uri;
+			return label;
 		}
 
 		@Override
@@ -66,6 +68,22 @@ public class DocumentLinkDetector extends AbstractHyperlinkDetector {
 			LSPEclipseUtils.open(uri, null, true);
 		}
 
+		private static String toLabel(final String uri) {
+			if (uri.isEmpty())
+				return uri;
+
+			if (uri.startsWith(LSPEclipseUtils.FILE_URI)) {
+				try {
+					final URI fileUri = URI.create(uri);
+					final String path = fileUri.getPath();
+					if (path != null && !path.isEmpty())
+						return path;
+				} catch (final IllegalArgumentException ex) {
+					LanguageServerPlugin.logError(ex);
+				}
+			}
+			return uri;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
DocumentLinkDetector now derives the hyperlink label from the decoded URI path for file:// links, so percent-encoded characters (e.g. %C3%A9) are shown as their human-readable form while still opening the original URI.

Fixes #474