### PR TITLE
fix: Restrict JUnit version

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -30,8 +30,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.ui.workbench,
  org.eclipse.tm4e.ui,
  org.eclipse.core.filesystem,
- junit-jupiter-api,
- junit-jupiter-params,
+ junit-jupiter-api;bundle-version="[5.14.1,6.0.0)",
+ junit-jupiter-params;bundle-version="[5.14.1,6.0.0)",
  org.hamcrest,
  org.opentest4j
 Automatic-Module-Name: org.eclipse.lsp4e.test


### PR DESCRIPTION
This should fix the current problems with the maven build, i.e., 
```
Failed to execute goal org.eclipse.tycho:tycho-surefire-plugin:5.0.1:test (default-test) on project org.eclipse.lsp4e.test: No tests found
```
I restricted the JUnit Version to 5, which seems to be the fix, according to https://eclipse.dev/eclipse/markdown/?f=news/4.38/pde.md