### PR TITLE
fix(tests): Use JUnit @TempDir to create temporary files

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServiceAccessorTest.java
@@ -21,7 +21,6 @@ import static org.eclipse.lsp4e.LanguageServiceAccessor.getLSWrappers;
 import static org.eclipse.lsp4e.LanguageServiceAccessor.hasActiveLanguageServers;
 import static org.eclipse.lsp4e.test.utils.TestUtils.createFile;
 import static org.eclipse.lsp4e.test.utils.TestUtils.createProject;
-import static org.eclipse.lsp4e.test.utils.TestUtils.createTempFile;
 import static org.eclipse.lsp4e.test.utils.TestUtils.createUniqueTestFile;
 import static org.eclipse.lsp4e.test.utils.TestUtils.createUniqueTestFileMultiLS;
 import static org.eclipse.lsp4e.test.utils.TestUtils.openEditor;
@@ -34,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
@@ -58,6 +59,7 @@ import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LanguageServiceAccessorTest extends AbstractTestWithProject {
 
@@ -368,10 +370,10 @@ public class LanguageServiceAccessorTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testLSforExternalThenLocalFile() throws Exception {
+	public void testLSforExternalThenLocalFile(@TempDir Path tempDir) throws Exception {
 		var wb = UI.getActiveWindow();
-		var local = createTempFile("testLSforExternalThenLocalFile", ".lspt");
-		var editor = (ITextEditor) IDE.openEditorOnFileStore(wb.getActivePage(), EFS.getStore(local.toURI()));
+		var local = Files.createFile(tempDir.resolve("testLSforExternalThenLocalFile.lspt"));
+		var editor = (ITextEditor) IDE.openEditorOnFileStore(wb.getActivePage(), EFS.getStore(local.toUri()));
 
 		Predicate<ServerCapabilities> hasHoverCapabilities = capabilities -> {
 			var hoverProvider = capabilities.getHoverProvider();

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/color/ColorTest.java
@@ -13,8 +13,8 @@ package org.eclipse.lsp4e.test.color;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
 
-import java.io.File;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.eclipse.core.filesystem.EFS;
@@ -37,6 +37,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.ide.IDE;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ColorTest extends AbstractTestWithProject {
 
@@ -56,12 +57,9 @@ public class ColorTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testColorProviderExternalFile() throws Exception {
-		File file = TestUtils.createTempFile("testColorProviderExternalFile", ".lspt");
-		try (var out = new FileOutputStream(file)) {
-			out.write("\u2588\u2588\u2588\u2588\u2588".getBytes());
-		}
-		ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI())));
+	public void testColorProviderExternalFile(@TempDir Path tempDir) throws Exception {
+		Path file = Files.write(tempDir.resolve("testColorProviderExternalFile.lspt"), "\u2588\u2588\u2588\u2588\u2588".getBytes());
+		ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri())));
 		StyledText widget = viewer.getTextWidget();
 		waitForAndAssertCondition(3_000, widget.getDisplay(), () -> containsColor(widget, color, 10));
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/IncompleteCompletionTest.java
@@ -18,8 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -56,6 +57,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class IncompleteCompletionTest extends AbstractCompletionTest {
 	/*
@@ -566,13 +568,13 @@ public class IncompleteCompletionTest extends AbstractCompletionTest {
 	}
 
 	@Test
-	public void testCompletionExternalFile() throws Exception {
+	public void testCompletionExternalFile(@TempDir Path tempDir) throws Exception {
 		final var items = new ArrayList<CompletionItem>();
 		items.add(createCompletionItem("FirstClassExternal", CompletionItemKind.Class));
 		MockLanguageServer.INSTANCE.setCompletionList(new CompletionList(true, items));
 
-		File file = TestUtils.createTempFile("testCompletionExternalFile", ".lspt");
-		final var editor = (ITextEditor) IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+		Path file = Files.createFile(tempDir.resolve("testCompletionExternalFile.lspt"));
+		final var editor = (ITextEditor) IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri()));
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		ICompletionProposal[] proposals = contentAssistProcessor.computeCompletionProposals(viewer, 0);
 		assertEquals(1, proposals.length);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/definition/DefinitionTest.java
@@ -14,7 +14,8 @@ package org.eclipse.lsp4e.test.definition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,6 +42,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DefinitionTest extends AbstractTestWithProject {
 
@@ -82,12 +84,12 @@ public class DefinitionTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testDefinitionOneLocationExternalFile() throws Exception {
+	public void testDefinitionOneLocationExternalFile(@TempDir Path tempDir) throws Exception {
 		final var location = new Location("file://test", new Range(new Position(0, 0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setDefinition(List.of(location));
 
-		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
-		final var editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+		Path file = Files.createFile(tempDir.resolve("testDocumentLinkExternalFile.lspt"));
+		final var editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri()));
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		IHyperlink[] hyperlinks = hyperlinkDetector.detectHyperlinks(viewer, new Region(0, 0), true);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/diagnostics/DiagnosticsTest.java
@@ -20,8 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -62,6 +62,7 @@ import org.eclipse.swt.graphics.RGB;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.MarkerUtilities;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DiagnosticsTest extends AbstractTestWithProject {
 
@@ -336,15 +337,12 @@ public class DiagnosticsTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testDiagnosticsOnExternalFile() throws Exception {
+	public void testDiagnosticsOnExternalFile(@TempDir Path tempDir) throws Exception {
 		MockLanguageServer.INSTANCE.setDiagnostics(List.of(new Diagnostic(new Range(new Position(0, 0), new Position(0, 1)), "This is a warning", DiagnosticSeverity.Warning, null)));
-		File file = TestUtils.createTempFile("testDiagnosticsOnExternalFile", ".lspt");
+		Path file = Files.writeString(tempDir.resolve("testDiagnosticsOnExternalFile.lspt"), "a");
 		Font font = null;
 		try {
-			try (var out = new FileOutputStream(file);) {
-				out.write('a');
-			}
-			ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI())));
+			ITextViewer viewer = LSPEclipseUtils.getTextViewer(IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri())));
 			StyledText widget = viewer.getTextWidget();
 			final var biggerFont = new FontData(); // bigger font to keep color intact in some pixel (not altered by anti-aliasing)
 			biggerFont.setHeight(40);

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkTest.java
@@ -14,7 +14,8 @@ package org.eclipse.lsp4e.test.documentLink;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import org.eclipse.core.filesystem.EFS;
@@ -34,6 +35,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DocumentLinkTest extends AbstractTestWithProject {
 
@@ -63,13 +65,13 @@ public class DocumentLinkTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testDocumentLinkExternalFile() throws Exception {
+	public void testDocumentLinkExternalFile(@TempDir Path tempDir) throws Exception {
 		final var links = new ArrayList<DocumentLink>();
 		links.add(new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file://test0"));
 		MockLanguageServer.INSTANCE.setDocumentLinks(links);
 
-		File file = TestUtils.createTempFile("testDocumentLinkExternalFile", ".lspt");
-		final var editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+		Path file = Files.createFile(tempDir.resolve("testDocumentLinkExternalFile.lspt"));
+		final var editor = (ITextEditor) IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri()));
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		viewer.getDocument().set("Long enough dummy content to match ranges");
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidChangeTest.java
@@ -17,7 +17,8 @@ import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -39,6 +40,7 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DocumentDidChangeTest extends AbstractTestWithProject {
 
@@ -193,12 +195,12 @@ public class DocumentDidChangeTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testFullSyncExternalFile() throws Exception {
+	public void testFullSyncExternalFile(@TempDir Path tempDir) throws Exception {
 		MockLanguageServer.INSTANCE.getInitializeResult().getCapabilities()
 				.setTextDocumentSync(TextDocumentSyncKind.Full);
 
-		File file = TestUtils.createTempFile("testFullSyncExternalFile", ".lspt");
-		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+		Path file = Files.createFile(tempDir.resolve("testFullSyncExternalFile.lspt"));
+		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri()));
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 		LanguageServers.forDocument(viewer.getDocument()).withFilter(new Predicate<ServerCapabilities>() {
 			@Override

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidCloseTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidCloseTest.java
@@ -14,7 +14,8 @@ package org.eclipse.lsp4e.test.edit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -31,6 +32,7 @@ import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DocumentDidCloseTest extends AbstractTestWithProject {
 
@@ -54,9 +56,9 @@ public class DocumentDidCloseTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testCloseExternalFile() throws Exception {
-		File testFile = TestUtils.createTempFile("testCloseExternalFile", ".lspt");
-		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(testFile.toURI()));
+	public void testCloseExternalFile(@TempDir Path tempDir) throws Exception {
+		Path testFile = Files.createFile(tempDir.resolve("testCloseExternalFile.lspt"));
+		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(testFile.toUri()));
 
 		// Force LS to initialize and open file
 		LanguageServers.forDocument(LSPEclipseUtils.getDocument(editor.getEditorInput())).anyMatching();
@@ -68,6 +70,6 @@ public class DocumentDidCloseTest extends AbstractTestWithProject {
 
 		DidCloseTextDocumentParams lastChange = didCloseExpectation.get(1000, TimeUnit.MILLISECONDS);
 		assertNotNull(lastChange.getTextDocument());
-		assertEquals(LSPEclipseUtils.toUri(testFile).toString(), lastChange.getTextDocument().getUri());
+		assertEquals(LSPEclipseUtils.toUri(testFile.toFile()).toString(), lastChange.getTextDocument().getUri());
 	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidOpenTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidOpenTest.java
@@ -14,7 +14,8 @@ package org.eclipse.lsp4e.test.edit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -32,6 +33,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DocumentDidOpenTest extends AbstractTestWithProject {
 
@@ -55,11 +57,11 @@ public class DocumentDidOpenTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testOpenExternalFile() throws Exception {
-		File file = TestUtils.createTempFile("testOpenExternalFile", ".lspt");
+	public void testOpenExternalFile(@TempDir Path tempDir) throws Exception {
+		Path file = Files.createFile(tempDir.resolve("testOpenExternalFile.lspt"));
 		final var didOpenExpectation = new CompletableFuture<DidOpenTextDocumentParams>();
 		MockLanguageServer.INSTANCE.setDidOpenCallback(didOpenExpectation);
-		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri()));
 		// Force LS to initialize and open file
 		LanguageServers.forDocument(LSPEclipseUtils.getDocument(editor.getEditorInput())).anyMatching();
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidSaveTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/DocumentDidSaveTest.java
@@ -16,7 +16,8 @@ import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +36,7 @@ import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.ide.IDE;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DocumentDidSaveTest extends AbstractTestWithProject {
 
@@ -67,9 +69,9 @@ public class DocumentDidSaveTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testSaveExternalFile() throws Exception {
-		File file = TestUtils.createTempFile("testSaveExternalFile", ".lspt");
-		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI()));
+	public void testSaveExternalFile(@TempDir Path tempDir) throws Exception {
+		Path file = Files.createFile(tempDir.resolve("testSaveExternalFile.lspt"));
+		IEditorPart editor = IDE.openEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri()));
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editor);
 
 		// make sure that timestamp after save will differ from creation time (no better idea at the moment)
@@ -87,7 +89,7 @@ public class DocumentDidSaveTest extends AbstractTestWithProject {
 		waitForAndAssertCondition(2_000, () -> {
 			DidSaveTextDocumentParams lastChange = didSaveExpectation.get(10, TimeUnit.MILLISECONDS);
 			assertNotNull(lastChange.getTextDocument());
-			assertEquals(LSPEclipseUtils.toUri(file).toString(), lastChange.getTextDocument().getUri());
+			assertEquals(LSPEclipseUtils.toUri(file.toFile()).toString(), lastChange.getTextDocument().getUri());
 			return true;
 		});
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
@@ -17,8 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +53,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("restriction")
 public class HoverTest extends AbstractTestWithProject {
@@ -136,14 +138,14 @@ public class HoverTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testHoverOnExternalFile() throws Exception {
+	public void testHoverOnExternalFile(@TempDir Path tempDir) throws Exception {
 		final var hoverResponse = new Hover(List.of(Either.forLeft("blah")),
 				new Range(new Position(0, 0), new Position(0, 0)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);
 
-		File file = TestUtils.createTempFile("testHoverOnExternalfile", ".lspt");
+		Path file = Files.createFile(tempDir.resolve("testHoverOnExternalfile.lspt"));
 		ITextViewer viewer = LSPEclipseUtils
-				.getTextViewer(IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toURI())));
+				.getTextViewer(IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri())));
 		String html = hover.getHoverInfoFuture(viewer, new Region(0, 0)).get(2, TimeUnit.SECONDS);
 		assertTrue(html != null && html.contains("blah"));
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineContentTest.java
@@ -12,8 +12,9 @@ import static org.eclipse.lsp4e.test.utils.TestUtils.waitForAndAssertCondition;
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForCondition;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
@@ -45,16 +46,13 @@ import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class OutlineContentTest extends AbstractTestWithProject {
 
 	@Test
-	public void testExternalFile() throws CoreException, IOException {
-		var testFile = TestUtils.createTempFile("test" + System.currentTimeMillis(), ".lspt");
-
-		try (FileWriter fileWriter =  new FileWriter(testFile)) {
-			fileWriter.write("content\n does\n not\n matter\n but needs to cover the ranges described below");
-		}
+	public void testExternalFile(@TempDir Path tempDir) throws CoreException, IOException {
+		var testFile = Files.writeString(tempDir.resolve("test.lspt"), "content\n does\n not\n matter\n but needs to cover the ranges described below");
 
 		final var symbolCow = new DocumentSymbol("cow", SymbolKind.Constant,
 				new Range(new Position(0, 0), new Position(0, 2)),
@@ -62,7 +60,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 
 		MockLanguageServer.INSTANCE.setDocumentSymbols(symbolCow);
 
-		final var editor = (ITextEditor) TestUtils.openExternalFileInEditor(testFile);
+		final var editor = (ITextEditor) TestUtils.openExternalFileInEditor(testFile.toFile());
 
 		final var outlinePage = (CNFOutlinePage) new EditorToOutlineAdapterFactory().getAdapter(editor, IContentOutlinePage.class);
 		final var shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());
@@ -83,12 +81,8 @@ public class OutlineContentTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testExternalFileOpenedOnFileStore() throws CoreException, IOException {
-		var testFile = TestUtils.createTempFile("test" + System.currentTimeMillis(), ".lspt");
-
-		try (FileWriter fileWriter =  new FileWriter(testFile)) {
-			fileWriter.write("content\n does\n not\n matter\n but needs to cover the ranges described below");
-		}
+	public void testExternalFileOpenedOnFileStore(@TempDir Path tempDir) throws CoreException, IOException {
+		var testFile = Files.writeString(tempDir.resolve("test.lspt"), "content\n does\n not\n matter\n but needs to cover the ranges described below");
 
 		final var symbolCow = new DocumentSymbol("cow", SymbolKind.Constant,
 				new Range(new Position(0, 0), new Position(0, 2)),
@@ -96,7 +90,7 @@ public class OutlineContentTest extends AbstractTestWithProject {
 
 		MockLanguageServer.INSTANCE.setDocumentSymbols(symbolCow);
 
-		final var editor = (ITextEditor) TestUtils.openExternalFileOnFileStore(testFile);
+		final var editor = (ITextEditor) TestUtils.openExternalFileOnFileStore(testFile.toFile());
 
 		final var outlinePage = (CNFOutlinePage) new EditorToOutlineAdapterFactory().getAdapter(editor, IContentOutlinePage.class);
 		final var shell = new Shell(editor.getEditorSite().getWorkbenchWindow().getShell());

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineViewerInputTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/OutlineViewerInputTest.java
@@ -14,9 +14,10 @@ package org.eclipse.lsp4e.test.outline;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.lsp4e.LSPEclipseUtils;
@@ -26,6 +27,7 @@ import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests to verify that documentURI always contains absolute paths in the file system.
@@ -55,15 +57,12 @@ public class OutlineViewerInputTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testDocumentURIAbsolutePathForExternalFile() throws IOException, CoreException {
+	public void testDocumentURIAbsolutePathForExternalFile(@TempDir Path tempDir) throws IOException, CoreException {
 		// Create a temporary file outside the workspace
-		var tempFile = TestUtils.createTempFile("externalTest" + System.currentTimeMillis(), ".lspt");
-		
-		try (var fileWriter = new FileWriter(tempFile)) {
-			fileWriter.write("external file content for testing absolute paths");
-		}
+		var tempFile = Files.writeString(tempDir.resolve("externalTest.lspt"), "external file content for testing absolute paths");
+
 		// Open the external file in an editor
-		var editor = (ITextEditor) TestUtils.openExternalFileInEditor(tempFile);
+		var editor = (ITextEditor) TestUtils.openExternalFileInEditor(tempFile.toFile());
 		var document = LSPEclipseUtils.getDocument(editor);
 
 		// Create OutlineViewerInput and verify documentURI
@@ -78,7 +77,7 @@ public class OutlineViewerInputTest extends AbstractTestWithProject {
 			
 		// Verify it points to the same file we created
 		// replace '\' with '/' on Windows and remove leading '/' from documentURI path on Windows:
-		assertTrue(documentURI.toString().contains(tempFile.getAbsolutePath().replace("\\","/")),
+		assertTrue(documentURI.toString().contains(tempFile.toFile().getAbsolutePath().replace("\\","/")),
 				"documentURI should contain the abolute path in the file system");
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/rename/LSPTextChangeTest.java
@@ -14,8 +14,8 @@ package org.eclipse.lsp4e.test.rename;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -29,6 +29,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class LSPTextChangeTest extends AbstractTestWithProject {
 
@@ -53,12 +54,11 @@ public class LSPTextChangeTest extends AbstractTestWithProject {
 	}
 
 	@Test
-	public void testPerformOperationExternalFile() throws Exception {
-		File file = TestUtils.createTempFile("testPerformOperationExternalFile", ".lspt");
-		Files.write(file.toPath(), "old".getBytes());
+	public void testPerformOperationExternalFile(@TempDir Path tempDir) throws Exception {
+		Path file = Files.writeString(tempDir.resolve("testPerformOperationExternalFile.lspt"), "old");
 		final var edit = new TextEdit(new Range(new Position(0, 0), new Position(0, 3)), "new");
-		final var operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file), edit));
+		final var operation = new PerformChangeOperation(new LSPTextChange("test", LSPEclipseUtils.toUri(file.toFile()), edit));
 		operation.run(new NullProgressMonitor());
-		assertEquals(edit.getNewText(), new String(Files.readAllBytes(file.toPath())));
+		assertEquals(edit.getNewText(), Files.readString(file));
 	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AllCleanExtension.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AllCleanExtension.java
@@ -71,7 +71,6 @@ public class AllCleanExtension implements BeforeEachCallback, AfterEachCallback 
 		LanguageServiceAccessor.clearStartedServers();
 		MockLanguageServer.reset(this.serverConfigurer);
 		MockConnectionProvider.cancellations.clear();
-		TestUtils.tearDown();
 	}
 
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -66,8 +65,6 @@ public class TestUtils {
 	public interface Condition {
 		boolean isMet() throws Exception;
 	}
-
-	private static final Set<File> tempFiles = new HashSet<>();
 
 	private TestUtils() {
 		// this class shouldn't be instantiated
@@ -247,29 +244,6 @@ public class TestUtils {
 
 	public static void delete(Path... paths) throws IOException {
 		ArrayUtil.forEach(paths, TestUtils::delete);
-	}
-
-	public static File createTempFile(String prefix, String suffix) throws IOException {
-		File tmp = File.createTempFile(prefix, suffix);
-		tempFiles.add(tmp);
-		return tmp;
-	}
-
-	public static void addManagedTempFile(File file) {
-		tempFiles.add(file);
-	}
-
-	public static void tearDown() {
-		tempFiles.forEach(file -> {
-			try {
-				Files.deleteIfExists(file.toPath());
-			} catch (IOException e) {
-				// Trying to have the tests run quieter but I suppose if there's an actual
-				// problem we'd better find out about it
-				e.printStackTrace();
-			}
-		});
-		tempFiles.clear();
 	}
 
 	public static ContentTypeToLanguageServerDefinition getDisabledLS() {


### PR DESCRIPTION
- Use JUnit Standard annotation `@TempDir` to replace utility methods which create tempFiles
- Use java.nio.Path and related API to read/write/create temp Files