### PR TITLE
Work-around for #1494: Custom default for in-line renaming preference

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.9.qualifier
+Bundle-Version: 0.19.10.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -145,6 +145,9 @@
       <initializer
             class="org.eclipse.lsp4e.operations.linkedediting.LSPLinkedEditingBase$PreferenceInitializer">
       </initializer>
+      <initializer
+            class="org.eclipse.lsp4e.operations.rename.LSPInlineRenameLinkedMode$PreferenceInitializer">
+      </initializer>
    </extension>
 
    <extension point="org.eclipse.ui.genericeditor.foldingReconcilers">

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.9-SNAPSHOT</version>
+	<version>0.19.10-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPInlineRenameLinkedMode.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPInlineRenameLinkedMode.java
@@ -27,7 +27,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -71,6 +71,15 @@ import org.eclipse.ui.texteditor.link.EditorLinkedModeUI;
 public final class LSPInlineRenameLinkedMode {
 
 	private static final String INLINE_RENAME_PREFERENCE = "org.eclipse.lsp4e.inlineRename"; //$NON-NLS-1$
+	private static final boolean INLINE_RENAME_ACTIVE_DEFAULT = true;
+
+	public static final class PreferenceInitializer extends AbstractPreferenceInitializer {
+		@Override
+		public void initializeDefaultPreferences() {
+			final var store = LanguageServerPlugin.getDefault().getPreferenceStore();
+			store.setDefault(INLINE_RENAME_PREFERENCE, INLINE_RENAME_ACTIVE_DEFAULT);
+		}
+	}
 
 	static boolean start(final IDocument document, final ITextViewer viewer, final int offset, final Shell shell) {
 		if (!isInlineRenameEnabled()) {
@@ -121,8 +130,7 @@ public final class LSPInlineRenameLinkedMode {
 	}
 
 	private static boolean isInlineRenameEnabled() {
-		final var prefs = InstanceScope.INSTANCE.getNode(LanguageServerPlugin.PLUGIN_ID);
-		return prefs.getBoolean(INLINE_RENAME_PREFERENCE, true);
+		return LanguageServerPlugin.getDefault().getPreferenceStore().getBoolean(INLINE_RENAME_PREFERENCE);
 	}
 
 	private static @Nullable RefactoringStatus runPrepareRename(final LSPRenameProcessor processor) {


### PR DESCRIPTION
- Allows for customizing the default preference value with a plugin_customization.ini
- This way, we can provide a work-around for #1494, i.e. switch the inline renaming feature off (`false`) for us as long as the feature doesn't work for us. The default value stays `true` (active) for all other users.

See comment https://github.com/eclipse-lsp4e/lsp4e/issues/1494#issuecomment-3892087443

*Details*

Customization (here switching the setting off) can be done with a `plugin_customization.ini` with the following content and by starting Eclipse with a program argument like ` -pluginCustomization ${workspace_loc:/path-to/plugin_customization.ini}`.

**plugin_customization.ini**:
```
org.eclipse.lsp4e/org.eclipse.lsp4e.inlineRename=false
```

This is a follow-up to PR #1511. In PR #1511, by mistake, I made another preference customizable, i.e. `org.eclipse.ui.genericeditor.linkedediting`, but to switch off in-line renaming as a work-around for issue #1494 we have to customize the default for `org.eclipse.lsp4e.inlineRename` instead.