### PR TITLE
fix: Handle Diagnostic with `null` severity

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.6.qualifier
+Bundle-Version: 0.19.7.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.6-SNAPSHOT</version>
+	<version>0.19.7-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/DiagnosticAnnotation.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/DiagnosticAnnotation.java
@@ -19,6 +19,9 @@ import org.eclipse.lsp4j.Diagnostic;
 
 class DiagnosticAnnotation extends Annotation {
 
+	private static final String TYPE_INFO = "org.eclipse.ui.workbench.texteditor.info"; //$NON-NLS-1$
+	private static final String TYPE_WARNING = "org.eclipse.ui.workbench.texteditor.warning"; //$NON-NLS-1$
+	private static final String TYPE_ERROR = "org.eclipse.ui.workbench.texteditor.error"; //$NON-NLS-1$
 	private final Diagnostic diagnostic;
 	private final Function<Diagnostic, String> textComputer;
 
@@ -30,10 +33,11 @@ class DiagnosticAnnotation extends Annotation {
 	@Override
 	public String getType() {
 		return switch (diagnostic.getSeverity()) {
-		case Error -> "org.eclipse.ui.workbench.texteditor.error"; //$NON-NLS-1$
-		case Warning -> "org.eclipse.ui.workbench.texteditor.warning"; //$NON-NLS-1$
-		case Information -> "org.eclipse.ui.workbench.texteditor.info"; //$NON-NLS-1$
-		case Hint -> "org.eclipse.ui.workbench.texteditor.info"; //$NON-NLS-1$
+		case Error -> TYPE_ERROR;
+		case Warning -> TYPE_WARNING;
+		case Information -> TYPE_INFO;
+		case Hint -> TYPE_INFO;
+		case null -> TYPE_ERROR;
 		};
 	}
 


### PR DESCRIPTION
Handle case `null` for `Diagnostic::severity`. We encountered several NPEs due to this:
```
ERROR 2026-01-13 16:28:43.442 [Text Viewer Hover Presenter] org.eclipse.equinox.logger - Unexpected runtime error while computing a text hover
java.lang.NullPointerException: Cannot invoke "org.eclipse.lsp4j.DiagnosticSeverity.ordinal()" because the return value of "org.eclipse.lsp4j.Diagnostic.getSeverity()" is null
	at org.eclipse.lsp4e.operations.diagnostics.DiagnosticAnnotation.getType(DiagnosticAnnotation.java:32)
	at org.eclipse.ui.texteditor.AnnotationPreferenceLookup.getAnnotationPreference(AnnotationPreferenceLookup.java:51)
	at org.eclipse.ui.internal.genericeditor.AnnotationHoverDelegate$1.isIncluded(AnnotationHoverDelegate.java:44)
	at org.eclipse.jface.text.DefaultTextHover.getHoverInfo(DefaultTextHover.java:60)
	at org.eclipse.ui.internal.genericeditor.AnnotationHoverDelegate.getHoverInfo(AnnotationHoverDelegate.java:68)
	at org.eclipse.ui.internal.genericeditor.hover.CompositeTextHover.getHoverInfo2(CompositeTextHover.java:60)
	at org.eclipse.jface.text.TextViewerHoverManager$1.run(TextViewerHoverManager.java:155)
```

and 

```
java.lang.NullPointerException: Cannot invoke "org.eclipse.lsp4j.DiagnosticSeverity.ordinal()" because the return value of "org.eclipse.lsp4j.Diagnostic.getSeverity()" is null
	at org.eclipse.lsp4e.operations.diagnostics.DiagnosticAnnotation.getType(DiagnosticAnnotation.java:32)
	at org.eclipse.jface.text.source.OverviewRuler$InternalListener.modelChanged(OverviewRuler.java:108)
	at org.eclipse.jface.text.source.AnnotationModel.fireModelChanged(AnnotationModel.java:592)
	at org.eclipse.jface.text.source.AnnotationModel$InternalModelListener.modelChanged(AnnotationModel.java:256)
	at org.eclipse.jface.text.source.AnnotationModel.fireModelChanged(AnnotationModel.java:592)
	at org.eclipse.jface.text.source.AnnotationModel.fireModelChanged(AnnotationModel.java:558)
	at org.eclipse.jface.text.source.AnnotationModel.replaceAnnotations(AnnotationModel.java:409)
	at org.eclipse.jface.text.source.AnnotationModel.replaceAnnotations(AnnotationModel.java:374)
	at org.eclipse.lsp4e.operations.diagnostics.LSPDiagnosticsToMarkers.updateEditorAnnotations(LSPDiagnosticsToMarkers.java:137)
	at org.eclipse.lsp4e.operations.diagnostics.LSPDiagnosticsToMarkers.accept(LSPDiagnosticsToMarkers.java:102)
	at org.eclipse.lsp4e.operations.diagnostics.LSPDiagnosticsToMarkers.accept(LSPDiagnosticsToMarkers.java:1)
	at org.eclipse.lsp4e.client.DefaultLanguageClient.publishDiagnostics(DefaultLanguageClient.java:110)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$recursiveFindRpcMethods$0(GenericEndpoint.java:65)
	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.notify(GenericEndpoint.java:160)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleNotification(RemoteEndpoint.java:231)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:198)
	at org.eclipse.lsp4e.LanguageServerWrapper.lambda$3(LanguageServerWrapper.java:449)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:185)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:97)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:114)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```