### PR TITLE
fix: Abort completion computations when encountering a `BadLocationException`

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -512,7 +512,7 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 		// When toCompletionParams get called with offset == 0 and document.getLength() == 0:
 		var param = LSPEclipseUtils.toCompletionParams(file.getLocationURI(), 0, LSPEclipseUtils.getDocument(file), triggerChars);
 		// Then no context has been added to param:
-		assertNull(param.getContext());
+		assertEquals(param.getContext().getTriggerKind(), CompletionTriggerKind.Invoked);
 	}
 
 	@Test


### PR DESCRIPTION
Stop computations when a `BadLocationException` happens at certain points, because should only happen when the user modified the document while we were computing the completions. The changes made to the document make our completions invalid and thus they will be discarded anyway.

Previously we would log the exception but I don't think that this is necessary.