### PR TITLE
fix: Stop processing resource changes when dispatcher was shutdown

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.3.qualifier
+Bundle-Version: 0.19.4.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.3-SNAPSHOT</version>
+	<version>0.19.4-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -1524,6 +1524,10 @@ public class LanguageServerWrapper {
 			if (currentServer == null)
 				return;
 
+			if (dispatcher.isShutdown()) {
+				return;
+			}
+
 			// Offload potentially expensive glob matching and notification dispatching
 			// to the language-server dispatcher thread to avoid blocking the workspace
 			// resource change thread.


### PR DESCRIPTION
Fixes #1446 

~~I was unable to reliably reproduce the error, so I am not 100 percent sure that this fix will work, but to me it seems logical that it should work~~
Using breakpoints in the Plugin Shutdown and the ResourceChangeListener, I was able to confirm that the patch works as expected.