### PR TITLE
fix: handle race conditions accessing elements in DOM

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
@@ -102,7 +102,7 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 		Point hint = computeSizeHint();
 		setSize(hint.x, hint.y);
 
-		if (!"complete".equals(safeEvaluate(browser, "return document.readyState"))) { //$NON-NLS-1$ //$NON-NLS-2$
+		if (!"complete".equals(safeEvaluate(browser, "return document.documentElement ? document.readyState : 'no content';"))) { //$NON-NLS-1$ //$NON-NLS-2$
 			UI.getDisplay().timerExec(200, () -> updateBrowserSize(browser));
 			return;
 		}


### PR DESCRIPTION
Fixed the browser to not appear to be 'ready' to set the body before the text to be set has been processed.

Otherwise, because the content is set asynchronously in a browser after the call to browser.setText, it can be that the first call to document.readyState is done before the browser has processed the request to modify the page, and therefore document.readyState returns true even if the page has no content. To fix this, we check that the document has at least one element before asking for document.readyState.