### PR TITLE
feat: render Github Markdown Tables in the text hover

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -41,7 +41,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.e4.core.commands,
  org.eclipse.compare.core,
  org.eclipse.compare,
- org.commonmark;bundle-version="0.23.0"
+ org.commonmark;bundle-version="0.23.0",
+ org.commonmark.ext-gfm-tables;bundle-version="0.23.0"
 Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -111,9 +113,10 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension, ITextHover
 					.collect(Collectors.joining("\n\n")) //$NON-NLS-1$
 					.trim();
 			if (!result.isEmpty()) {
-				Parser parser = Parser.builder().build();
+				List<Extension> extensions = List.of(TablesExtension.create());
+				Parser parser = Parser.builder().extensions(extensions).build();
 				Node document = parser.parse(result);
-				HtmlRenderer renderer = HtmlRenderer.builder().build();
+				HtmlRenderer renderer = HtmlRenderer.builder().extensions(extensions).build();
 				return renderer.render(document);
 			} else {
 				return null;


### PR DESCRIPTION
commit 68f9534c97107529e94184cc864917da1f910551 added the necessary plugin for support for Github Markdown Tables but this library was not properly wired up. This commit correctly wires Github Markdown Tables support.