### PR TITLE
fix(deps): Update to tycho 5.0.2 and JUnit 6

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -30,8 +30,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.ui.workbench,
  org.eclipse.tm4e.ui,
  org.eclipse.core.filesystem,
- junit-jupiter-api;bundle-version="[5.14.1,6.0.0)",
- junit-jupiter-params;bundle-version="[5.14.1,6.0.0)",
+ junit-jupiter-api;bundle-version="[6.0.1,7.0.0)",
+ junit-jupiter-params;bundle-version="[6.0.1,7.0.0)",
  org.hamcrest,
  org.opentest4j
 Automatic-Module-Name: org.eclipse.lsp4e.test

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -43,6 +43,7 @@
 					<useUIThread>true</useUIThread>
 					<forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
 					<argLine>-Dfile.encoding=${project.build.sourceEncoding} -Xms1g -Xmx1g -Djava.util.logging.config.file=${project.basedir}/src/jul.properties ${ui.test.vmargs} ${os-jvm-flags}</argLine>
+					<providerHint>junit6</providerHint>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.minimum.version>3.9.9</maven.minimum.version>
-		<tycho-version>5.0.1</tycho-version>
+		<tycho-version>5.0.2</tycho-version>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse-lsp4e/lsp4e.git</tycho.scmUrl>
 		<ui.test.vmargs></ui.test.vmargs>
 		<jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>

--- a/target-platforms/target-platform-latest/target-platform-latest.target
+++ b/target-platforms/target-platform-latest/target-platform-latest.target
@@ -21,18 +21,6 @@
       <unit id="org.commonmark.ext-gfm-tables" version="0.0.0"/>
       <unit id="com.google.guava" version="0.0.0"/>
       <unit id="com.google.guava.failureaccess" version="0.0.0"/>
-      <!-- Pinning JUnit 5 for now -->
-      <unit id="junit-jupiter-api" version="5.14.1"/>
-      <unit id="junit-jupiter-engine" version="5.14.1"/>
-      <unit id="junit-jupiter-params" version="5.14.1"/>
-      <unit id="junit-platform-commons" version="1.14.1"/>
-      <unit id="junit-platform-engine" version="1.14.1"/>
-      <unit id="junit-platform-launcher" version="1.14.1"/>
-      <unit id="junit-platform-runner" version="1.14.1"/>
-      <unit id="junit-platform-suite-api" version="1.14.1"/>
-      <unit id="junit-platform-suite-commons" version="1.14.1"/>
-      <unit id="junit-platform-suite-engine" version="1.14.1"/>
-      <unit id="junit-vintage-engine" version="5.14.1"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.tm4e.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
[Tycho 5.0.2](https://github.com/eclipse-tycho/tycho/blob/tycho-5.0.2/RELEASE_NOTES.md) added support for JUnit 6. We can easily upgrade to it, because we don't use any of the JUnit 5 APIs that were removed in [JUnit 6](https://docs.junit.org/6.0.0/release-notes).