### PR TITLE
refactor: Get rid of some deprecated APIs

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
 Bundle-Vendor: Eclipse LSP4E
-Bundle-Version: 0.16.3.qualifier
+Bundle-Version: 0.17.0.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/DSPImages.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/DSPImages.java
@@ -13,74 +13,58 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.debug;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
+import org.osgi.framework.Bundle;
 
 public final class DSPImages {
 	private DSPImages() {
 		// private constructor to avoid instances, requested by sonar
 	}
 
-	private static final String NAME_PREFIX = DSPPlugin.PLUGIN_ID + '.';
-	private static final int NAME_PREFIX_LENGTH = NAME_PREFIX.length();
+	private static @Nullable ImageRegistry imageRegistry;
+	private static final String ICONS_PATH = "$nl$/icons/"; //$NON-NLS-1$
+	private static final String VIEWS = ICONS_PATH + "view16/";
 
-	// The plugin registry
-	private static ImageRegistry imageRegistry = new ImageRegistry();
+	public static final String IMG_VIEW_DEBUGGER_TAB = "IMG_DEBUGGER_TAB"; //$NON-NLS-1$
 
-	// Subdirectory (under the package containing this class) where 16 color images
-	// are
-	private static URL fgIconBaseURL;
-	static {
-		fgIconBaseURL = Platform.getBundle(DSPPlugin.PLUGIN_ID).getEntry("/icons/"); //$NON-NLS-1$
+	public static void initialize(ImageRegistry registry) {
+		imageRegistry = registry;
+		declareRegistryImage(IMG_VIEW_DEBUGGER_TAB, VIEWS + "debugger_tab.svg");
 	}
 
-	private static final String T_TABS = "view16/"; //$NON-NLS-1$
-	@SuppressWarnings("unused") // none yet, leave for the future
-	private static final String T_OBJS = "obj16/"; //$NON-NLS-1$
-
-	public static final String IMG_VIEW_DEBUGGER_TAB = NAME_PREFIX + "debugger_tab.svg"; //$NON-NLS-1$
-
-	public static final ImageDescriptor DESC_TAB_DEBUGGER = createManaged(T_TABS, IMG_VIEW_DEBUGGER_TAB);
-
-	public static void initialize() {
-	}
-
-	private static ImageDescriptor createManaged(String prefix, String name) {
-		return createManaged(imageRegistry, prefix, name);
-	}
-
-	private static ImageDescriptor createManaged(ImageRegistry registry, String prefix, String name) {
-		ImageDescriptor result = ImageDescriptor
-				.createFromURL(makeIconFileURL(prefix, name.substring(NAME_PREFIX_LENGTH)));
-		registry.put(name, result);
-		return result;
+	private static void declareRegistryImage(String key, String path) {
+		ImageDescriptor desc = ImageDescriptor.getMissingImageDescriptor();
+		Bundle bundle = Platform.getBundle(DSPPlugin.PLUGIN_ID);
+		URL url = null;
+		if (bundle != null) {
+			url = FileLocator.find(bundle, new Path(path), null);
+			if (url != null) {
+				desc = ImageDescriptor.createFromURL(url);
+			}
+		}
+		getImageRegistry().put(key, desc);
 	}
 
 	public static @Nullable Image get(String key) {
-		return imageRegistry.get(key);
-	}
-
-	private static @Nullable URL makeIconFileURL(String prefix, String name) {
-		final var buffer = new StringBuilder(prefix);
-		buffer.append(name);
-		try {
-			return new URL(fgIconBaseURL, buffer.toString());
-		} catch (MalformedURLException e) {
-			DSPPlugin.logError(e);
-			return null;
-		}
+		return getImageRegistry().get(key);
 	}
 
 	/**
 	 * Helper method to access the image registry from the JavaPlugin class.
 	 */
 	static ImageRegistry getImageRegistry() {
+		ImageRegistry imageRegistry = DSPImages.imageRegistry;
+		if (imageRegistry == null) {
+			imageRegistry = DSPImages.imageRegistry = DSPPlugin.getDefault().getImageRegistry();
+		}
 		return imageRegistry;
 	}
 }

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/DSPPlugin.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/DSPPlugin.java
@@ -13,6 +13,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -133,6 +134,11 @@ public class DSPPlugin extends AbstractUIPlugin {
 			}
 		}
 		getDefault().getLog().log(new Status(severity, PLUGIN_ID, 0, message, thr));
+	}
+
+	@Override
+	protected void initializeImageRegistry(ImageRegistry registry) {
+		DSPImages.initialize(registry);
 	}
 
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -32,7 +32,6 @@ import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -813,7 +812,7 @@ public final class LSPEclipseUtils {
 	protected static void openHttpLocationInBrowser(final String uri, IWorkbenchPage page) {
 		page.getWorkbenchWindow().getShell().getDisplay().asyncExec(() -> {
 			try {
-				final var url = new URL(uri);
+				final var parsed = new URI(uri);
 
 				IWorkbenchBrowserSupport browserSupport = page.getWorkbenchWindow().getWorkbench()
 						.getBrowserSupport();
@@ -826,8 +825,7 @@ public final class LSPEclipseUtils {
 				browserSupport
 						.createBrowser(IWorkbenchBrowserSupport.AS_EDITOR | IWorkbenchBrowserSupport.LOCATION_BAR
 								| IWorkbenchBrowserSupport.NAVIGATION_BAR, "lsp4e-symbols", browserName, uri) //$NON-NLS-1$
-						.openURL(url);
-
+						.openURL(parsed.toURL());
 			} catch (Exception e) {
 				LanguageServerPlugin.logError(e);
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
@@ -89,7 +89,7 @@ public class CNFOutlinePage implements IContentOutlinePage, ILabelProviderListen
 		if (document != null) {
 			outlineViewer.setInput(new OutlineViewerInput(document, wrapper, textEditor));
 		}
-		outlineViewer.setSorter(new CommonViewerSorter());
+		outlineViewer.setComparator(new CommonViewerSorter());
 		outlineViewer.getLabelProvider().addListener(this);
 		final var textEditor = this.textEditor;
 		if (textEditor != null) {


### PR DESCRIPTION
+ Use `setComparator` instead of `setSorter`
+ Don't use deprecated URL constructor when opening a Browser
+ Refactor `DSPImages` to be more similar to `LSPImages`, to get rid of URL constructor usage
+ Bump minor version of Debug Plugin due to removed constants from DSPImages