### PR TITLE
fix: Cancel computation when Thread has been interrupted

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
@@ -181,10 +181,11 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 			this.errorMessage = createErrorMessage(offset, e);
 			return createErrorProposal(offset, e);
 		} catch (InterruptedException e) {
-			LanguageServerPlugin.logError(e);
-			this.errorMessage = createErrorMessage(offset, e);
-			Thread.currentThread().interrupt();
-			return createErrorProposal(offset, e);
+			// The current thread has been interrupted by the AsyncCompletionProposalPopup#cancelFutures to
+			// indicate that we can stop computing results, because they won't be used anymore.
+			// Forward cancellation to LS and return dummy result
+			completionCancellationSupport.cancel();
+			return NO_COMPLETION_PROPOSALS;
 		} catch (CancellationException e) {
 			// return the elements already collected, if any
 		}


### PR DESCRIPTION
This is similar to #1486, but here our Thread is informed directly via `org.eclipse.jface.text.contentassist.AsyncCompletionProposalPopup.cancelFutures()`, which interrupts all running completion computations.

We spotted this rare problem within our application and noticed the following Error being logged:
```
ERROR 2026-01-28 08:50:18.708 [org.eclipse.jface.text-worker-1] org.eclipse.equinox.logger - InterruptedException
java.lang.InterruptedException: null
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:386)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
	at org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor.computeCompletionProposals(LSContentAssistProcessor.java:177)
	at org.eclipse.jface.text.contentassist.AsyncCompletionProposalPopup.lambda$10(AsyncCompletionProposalPopup.java:385)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.jface.text.contentassist.AsyncCompletionProposalPopup.lambda$9(AsyncCompletionProposalPopup.java:384)
	at org.eclipse.jface.text.contentassist.AsyncCompletionProposalPopup.lambda$11(AsyncCompletionProposalPopup.java:419)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```