### PR TITLE
feat: Add svg icons for key, event and operator

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.6.qualifier
+Bundle-Version: 0.19.7.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/icons/full/obj16/event.svg
+++ b/org.eclipse.lsp4e/icons/full/obj16/event.svg
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.0 r9654"
+   sodipodi:docname="configs.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17410">
+      <stop
+         style="stop-color:#e0ebf6;stop-opacity:1;"
+         offset="0"
+         id="stop17412" />
+      <stop
+         style="stop-color:#f3f5f6;stop-opacity:1"
+         offset="1"
+         id="stop17414" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient17159">
+      <stop
+         style="stop-color:#ffeece;stop-opacity:1"
+         offset="0"
+         id="stop17161" />
+      <stop
+         style="stop-color:#e1eaba;stop-opacity:1"
+         offset="1"
+         id="stop17163" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17410"
+       id="linearGradient17441"
+       gradientUnits="userSpaceOnUse"
+       x1="-9.733428"
+       y1="12.635066"
+       x2="-3.9386158"
+       y2="6.8402538" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17159"
+       id="linearGradient17443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59076155,0.59076155,-0.59076155,0.59076155,17.040411,1049.6082)"
+       x1="-20.742412"
+       y1="7.9916593"
+       x2="-10.422931"
+       y2="7.9916593" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627418"
+     inkscape:cx="1.2239013"
+     inkscape:cy="5.7033411"
+     inkscape:document-units="px"
+     inkscape:current-layer="g17418"
+     showgrid="true"
+     inkscape:window-width="1497"
+     inkscape:window-height="814"
+     inkscape:window-x="226"
+     inkscape:window-y="512"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5126" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline;fill:none"
+       id="layer1-4"
+       inkscape:label="Layer 1"
+       transform="matrix(0.8261236,0,0,0.8261236,1.7832208,183.40446)">
+      <g
+         transform="matrix(1.2065384,0,0,1.2065384,-22.98457,-221.37405)"
+         id="g17594"
+         style="fill:none">
+        <g
+           id="g17418"
+           transform="matrix(0.96836657,0,0,0.96836657,20.738144,33.659982)">
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:url(#linearGradient17441);fill-opacity:1;stroke:#3f7fbf;stroke-width:0.5091278;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-5"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
+             transform="matrix(1.0450409,-1.0450409,1.0450409,1.0450409,2.1256839,1029.9689)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14"
+             d="m 11.53513,1045.8134 c 0.07294,0.9455 0.07325,1.9032 9.05e-4,2.8489 l -2.3011454,-1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2"
+             d="m -1.0914354,1048.6741 c -0.07294,-0.9455 -0.07325,-1.9032 -9.07e-4,-2.849 l 2.301146,1.4186 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3"
+             d="m 6.6521976,1053.557 c -0.9455,0.073 -1.9032,0.073 -2.8489,9e-4 l 1.4186,-2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2"
+             d="m 3.7914976,1040.9305 c 0.9455,-0.073 1.9032,-0.073 2.849,-9e-4 l -1.4186,2.3011 z"
+             style="color:#000000;fill:#d2d5cb;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-2"
+             d="m 10.697423,1050.6965 c -0.616993,0.7202 -1.2939698,1.3976 -2.013837,2.0151 l -0.6240538,-2.6302 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-1"
+             d="m -0.2537278,1043.791 c 0.61699309,-0.7202 1.2939701,-1.3976 2.0139059,-2.0152 l 0.6240542,2.6303 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-14-3-6"
+             d="m 1.7691159,1052.7193 c -0.7201883,-0.6169 -1.39738442,-1.2941 -2.0151129,-2.0138 l 2.6302251,-0.6241 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-2-2-8"
+             d="m 8.6745793,1041.7682 c 0.7201883,0.6169 1.3973847,1.2941 2.0151837,2.0139 l -2.6302252,0.624 z"
+             style="color:#000000;fill:#bfdfbf;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:#1d4984;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1-76"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
+             transform="matrix(0.31739531,-0.31739531,0.31739531,0.31739531,4.2814936,1041.9971)" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4"
+             d="m 11.535129,1046.4091 c 0.07294,0.5517 0.07325,1.1106 9.06e-4,1.6624 l -2.3011454,-0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5"
+             d="m -1.0914359,1048.0784 c -0.072942,-0.5517 -0.073247,-1.1106 -9.07e-4,-1.6625 l 2.3011463,0.8278 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51"
+             d="m 6.0564977,1053.557 c -0.5517,0.073 -1.1106,0.073 -1.6624,9e-4 l 0.8278,-2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7"
+             d="m 4.3871977,1040.9305 c 0.5517,-0.073 1.1106,-0.073 1.6624,-9e-4 l -0.8277,2.3011 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-1"
+             d="m 10.276129,1051.1178 c -0.3385343,0.4417 -0.7335171,0.8371 -1.1748536,1.1761 l -1.0418139,-2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-1"
+             d="m 0.16742503,1043.3698 c 0.33853445,-0.4416 0.73351722,-0.8371 1.17492367,-1.1762 l 1.0418137,2.2125 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-51-5"
+             d="m 1.3478924,1052.2981 c -0.44172887,-0.3385 -0.83693085,-0.7337 -1.17612997,-1.1749 l 2.21246567,-1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-4-5-7-2"
+             d="m 9.0958029,1042.1894 c 0.4417296,0.3385 0.8369322,0.7337 1.1761311,1.1749 l -2.2123961,1.0418 z"
+             style="color:#000000;fill:#4d607b;fill-opacity:1;stroke:none;stroke-width:0.33941853;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+          <path
+             sodipodi:type="arc"
+             style="color:#000000;fill:none;stroke:#3f7fbf;stroke-width:0.7180745;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+             id="path6139-1"
+             sodipodi:cx="-6.7838054"
+             sodipodi:cy="9.7465248"
+             sodipodi:rx="4.3089318"
+             sodipodi:ry="4.3089318"
+             d="m -2.4748735,9.7465248 c 0,2.3797572 -1.9291745,4.3089322 -4.3089319,4.3089322 -2.3797573,0 -4.3089316,-1.929175 -4.3089316,-4.3089322 0,-2.3797573 1.9291743,-4.3089318 4.3089316,-4.3089318 2.3797574,0 4.3089319,1.9291745 4.3089319,4.3089318 z"
+             transform="matrix(1.0202099,-1.0202099,1.0202099,1.0202099,2.1992508,1030.3794)" />
+          <path
+             sodipodi:nodetypes="cccccssc"
+             inkscape:connector-curvature="0"
+             id="path6139-1-7"
+             d="m 6.0190516,1046.4513 -4.6356786,-3.9985 -1.80221867,-0.8517 0.85667548,1.7973 4.00338379,4.6307 c 0.2002055,0.2002 0.4771321,0.3237 0.7840021,0.3237 0.61367,0 1.1076548,-0.494 1.1076828,-1.1077 -5.64e-5,-0.3068 -0.1127546,-0.5927 -0.3138469,-0.7938 z"
+             style="color:#000000;fill:url(#linearGradient17443);fill-opacity:1;stroke:#4d607b;stroke-width:0.80260861;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.lsp4e/icons/full/obj16/key.svg
+++ b/org.eclipse.lsp4e/icons/full/obj16/key.svg
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   sodipodi:docname="key.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4502">
+      <stop
+         style="stop-color:#fce20d;stop-opacity:1"
+         offset="0"
+         id="stop4504" />
+      <stop
+         style="stop-color:#c65c00;stop-opacity:1"
+         offset="1"
+         id="stop4506" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4353">
+      <stop
+         id="stop4355"
+         offset="0"
+         style="stop-color:#17639e;stop-opacity:1" />
+      <stop
+         id="stop4357"
+         offset="1"
+         style="stop-color:#0d4a81;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18855">
+      <stop
+         id="stop18857"
+         offset="0"
+         style="stop-color:#a4b1c7;stop-opacity:1;" />
+      <stop
+         style="stop-color:#e1e9f8;stop-opacity:0"
+         offset="0.50000364"
+         id="stop18859" />
+      <stop
+         id="stop18861"
+         offset="1"
+         style="stop-color:#e7eefa;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18808">
+      <stop
+         style="stop-color:#a4b1c7;stop-opacity:1;"
+         offset="0"
+         id="stop18810" />
+      <stop
+         id="stop18816"
+         offset="0.24999017"
+         style="stop-color:#e1e9f8;stop-opacity:1" />
+      <stop
+         style="stop-color:#e7eefa;stop-opacity:1"
+         offset="1"
+         id="stop18812" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18543">
+      <stop
+         style="stop-color:#a79c68;stop-opacity:1;"
+         offset="0"
+         id="stop18545" />
+      <stop
+         id="stop18555"
+         offset="0.31919643"
+         style="stop-color:#687692;stop-opacity:1" />
+      <stop
+         id="stop18553"
+         offset="0.42585152"
+         style="stop-color:#8c99a6;stop-opacity:1" />
+      <stop
+         id="stop18551"
+         offset="0.671875"
+         style="stop-color:#7b8da7;stop-opacity:1" />
+      <stop
+         style="stop-color:#5e78a8;stop-opacity:1"
+         offset="1"
+         id="stop18547" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4862">
+      <stop
+         style="stop-color:#5b8eb7;stop-opacity:1"
+         offset="0"
+         id="stop4864" />
+      <stop
+         style="stop-color:#0e4b81;stop-opacity:1"
+         offset="1"
+         id="stop4866" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5156">
+      <stop
+         style="stop-color:#fdf3cb;stop-opacity:1;"
+         offset="0"
+         id="stop5158" />
+      <stop
+         id="stop5166"
+         offset="0.48612955"
+         style="stop-color:#fdf3cb;stop-opacity:1" />
+      <stop
+         id="stop5164"
+         offset="0.56520796"
+         style="stop-color:#a77e1c;stop-opacity:0.502" />
+      <stop
+         style="stop-color:#a77e1c;stop-opacity:0.5"
+         offset="1"
+         id="stop5160" />
+    </linearGradient>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask8608">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         id="rect8610"
+         width="14"
+         height="14"
+         x="1"
+         y="1037.3622"
+         rx="0.67081022"
+         ry="0.67081022" />
+    </mask>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11388"
+       id="linearGradient11394"
+       x1="477.41272"
+       y1="383.70734"
+       x2="476.45828"
+       y2="364.67343"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30607211,0,0,0.31290838,-142.18493,911.64375)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11388">
+      <stop
+         style="stop-color:#f9e633;stop-opacity:1"
+         offset="0"
+         id="stop11390" />
+      <stop
+         id="stop11402"
+         offset="0.39080957"
+         style="stop-color:#f9d953;stop-opacity:1" />
+      <stop
+         style="stop-color:#fffd6f;stop-opacity:1"
+         offset="1"
+         id="stop11392" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient11372"
+       id="linearGradient11378"
+       x1="480.18253"
+       y1="384.17654"
+       x2="480.08356"
+       y2="361.48178"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30607211,0,0,0.31290838,-142.18493,911.64375)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient11372">
+      <stop
+         style="stop-color:#886030;stop-opacity:1"
+         offset="0"
+         id="stop11374" />
+      <stop
+         style="stop-color:#b09068;stop-opacity:1"
+         offset="1"
+         id="stop11376" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4502"
+       id="linearGradient4508"
+       x1="14"
+       y1="1044.8622"
+       x2="20"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62843493,0,0,0.62843493,0.50348275,371.32474)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#d6d6d6"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.482932"
+     inkscape:cx="2.3085583"
+     inkscape:cy="6.1891349"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="2552"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1020.3622)">
+    <path
+       style="display:inline;opacity:1;fill:url(#linearGradient11394);fill-opacity:1;stroke:url(#linearGradient11378);stroke-width:0.628435;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 4.813541,1024.8104 c -1.8174115,0 -3.3674079,1.5753 -3.3674055,3.4333 -2.4e-6,1.858 1.549994,3.2957 3.3674055,3.2957 1.3035567,0 2.3895576,-0.5974 2.9052832,-1.7014 h 0.5758952 l 0.5632361,-0.588 0.7107268,0.588 h 0.8735747 l 0.599636,-0.5508 0.63793,0.5508 H 12.4442 l 0.381242,-0.4019 0.528733,0.4019 h 0.07976 c 0.568302,0 1.209336,-1.0609 1.209336,-1.5943 0,-0.5335 -0.458784,-1.5479 -1.027088,-1.5479 H 7.7319721 c -0.5105421,-1.158 -1.6045942,-1.8854 -2.9184272,-1.8854 z"
+       id="path11368"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssccccccccccssscs" />
+    <path
+       style="display:inline;opacity:1;fill:#6d6666;fill-opacity:1;stroke:#8a6333;stroke-width:0.033893;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 4.6125024,1029.0551 c -0.3790387,-0.138 -0.5429195,-0.8704 -0.2964944,-1.3251 0.1243617,-0.2295 0.2785161,-0.3114 0.5977314,-0.3173 0.5287625,-0.01 0.7270752,0.2636 0.6874105,0.9472 -0.026066,0.4496 -0.1103768,0.617 -0.3583986,0.7118 -0.1875835,0.072 -0.4037446,0.066 -0.6302489,-0.017 z"
+       id="path11423"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#b85606;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.75159;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 4.921108,1026.9181 c -0.8040953,0 -1.2754504,0.5665 -1.2754504,1.2569 0,0.6904 0.4713551,1.2569 1.2754504,1.2569 0.804097,0 1.2382891,-0.5665 1.2382891,-1.2569 0,-0.6904 -0.4341921,-1.2569 -1.2382891,-1.2569 z m 0,0.6518 c 0.3938453,0 0.4792168,0.2669 0.4792168,0.6051 0,0.3382 -0.085376,0.6051 -0.4792168,0.6051 -0.3938429,0 -0.5163745,-0.2669 -0.5163745,-0.6051 0,-0.3382 0.1225316,-0.6051 0.5163745,-0.6051 z"
+       id="path11417"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssssssssss" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4508);stroke-width:0.628435px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 13.072182,1027.9526 H 9.3015718"
+       id="path4500"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/org.eclipse.lsp4e/icons/full/obj16/operator.svg
+++ b/org.eclipse.lsp4e/icons/full/obj16/operator.svg
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   sodipodi:docname="operator.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient6738">
+      <stop
+         style="stop-color:#5481b6;stop-opacity:1"
+         offset="0"
+         id="stop6740" />
+      <stop
+         id="stop5729"
+         offset="0.5"
+         style="stop-color:#1c65a2;stop-opacity:1" />
+      <stop
+         style="stop-color:#5286ba;stop-opacity:1"
+         offset="1"
+         id="stop6742" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="32"
+     inkscape:cx="1.40625"
+     inkscape:cy="9.140625"
+     inkscape:document-units="px"
+     inkscape:current-layer="g6438"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="2552"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3960"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,16.12959,8.0140628)"
+       style="display:inline"
+       id="g6124-3">
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+         id="text6430" />
+      <g
+         transform="scale(-1,1)"
+         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
+         id="g6438">
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:14.5408px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#246196;fill-opacity:1;stroke:#246196;stroke-width:0.146793;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+           x="-7.7880683"
+           y="995.12128"
+           id="text4149"
+           transform="scale(0.95278565,1.049554)"><tspan
+             sodipodi:role="line"
+             x="-7.7880683"
+             y="995.12128"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.9341px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#246196;fill-opacity:1;stroke:#246196;stroke-width:0.146793;stroke-opacity:1"
+             id="tspan1">+</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:14.5408px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#246196;fill-opacity:1;stroke:#246196;stroke-width:0.146793;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+           x="-7.8318019"
+           y="987.52759"
+           id="text4149-8"
+           transform="scale(0.95278565,1.049554)"><tspan
+             sodipodi:role="line"
+             x="-7.8318019"
+             y="987.52759"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.9341px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#246196;fill-opacity:1;stroke:#246196;stroke-width:0.146793;stroke-opacity:1"
+             id="tspan1-2">−</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:14.5408px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#246196;fill-opacity:1;stroke:#246196;stroke-width:0.146793;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+           x="-15.55422"
+           y="995.11035"
+           id="text4149-8-7"
+           transform="scale(0.95278565,1.049554)"><tspan
+             sodipodi:role="line"
+             x="-15.55422"
+             y="995.11035"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.9341px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#246196;fill-opacity:1;stroke:#246196;stroke-width:0.146793;stroke-opacity:1"
+             id="tspan1-2-1">&gt;</tspan></text>
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:14.5408px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;fill:#246196;fill-opacity:1;stroke:#246196;stroke-width:0.146793;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+           x="-15.55422"
+           y="987.53308"
+           id="text4149-5"
+           transform="scale(0.95278565,1.049554)"><tspan
+             sodipodi:role="line"
+             x="-15.55422"
+             y="987.53308"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.9341px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';fill:#246196;fill-opacity:1;stroke:#246196;stroke-width:0.146793;stroke-opacity:1"
+             id="tspan1-27">×</tspan></text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.6-SNAPSHOT</version>
+	<version>0.19.7-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
@@ -74,6 +74,9 @@ public final class LSPImages {
 	public static final String IMG_SNIPPET = "IMG_SNIPPET"; //$NON-NLS-1$
 	public static final String IMG_REFERENCE = "IMG_REFERENCE"; //$NON-NLS-1$
 	public static final String IMG_TERMINATE_CO = "IMG_TERMINATE_CO"; //$NON-NLS-1$
+	public static final String IMG_EVENT = "IMG_EVENT"; //$NON-NLS-1$
+	public static final String IMG_KEY = "IMG_KEY"; //$NON-NLS-1$
+	public static final String IMG_OPERATOR = "IMG_OPERATOR"; //$NON-NLS-1$
 
 	public static final String IMG_SUPERTYPE = "IMG_SUPERTYPE"; //$NON-NLS-1$
 	public static final String IMG_SUBTYPE = "IMG_SUBTYPE"; //$NON-NLS-1$
@@ -102,6 +105,9 @@ public final class LSPImages {
 		declareRegistryImage(IMG_BOOLEAN, OBJECT + "boolean.svg"); //$NON-NLS-1$
 		declareRegistryImage(IMG_ARRAY, OBJECT + "array.png"); //$NON-NLS-1$
 		declareRegistryImage(IMG_NULL, OBJECT + "null.svg"); //$NON-NLS-1$
+		declareRegistryImage(IMG_KEY, OBJECT + "key.svg"); //$NON-NLS-1$
+		declareRegistryImage(IMG_EVENT, OBJECT + "event.svg"); //$NON-NLS-1$
+		declareRegistryImage(IMG_OPERATOR, OBJECT + "operator.svg"); //$NON-NLS-1$
 
 		declareRegistryImage(IMG_TEXT, OBJECT + "text.svg"); //$NON-NLS-1$
 		declareRegistryImage(IMG_UNIT, OBJECT + "unit.svg"); //$NON-NLS-1$
@@ -196,7 +202,9 @@ public final class LSPImages {
 		case TypeParameter -> getImage(IMG_TYPE_PARAMETER);
 		case Variable -> getImage(IMG_VARIABLE);
 		case Null -> getImage(IMG_NULL);
-		case Event, Key, Operator -> EMPTY_IMAGE;
+		case Event -> getImage(IMG_EVENT);
+		case Key -> getImage(IMG_KEY);
+		case Operator -> getImage(IMG_OPERATOR);
 		case null -> EMPTY_IMAGE;
 		};
 	}
@@ -226,7 +234,8 @@ public final class LSPImages {
 		case Reference -> getImage(IMG_REFERENCE);
 		case Constant -> getImage(IMG_CONSTANT);
 		case TypeParameter -> getImage(IMG_TYPE_PARAMETER);
-		case Event, Operator -> null;
+		case Event -> getImage(IMG_EVENT);
+		case Operator -> getImage(IMG_OPERATOR);
 		case null -> null;
 		};
 	}


### PR DESCRIPTION
Closes #1459 

- event.svg comes from https://github.com/eclipse-platform/eclipse.platform.images/blob/master/org.eclipse.images/eclipse-svg/org.eclipse.e4.tools.event.spy/icons/eventspy.svg
- key.svg is just the key from https://github.com/eclipse-platform/eclipse.platform.images/blob/master/org.eclipse.images/eclipse-svg/org.eclipse.team.ui/icons/full/wizban/keylock.svg
- operator.svg was created by me using the same font/color as in our https://github.com/eclipse-lsp4e/lsp4e/blob/main/org.eclipse.lsp4e/icons/full/obj16/function.svg