### PR TITLE
fix: fall back to next LS when formatting returns no edits

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.16.3.qualifier
+Bundle-Version: 0.16.4.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.16.3-SNAPSHOT</version>
+	<version>0.16.4-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.2.qualifier
+Bundle-Version: 0.19.3.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.2-SNAPSHOT</version>
+	<version>0.19.3-SNAPSHOT</version>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
In WildWebDeveloper it is currently not possible to format .vue files because VUE and TS LS are both launched and the TS LS processes the format request first and returns an empty list of edits for .vue documents. 

LSP4E’s `LSPFormatter` currently wraps the result of each server call into `VersionedEdits` before passing it to `LanguageServers.computeFirst(...)`, so computeFirst only sees a non-null object and cannot detect that the underlying edit list is empty. As a result, the TS LS “wins” the formatting request for .vue files and the Vue LS is never consulted.

This PR changes `LSPFormatter.requestFormatting(...)` to let `computeFirst` operate on the raw `List<? extends TextEdit>` returned by each language server. Only after `computeFirst` has selected a non-empty edit list do we wrap it into `VersionedEdits`. This allows `computeFirst`’s existing logic (which treats `null` and empty collections as “no result”) to work as intended: servers that advertise formatting but return no edits are skipped, and the next server with real edits (e.g. the Vue LS) is used instead.

The behavior for single-server scenarios is unchanged (an empty edit list still means “no formatting applied”), while multi-server setups like WildWebDeveloper (TS + Vue) now correctly fall back to the Vue language server for .vue formatting.