### PR TITLE
Make overlay icons in various views like the outline view customizable in client plug-ins

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.16.9.qualifier
+Bundle-Version: 0.16.10.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.16.9-SNAPSHOT</version>
+	<version>0.16.10-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/LSPImagesTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/LSPImagesTest.java
@@ -28,21 +28,21 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 public class LSPImagesTest {
-	
+
 	@ParameterizedTest
 	@EnumSource(SymbolKind.class)
 	public void testAllImagesForSymbolKindAvailable(SymbolKind kind) {
 		Image img = LSPImages.imageFromSymbolKind(kind);
-		
+
 		assertNotNull(img);
 	}
-	
+
 	@ParameterizedTest
 	@EnumSource(SymbolTag.class)
 	public void testAllOverlayImagesForSymbolTagAvailable(SymbolTag tag) {
 		ImageDescriptor descriptor = LSPImages.imageDescriptorOverlayFromSymbolTag(tag);
 		Image img = LSPImages.imageOverlayFromSymbolTag(tag);
-		
+
 		assertNotNull(descriptor);
 		assertNotNull(img);
 	}
@@ -54,22 +54,23 @@ public class LSPImagesTest {
 	public void testVisibilityOverlayImagesForFieldsAndMethodsAvailable(SymbolTag tag) {
 		var symbolTags = List.of(tag);
 		SymbolIconProvider labelProvider = new SymbolIconProvider();
-		
-		Image fieldImage = labelProvider.getImageFor(SymbolKind.Field, symbolTags);
-		Image methodImage = labelProvider.getImageFor(SymbolKind.Method, symbolTags);
-		
+
+		// we do not need a symbol for this test, so the last argument is null
+		Image fieldImage = labelProvider.getImageFor(SymbolKind.Field, symbolTags, null);
+		Image methodImage = labelProvider.getImageFor(SymbolKind.Method, symbolTags, null);
+
 		assertNotNull(fieldImage);
 		assertNotNull(methodImage);
 	}
-	
+
 	@ParameterizedTest
 	@EnumSource(value=CompletionItemKind.class, mode=Mode.EXCLUDE, names= { "Color", "Event", "Operator" })
 	public void testAllImagesForCompletionItemKindAvailable(CompletionItemKind kind) {
 		CompletionItem item = new CompletionItem();
 		item.setKind(kind);
-		
+
 		Image img = LSPImages.imageFromCompletionItem(item);
-		
+
 		assertNotNull(img);
 	}
 

--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -2,6 +2,7 @@
 <?eclipse version="3.4"?>
 <plugin>
    <extension-point id="languageServer" name="Language Server" schema="schema/languageServer.exsd" />
+   <extension-point id="symbolIconsProvider" name="Symbol Icons Provider" schema="schema/symbolIconsProvider.exsd"/>
 
    <!-- ===================================== -->
    <!-- Setup Text Doc To LS Connection       -->

--- a/org.eclipse.lsp4e/schema/symbolIconsProvider.exsd
+++ b/org.eclipse.lsp4e/schema/symbolIconsProvider.exsd
@@ -98,23 +98,7 @@ This extension point offers client plug-ins options to adapt placement and selec
       </documentation>
    </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="examples"/>
-      </appinfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appinfo>
-         <meta.section type="apiinfo"/>
-      </appinfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
    <annotation>
       <appinfo>

--- a/org.eclipse.lsp4e/schema/symbolIconsProvider.exsd
+++ b/org.eclipse.lsp4e/schema/symbolIconsProvider.exsd
@@ -23,7 +23,9 @@
          <attribute name="point" type="string" use="required">
             <annotation>
                <documentation>
-                  
+                  The fully qualified identifier of the extension point.
+
+This extension point offers client plug-ins options to adapt placement and selection of overlay icons for document symbols and other related elements.
                </documentation>
             </annotation>
          </attribute>
@@ -62,7 +64,7 @@
          <attribute name="class" type="string" use="required">
             <annotation>
                <documentation>
-                  
+                  The fully qualified name of the class implementing this symbol icon provider. The class must extend &lt;code&gt;org.eclipse.lsp4e.ui.SymbolIconProvider&lt;/code&gt;. Clients can override individual methods to customize overlay icons and their placement (top-left, top-right, bottom-left, bottom-right, underlay).
                </documentation>
                <appinfo>
                   <meta.attribute kind="java" basedOn="org.eclipse.lsp4e.ui.SymbolIconProvider:"/>
@@ -77,7 +79,7 @@
          <attribute name="contentTypeId" type="string" use="required">
             <annotation>
                <documentation>
-                  
+                  The unique identifier of a content type (as registered with the &lt;code&gt;org.eclipse.core.contenttype.contentTypes&lt;/code&gt; extension point) for which this icon provider should be used. The provider is also used for all derived content types that do not have a more specific provider registered.
                </documentation>
                <appinfo>
                   <meta.attribute kind="identifier" basedOn="org.eclipse.core.contenttype.contentTypes/content-type/@id"/>
@@ -92,7 +94,7 @@
          <meta.section type="since"/>
       </appinfo>
       <documentation>
-         [Enter the first release in which this extension point appears.]
+         0.19.10
       </documentation>
    </annotation>
 
@@ -119,7 +121,7 @@
          <meta.section type="implementation"/>
       </appinfo>
       <documentation>
-         [Enter information about supplied implementation of this extension point.]
+         LSP4E provides a default implementation via &lt;code&gt;org.eclipse.lsp4e.ui.SymbolIconProvider&lt;/code&gt;. It is used automatically for all content types that have no specific provider registered through this extension point. It renders symbol icons based on the LSP &lt;code&gt;SymbolKind&lt;/code&gt; and up to four overlay icons derived from &lt;code&gt;SymbolTag&lt;/code&gt;s (visibility, static/final/abstract/etc., marker severity) plus a deprecation underlay.
       </documentation>
    </annotation>
 

--- a/org.eclipse.lsp4e/schema/symbolIconsProvider.exsd
+++ b/org.eclipse.lsp4e/schema/symbolIconsProvider.exsd
@@ -1,0 +1,140 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.lsp4e" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appinfo>
+         <meta.schema plugin="org.eclipse.lsp4e" id="symbolIconsProvider" name="Symbol Icons Provider"/>
+      </appinfo>
+      <documentation>
+         This extension point allows for customizing the (document) symbol icons with their overlays, their placing and filtering for certain language servers. This way, clients can use other images, adapt overlay icon placing and decide wich symbol details to show or hide in the outline view, call hierarchy, or type hierarchy.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="iconProvider"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute translatable="true"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="iconProvider">
+      <complexType>
+         <sequence minOccurs="1" maxOccurs="unbounded">
+            <element ref="contentType"/>
+         </sequence>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  A string uniquely identifying this symbol icon provider extension.
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="java" basedOn="org.eclipse.lsp4e.ui.SymbolIconProvider:"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="contentType">
+      <complexType>
+         <attribute name="contentTypeId" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appinfo>
+                  <meta.attribute kind="identifier" basedOn="org.eclipse.core.contenttype.contentTypes/content-type/@id"/>
+               </appinfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="since"/>
+      </appinfo>
+      <documentation>
+         [Enter the first release in which this extension point appears.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         [Enter extension point usage example here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="apiinfo"/>
+      </appinfo>
+      <documentation>
+         [Enter API information here.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="implementation"/>
+      </appinfo>
+      <documentation>
+         [Enter information about supplied implementation of this extension point.]
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appinfo>
+         <meta.section type="copyright"/>
+      </appinfo>
+      <documentation>
+         Copyright (c) 2024 Advantest GmbH and others.
+This program and the accompanying materials are made
+available under the terms of the Eclipse Public License 2.0
+which is available at https://www.eclipse.org/legal/epl-2.0/
+
+SPDX-License-Identifier: EPL-2.0
+      </documentation>
+   </annotation>
+
+</schema>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.charset.StandardCharsets.*;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -89,6 +89,16 @@ public class LanguageServerPlugin extends AbstractUIPlugin {
 	@Override
 	protected void initializeImageRegistry(ImageRegistry registry) {
 		LSPImages.initalize(registry);
+	}
+
+	/**
+	 * Utility method to log errors.
+	 *
+	 * @param message
+	 *            User comprehensible message
+	 */
+	public static void logError(final String message) {
+		logError(message, null);
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyLabelProvider.java
@@ -39,7 +39,7 @@ public class CallHierarchyLabelProvider extends LabelProvider implements IStyled
 	public @Nullable Image getImage(final @Nullable Object element) {
 		if (element instanceof CallHierarchyViewTreeNode treeNode) {
 			CallHierarchyItem callContainer = treeNode.getCallContainer();
-			Image res = symbolIconProvider.getImageFor(callContainer.getKind(), callContainer.getTags());
+			Image res = symbolIconProvider.getImageFor(callContainer.getKind(), callContainer.getTags(), element);
 			if (res != null) {
 				return res;
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/callhierarchy/CallHierarchyLabelProvider.java
@@ -16,6 +16,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider.IStyledLabelProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.lsp4e.operations.symbols.internal.SymbolIconProviderRegistry;
 import org.eclipse.lsp4e.ui.SymbolIconProvider;
 import org.eclipse.lsp4j.CallHierarchyItem;
 import org.eclipse.swt.graphics.Image;
@@ -25,21 +26,12 @@ import org.eclipse.swt.graphics.Image;
  */
 public class CallHierarchyLabelProvider extends LabelProvider implements IStyledLabelProvider {
 
-	private final SymbolIconProvider symbolIconProvider;
-
-	public CallHierarchyLabelProvider() {
-		this(new SymbolIconProvider());
-	}
-
-	public CallHierarchyLabelProvider(SymbolIconProvider symbolIconProvider) {
-		this.symbolIconProvider = symbolIconProvider;
-	}
-
 	@Override
 	public @Nullable Image getImage(final @Nullable Object element) {
 		if (element instanceof CallHierarchyViewTreeNode treeNode) {
 			CallHierarchyItem callContainer = treeNode.getCallContainer();
-			Image res = symbolIconProvider.getImageFor(callContainer.getKind(), callContainer.getTags(), element);
+			SymbolIconProvider symbolIconProvider = SymbolIconProviderRegistry.getSymbolIconProviderFor(callContainer);
+			Image res = symbolIconProvider.getImageFor(callContainer.getKind(), callContainer.getTags(), callContainer);
 			if (res != null) {
 				return res;
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
@@ -99,7 +99,7 @@ public class SymbolIconProviderRegistry {
 	private SymbolIconProvider getIconProvider(Object symbol) {
 		URI uri = getUri(symbol);
 		if (uri == null) {
-			return null;
+			return defaultIconProvider;
 		}
 
 		String fileName = null;
@@ -107,7 +107,7 @@ public class SymbolIconProviderRegistry {
 			fileName = Path.of(uri.getPath()).getFileName().toString();
 		} catch (Exception e) {
 			Platform.getLog(getClass()).warn("Failed to parse file name from URI " + uri, e); //$NON-NLS-1$
-			return null;
+			return defaultIconProvider;
 		}
 
 		IContentType[] contentTypes = Platform.getContentTypeManager().findContentTypesFor(fileName);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
@@ -130,17 +130,14 @@ public class SymbolIconProviderRegistry {
 	}
 
 	private @Nullable URI getUri(Object symbol) {
-		if (symbol instanceof SymbolInformation info)
-			return toUri(info.getLocation().getUri());
-		if (symbol instanceof WorkspaceSymbol ws)
-			return toUri(ws.getLocation().map(Location::getUri, WorkspaceSymbolLocation::getUri));
-		if (symbol instanceof DocumentSymbolWithURI s)
-			return s.uri;
-		if (symbol instanceof TypeHierarchyItem item) // for subclasses handling TH
-			return toUri(item.getUri());
-		if (symbol instanceof CallHierarchyItem item) // for subclasses handling CH
-			return toUri(item.getUri());
-		return null; // plain DocumentSymbol — no URI
+		return switch (symbol) {
+			case SymbolInformation info -> toUri(info.getLocation().getUri());
+			case WorkspaceSymbol ws -> toUri(ws.getLocation().map(Location::getUri, WorkspaceSymbolLocation::getUri));
+			case DocumentSymbolWithURI s -> s.uri;
+			case TypeHierarchyItem item -> toUri(item.getUri());
+			case CallHierarchyItem item -> toUri(item.getUri());
+			default -> null; // plain DocumentSymbol — no URI
+		};
 	}
 
 	private @Nullable URI toUri(String uri) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Advantest GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Dietrich Travkin (Solunar GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.operations.symbols.internal;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.content.IContentType;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
+import org.eclipse.lsp4e.ui.SymbolIconProvider;
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.TypeHierarchyItem;
+import org.eclipse.lsp4j.WorkspaceSymbol;
+import org.eclipse.lsp4j.WorkspaceSymbolLocation;
+
+public class SymbolIconProviderRegistry {
+
+	private static final String EXTENSION_POINT_ID = LanguageServerPlugin.PLUGIN_ID + ".symbolIconsProvider"; //$NON-NLS-1$
+
+	private static SymbolIconProviderRegistry INSTANCE = null;
+
+	// default icon provider from LSP4E
+	private final SymbolIconProvider defaultIconProvider = new SymbolIconProvider();
+
+	// symbol icon providers from extensions, cached per content type ID
+	private final Map<String, SymbolIconProvider> cachedIconProviders = new HashMap<>();
+
+	private SymbolIconProviderRegistry() {
+		loadExtensions();
+	}
+
+	private static SymbolIconProviderRegistry get() {
+		if (INSTANCE == null) {
+			INSTANCE = new SymbolIconProviderRegistry();
+		}
+		return INSTANCE;
+	}
+
+	private void loadExtensions() {
+		IExtensionPoint extensionPoint = Platform.getExtensionRegistry().getExtensionPoint(EXTENSION_POINT_ID);
+
+		if (extensionPoint == null) {
+			Platform.getLog(getClass()).error("No extension point found for ID " + EXTENSION_POINT_ID); //$NON-NLS-1$
+			return;
+		}
+
+		for (IConfigurationElement configurationElement : extensionPoint.getConfigurationElements()) {
+			if ("iconProvider".equals(configurationElement.getName())) { //$NON-NLS-1$
+				String className = configurationElement.getAttribute("class"); //$NON-NLS-1$
+
+				if (className == null || className.isBlank()) {
+					continue;
+				}
+
+				SymbolIconProvider iconProvider;
+				try {
+					iconProvider = (SymbolIconProvider) configurationElement.createExecutableExtension("class"); //$NON-NLS-1$
+				} catch (CoreException | ClassCastException e) {
+					Platform.getLog(getClass()).error("Failed instantiating class " + className, e); //$NON-NLS-1$
+					continue;
+				}
+
+				for ( IConfigurationElement contentTypeConfigElement : configurationElement.getChildren("contentType")) { //$NON-NLS-1$
+					String contentTypeId = contentTypeConfigElement.getAttribute("contentTypeId"); //$NON-NLS-1$
+
+					if (contentTypeId == null || contentTypeId.isBlank()) {
+						continue;
+					}
+
+					cachedIconProviders.put(contentTypeId, iconProvider);
+				}
+			}
+		}
+	}
+
+	public static SymbolIconProvider getSymbolIconProviderFor(Object symbol) {
+		return get().getIconProvider(symbol);
+	}
+
+	private SymbolIconProvider getIconProvider(Object symbol) {
+		URI uri = getUri(symbol);
+		if (uri == null) {
+			return null;
+		}
+
+		String fileName = null;
+		try {
+			fileName = Path.of(uri.getPath()).getFileName().toString();
+		} catch (Exception e) {
+			Platform.getLog(getClass()).warn("Failed to parse file name from URI " + uri, e); //$NON-NLS-1$
+			return null;
+		}
+
+		IContentType[] contentTypes = Platform.getContentTypeManager().findContentTypesFor(fileName);
+		for (IContentType contentType : contentTypes) {
+			IContentType candidate = contentType;
+			while (candidate != null) {
+				SymbolIconProvider iconProvider = cachedIconProviders.get(candidate.getId());
+				if (iconProvider != null) {
+					return iconProvider;
+				}
+				candidate = candidate.getBaseType();
+			}
+		}
+
+		return defaultIconProvider;
+	}
+
+	private @Nullable URI getUri(Object symbol) {
+		if (symbol instanceof SymbolInformation info)
+			return toUri(info.getLocation().getUri());
+		if (symbol instanceof WorkspaceSymbol ws)
+			return toUri(ws.getLocation().map(Location::getUri, WorkspaceSymbolLocation::getUri));
+		if (symbol instanceof DocumentSymbolWithURI s)
+			return s.uri;
+		if (symbol instanceof TypeHierarchyItem item) // for subclasses handling TH
+			return toUri(item.getUri());
+		if (symbol instanceof CallHierarchyItem item) // for subclasses handling CH
+			return toUri(item.getUri());
+		return null; // plain DocumentSymbol — no URI
+	}
+
+	private @Nullable URI toUri(String uri) {
+		if (uri == null) {
+			return null;
+		}
+
+		try {
+			return URI.create(uri);
+		} catch (IllegalArgumentException e) {
+			Platform.getLog(getClass()).warn("Failed to parse URI " + uri, e); //$NON-NLS-1$
+			return null;
+		}
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
@@ -36,8 +36,6 @@ public class SymbolIconProviderRegistry {
 
 	private static final String EXTENSION_POINT_ID = LanguageServerPlugin.PLUGIN_ID + ".symbolIconsProvider"; //$NON-NLS-1$
 
-	private static SymbolIconProviderRegistry INSTANCE = null;
-
 	// default icon provider from LSP4E
 	private final SymbolIconProvider defaultIconProvider = new SymbolIconProvider();
 
@@ -48,11 +46,17 @@ public class SymbolIconProviderRegistry {
 		loadExtensions();
 	}
 
+	/**
+	 * Initialization-on-demand holder: the JVM guarantees that this nested class
+	 * is loaded and initialized exactly once, in a thread-safe manner, the first
+	 * time {@link #get()} is called.
+	 */
+	private static final class Holder {
+		static final SymbolIconProviderRegistry INSTANCE = new SymbolIconProviderRegistry();
+	}
+
 	private static SymbolIconProviderRegistry get() {
-		if (INSTANCE == null) {
-			INSTANCE = new SymbolIconProviderRegistry();
-		}
-		return INSTANCE;
+		return Holder.INSTANCE;
 	}
 
 	private void loadExtensions() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
@@ -63,7 +63,7 @@ public class SymbolIconProviderRegistry {
 		IExtensionPoint extensionPoint = Platform.getExtensionRegistry().getExtensionPoint(EXTENSION_POINT_ID);
 
 		if (extensionPoint == null) {
-			Platform.getLog(getClass()).error("No extension point found for ID " + EXTENSION_POINT_ID); //$NON-NLS-1$
+			LanguageServerPlugin.logError("No extension point found for ID " + EXTENSION_POINT_ID); //$NON-NLS-1$
 			return;
 		}
 
@@ -79,7 +79,7 @@ public class SymbolIconProviderRegistry {
 				try {
 					iconProvider = (SymbolIconProvider) configurationElement.createExecutableExtension("class"); //$NON-NLS-1$
 				} catch (CoreException | ClassCastException e) {
-					Platform.getLog(getClass()).error("Failed instantiating class " + className, e); //$NON-NLS-1$
+					LanguageServerPlugin.logError("Failed instantiating class " + className, e); //$NON-NLS-1$
 					continue;
 				}
 
@@ -110,7 +110,7 @@ public class SymbolIconProviderRegistry {
 		try {
 			fileName = Path.of(uri.getPath()).getFileName().toString();
 		} catch (Exception e) {
-			Platform.getLog(getClass()).warn("Failed to parse file name from URI " + uri, e); //$NON-NLS-1$
+			LanguageServerPlugin.logWarning("Failed to parse file name from URI " + uri, e); //$NON-NLS-1$
 			return defaultIconProvider;
 		}
 
@@ -151,7 +151,7 @@ public class SymbolIconProviderRegistry {
 		try {
 			return URI.create(uri);
 		} catch (IllegalArgumentException e) {
-			Platform.getLog(getClass()).warn("Failed to parse URI " + uri, e); //$NON-NLS-1$
+			LanguageServerPlugin.logWarning("Failed to parse URI " + uri, e); //$NON-NLS-1$
 			return null;
 		}
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyItemLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyItemLabelProvider.java
@@ -39,7 +39,7 @@ public class TypeHierarchyItemLabelProvider extends LabelProvider implements ISt
 	@Override
 	public @Nullable Image getImage(@Nullable Object element) {
 		if (element instanceof TypeHierarchyItem item) {
-			return symbolIconProvider.getImageFor(item.getKind(), item.getTags());
+			return symbolIconProvider.getImageFor(item.getKind(), item.getTags(), element);
 		}
 		return element == null ? null : super.getImage(element);
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyItemLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/typeHierarchy/TypeHierarchyItemLabelProvider.java
@@ -12,21 +12,12 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.viewers.DelegatingStyledCellLabelProvider.IStyledLabelProvider;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.lsp4e.operations.symbols.internal.SymbolIconProviderRegistry;
 import org.eclipse.lsp4e.ui.SymbolIconProvider;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.eclipse.swt.graphics.Image;
 
 public class TypeHierarchyItemLabelProvider extends LabelProvider implements IStyledLabelProvider {
-
-	private final SymbolIconProvider symbolIconProvider;
-
-	public TypeHierarchyItemLabelProvider() {
-		this(new SymbolIconProvider());
-	}
-
-	public TypeHierarchyItemLabelProvider(SymbolIconProvider symbolIconProvider) {
-		this.symbolIconProvider = symbolIconProvider;
-	}
 
 	@Override
 	public String getText(Object element) {
@@ -39,7 +30,8 @@ public class TypeHierarchyItemLabelProvider extends LabelProvider implements ISt
 	@Override
 	public @Nullable Image getImage(@Nullable Object element) {
 		if (element instanceof TypeHierarchyItem item) {
-			return symbolIconProvider.getImageFor(item.getKind(), item.getTags(), element);
+			SymbolIconProvider symbolIconProvider = SymbolIconProviderRegistry.getSymbolIconProviderFor(item);
+			return symbolIconProvider.getImageFor(item.getKind(), item.getTags(), item);
 		}
 		return element == null ? null : super.getImage(element);
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
@@ -45,6 +45,7 @@ import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.internal.StyleUtil;
 import org.eclipse.lsp4e.operations.symbols.SymbolsUtil;
+import org.eclipse.lsp4e.operations.symbols.internal.SymbolIconProviderRegistry;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4e.ui.LSPImages;
 import org.eclipse.lsp4e.ui.Messages;
@@ -71,8 +72,6 @@ import com.google.common.collect.TreeRangeMap;
 
 public class SymbolsLabelProvider extends LabelProvider
 		implements ICommonLabelProvider, IStyledLabelProvider, IPreferenceChangeListener {
-
-	private final SymbolIconProvider symbolIconProvider;
 
 	private final Map<IResource, RangeMap<Integer, Integer>> severities = new HashMap<>();
 	private final IResourceChangeListener listener = e -> {
@@ -103,13 +102,8 @@ public class SymbolsLabelProvider extends LabelProvider
 	}
 
 	public SymbolsLabelProvider(final boolean showLocation, final boolean showKind) {
-		this(showLocation, showKind, new SymbolIconProvider());
-	}
-
-	public SymbolsLabelProvider(final boolean showLocation, final boolean showKind, SymbolIconProvider symbolIconProvider) {
 		this.showLocation = showLocation;
 		this.showKind = showKind;
-		this.symbolIconProvider = symbolIconProvider;
 		InstanceScope.INSTANCE.getNode(LanguageServerPlugin.PLUGIN_ID).addPreferenceChangeListener(this);
 		ResourcesPlugin.getWorkspace().addResourceChangeListener(listener);
 	}
@@ -170,6 +164,7 @@ public class SymbolsLabelProvider extends LabelProvider
 		}
 
 		if (actualElement != null && symbolKind != null) {
+			SymbolIconProvider symbolIconProvider = SymbolIconProviderRegistry.getSymbolIconProviderFor(actualElement);
 			return symbolIconProvider.getImageFor(symbolKind, symbolTags, getMaxSeverity(actualElement), actualElement);
 		}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsLabelProvider.java
@@ -170,7 +170,7 @@ public class SymbolsLabelProvider extends LabelProvider
 		}
 
 		if (actualElement != null && symbolKind != null) {
-			return symbolIconProvider.getImageFor(symbolKind, symbolTags, getMaxSeverity(actualElement));
+			return symbolIconProvider.getImageFor(symbolKind, symbolTags, getMaxSeverity(actualElement), actualElement);
 		}
 
 		return null;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
@@ -290,7 +290,7 @@ public final class LSPImages {
 	 * @param kind a document symbol's kind
 	 * @return an image representing the given symbol kind or <code>null</code>
 	 *
-	 * @see #getImage(String))
+	 * @see #getImage(String)
 	 * @see #getImageDescriptor(String)
 	 * @see SymbolIconProvider#getImageFor(SymbolKind, java.util.List, Object)
 	 * @see SymbolIconProvider#getImageFor(SymbolKind, java.util.List, int, Object)

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
@@ -292,8 +292,8 @@ public final class LSPImages {
 	 *
 	 * @see #getImage(String))
 	 * @see #getImageDescriptor(String)
-	 * @see SymbolIconProvider#getImageFor(SymbolKind, java.util.List)
-	 * @see SymbolIconProvider#getImageFor(SymbolKind, java.util.List, int)
+	 * @see SymbolIconProvider#getImageFor(SymbolKind, java.util.List, Object)
+	 * @see SymbolIconProvider#getImageFor(SymbolKind, java.util.List, int, Object)
 	 */
 	public static @Nullable Image imageFromSymbolKind(@Nullable SymbolKind kind) {
 		if (kind == null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
@@ -243,6 +243,9 @@ public final class LSPImages {
 	 * Returns the <code>Image</code> identified by the given key, or <code>null</code> if it does not exist.
 	 */
 	public static @Nullable Image getImage(String key) {
+		if (ISharedImages.IMG_OBJ_FILE.equals(key)) {
+			return getSharedImage(key);
+		}
 		return getImageRegistry().get(key);
 	}
 
@@ -250,6 +253,9 @@ public final class LSPImages {
 	 * Returns the <code>ImageDescriptor</code> identified by the given key, or <code>null</code> if it does not exist.
 	 */
 	public static @Nullable ImageDescriptor getImageDescriptor(String key) {
+		if (ISharedImages.IMG_OBJ_FILE.equals(key)) {
+			return getSharedImageDescriptor(key);
+		}
 		return getImageRegistry().getDescriptor(key);
 	}
 
@@ -266,7 +272,7 @@ public final class LSPImages {
 	 * @return the workbench's shared image for the , or null if not found
 	 */
 	public static @Nullable Image getSharedImage(@Nullable String imageId) {
-		if(imageId == null) {
+		if (imageId == null) {
 			return null;
 		}
 		return PlatformUI.getWorkbench().getSharedImages().getImage(imageId);
@@ -277,7 +283,7 @@ public final class LSPImages {
 	 * @return the workbench's shared image descriptor for the workbench, or null if not found
 	 */
 	public static @Nullable ImageDescriptor getSharedImageDescriptor(@Nullable String imageId) {
-		if(imageId == null) {
+		if (imageId == null) {
 			return null;
 		}
 		return PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(imageId);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
@@ -240,6 +240,15 @@ public final class LSPImages {
 			@Nullable ImageDescriptor underlayDescriptor) {}
 
 	/**
+	 * Returns an empty fallback image f(16x16 pixels).
+	 *
+	 * @return an empty 16x16 icon
+	 */
+	public static Image getEmptyImage() {
+		return EMPTY_IMAGE;
+	}
+
+	/**
 	 * Returns the <code>Image</code> identified by the given key, or <code>null</code> if it does not exist.
 	 */
 	public static @Nullable Image getImage(String key) {
@@ -303,7 +312,7 @@ public final class LSPImages {
 	 */
 	public static @Nullable Image imageFromSymbolKind(@Nullable SymbolKind kind) {
 		if (kind == null) {
-			return EMPTY_IMAGE;
+			return getEmptyImage();
 		}
 
 		String imgKey = imageKeyFromSymbolKind(kind);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
@@ -21,8 +21,12 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.lsp4e.operations.symbols.SymbolsUtil;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
+import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.ISharedImages;
 
@@ -32,6 +36,30 @@ import org.eclipse.ui.ISharedImages;
  * {@link SymbolKind} and {@link SymbolTag}s. This class is meant to be used with {@link LabelProvider}s.
  */
 public class SymbolIconProvider {
+
+	/**
+	 * Returns a symbol's name if the given symbol is an instance of
+	 * {@link DocumentSymbol}, or {@link DocumentSymbolWithURI},
+	 * {@link SymbolInformation}, or {@link WorkspaceSymbol},
+	 * returns <code>null</code> otherwise.
+	 *
+	 * @param symbol the symbol to get the name for
+	 * @return the symbol's name or <code>null</code>.
+	 */
+	protected @Nullable String getName(Object symbol) {
+		String name = null;
+		if (symbol instanceof SymbolInformation info) {
+			name = info.getName();
+		} else if (symbol instanceof WorkspaceSymbol wpSymbol) {
+			name = wpSymbol.getName();
+		} else if (symbol instanceof DocumentSymbol docSymbol) {
+			name = docSymbol.getName();
+		} else if (symbol instanceof DocumentSymbolWithURI symbolWithURI) {
+			name = symbolWithURI.symbol.getName();
+		}
+
+		return name;
+	}
 
 	/**
 	 * Returns an overlay icon {@link ImageDescriptor} for the given severity.
@@ -154,6 +182,10 @@ public class SymbolIconProvider {
 		Optional<SymbolTag> visibilityTag = getHighestPrecedenceVisibilitySymbolTag(symbolTags);
 
 		if (visibilityTag.isEmpty()) {
+			if (kind == SymbolKind.Constructor) {
+				// we'll add a constructor overlay icon instead in #getOverlaysFor(...), this way, the overlays will be customizable
+				return LSPImages.IMG_METHOD;
+			}
 			return LSPImages.imageKeyFromSymbolKind(kind);
 		}
 
@@ -189,12 +221,14 @@ public class SymbolIconProvider {
 	 *
 	 * @param symbolKind the kind of symbol
 	 * @param symbolTags the symbol tags
+	 * @param symbol the symbol for which an image should be returned, may be used by subclasses to determine the image to return
 	 * @return a new or cached image for the given symbol kind with overlay icons computed for the given arguments.
 	 *
-	 * @see #getImageFor(SymbolKind, List, int)
+	 * @see #getImageFor(SymbolKind, List, int, Object)
 	 */
-	public @Nullable Image getImageFor(@Nullable SymbolKind symbolKind, @Nullable List<SymbolTag> symbolTags) {
-		return getImageFor(symbolKind, symbolTags, -1);
+	public @Nullable Image getImageFor(@Nullable SymbolKind symbolKind, @Nullable List<SymbolTag> symbolTags,
+			Object symbol) {
+		return getImageFor(symbolKind, symbolTags, -1, symbol);
 	}
 
 	/**
@@ -206,12 +240,13 @@ public class SymbolIconProvider {
 	 * @param symbolKind the kind of symbol
 	 * @param symbolTags the symbol tags
 	 * @param severity one of -1, {@link IMarker#SEVERITY_WARNING}, and {@link IMarker#SEVERITY_ERROR}. -1 indicates no overlay icon.
+	 * @param symbol the symbol for which an image should be returned, may be used by subclasses to determine the image to return
 	 * @return a new or cached image for the given symbol kind with overlay icons computed for the given arguments.
 	 *
-	 * @see #getImageFor(SymbolKind, List)
+	 * @see #getImageFor(SymbolKind, List, Object)
 	 */
 	public @Nullable Image getImageFor(final @Nullable SymbolKind symbolKind,
-			final @Nullable List<SymbolTag> symbolTags, int severity) {
+			final @Nullable List<SymbolTag> symbolTags, int severity, Object symbol) {
 
 		if (symbolKind == null) {
 			return LSPImages.imageFromSymbolKind(symbolKind);
@@ -221,10 +256,29 @@ public class SymbolIconProvider {
 
 		String baseImageKey = getImageKeyFromSymbolKindWithVisibility(symbolKind, finalSymbolTags);
 
-		ImageDescriptor severityImageDescriptor = getOverlayForMarkerSeverity(severity);
-		ImageDescriptor deprecatedImageDescriptor = getUnderlayForDeprecation(SymbolsUtil.isDeprecated(finalSymbolTags));
+		Overlays overlays = getOverlaysFor(symbolKind, finalSymbolTags, severity, symbol);
 
-		List<SymbolTag> additionalTags = getAdditionalSymbolTagsSorted(finalSymbolTags);
+		return LSPImages.getImageWithOverlays(baseImageKey, overlays.topLeft, overlays.topRight,
+				overlays.bottomLeft, overlays.bottomRight, overlays.underlay);
+	}
+
+	/**
+	 * Determines the overlay icons to be shown for a symbol with the given arguments.
+	 * Sub-classes may override this method to customize the overlay icons.
+	 *
+	 * @param symbolKind the symbol kind, e.g. field, method, constructor, class, property
+	 * @param symbolTags the symbol tags, e.g. visibility tags, deprecation tag, static tag, final tag
+	 * @param severity the severity of the most severe marker associated with the symbol, or -1 if no marker is associated with the symbol
+	 * @param symbol the original symbol, i.e. an instance of {@link DocumentSymbol}, {@link DocumentSymbolWithURI}, {@link SymbolInformation}, or {@link WorkspaceSymbol}
+	 * @return The overlay icons to display for the given symbol
+	 */
+	protected Overlays getOverlaysFor(final SymbolKind symbolKind,
+			final List<SymbolTag> symbolTags, int severity, Object symbol) {
+
+		ImageDescriptor severityImageDescriptor = getOverlayForMarkerSeverity(severity);
+		ImageDescriptor deprecatedImageDescriptor = getUnderlayForDeprecation(SymbolsUtil.isDeprecated(symbolTags));
+
+		List<SymbolTag> additionalTags = getAdditionalSymbolTagsSorted(symbolTags);
 
 		ImageDescriptor topLeftOverlayDescriptor = null;
 		ImageDescriptor topRightOverlayDescriptor = null;
@@ -233,8 +287,7 @@ public class SymbolIconProvider {
 		ImageDescriptor underlayDescriptor = deprecatedImageDescriptor;
 
 		// special case for a constructor with visibility tag => we need to add a "C" overlay to show it's a constructor
-		if (SymbolKind.Constructor == symbolKind
-				&& !baseImageKey.equals(LSPImages.imageKeyFromSymbolKind(symbolKind))) {
+		if (SymbolKind.Constructor == symbolKind) {
 			topRightOverlayDescriptor = LSPImages.getImageDescriptor(LSPImages.IMG_OVR_CONSTRUCTOR);
 		}
 
@@ -262,11 +315,29 @@ public class SymbolIconProvider {
 			// The top left and top right corners remain for additional symbol tags (besides visibility, severity, deprecation)
 			// In case of constructors we already have a "C" for "constructor" in the upper right corner
 			// and have use the lower right corner for another additional symbol tag.
-			bottomRightOverlayDescriptor = getOverlayForVisibility(finalSymbolTags);
+			bottomRightOverlayDescriptor = getOverlayForVisibility(symbolTags);
 		}
 
-		return LSPImages.getImageWithOverlays(baseImageKey, topLeftOverlayDescriptor, topRightOverlayDescriptor,
-				bottomLeftOverlayDescriptor, bottomRightOverlayDescriptor, underlayDescriptor);
+		return new Overlays(topLeftOverlayDescriptor, topRightOverlayDescriptor, bottomLeftOverlayDescriptor,
+				bottomRightOverlayDescriptor, underlayDescriptor);
+	}
+
+	public static final class Overlays {
+		public final @Nullable ImageDescriptor topLeft;
+		public final @Nullable ImageDescriptor topRight;
+		public final @Nullable ImageDescriptor bottomLeft;
+		public final @Nullable ImageDescriptor bottomRight;
+		public final @Nullable ImageDescriptor underlay;
+
+		public Overlays(@Nullable ImageDescriptor topLeft, @Nullable ImageDescriptor topRight,
+				@Nullable ImageDescriptor bottomLeft, @Nullable ImageDescriptor bottomRight,
+				@Nullable ImageDescriptor underlay) {
+			this.topLeft = topLeft;
+			this.topRight = topRight;
+			this.bottomLeft = bottomLeft;
+			this.bottomRight = bottomRight;
+			this.underlay = underlay;
+		}
 	}
 
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
@@ -22,10 +22,12 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.lsp4e.operations.symbols.SymbolsUtil;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
+import org.eclipse.lsp4j.CallHierarchyItem;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
+import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.ISharedImages;
@@ -41,6 +43,7 @@ public class SymbolIconProvider {
 	 * Returns a symbol's name if the given symbol is an instance of
 	 * {@link DocumentSymbol}, or {@link DocumentSymbolWithURI},
 	 * {@link SymbolInformation}, or {@link WorkspaceSymbol},
+	 * or {@link CallHierarchyItem}, or {@link TypeHierarchyItem},
 	 * returns <code>null</code> otherwise.
 	 *
 	 * @param symbol the symbol to get the name for
@@ -56,6 +59,10 @@ public class SymbolIconProvider {
 			name = docSymbol.getName();
 		} else if (symbol instanceof DocumentSymbolWithURI symbolWithURI) {
 			name = symbolWithURI.symbol.getName();
+		} else if (symbol instanceof CallHierarchyItem callHierItem) {
+			name = callHierItem.getName();
+		} else if (symbol instanceof TypeHierarchyItem typeHierItem) {
+			name = typeHierItem.getName();
 		}
 
 		return name;
@@ -88,7 +95,7 @@ public class SymbolIconProvider {
 		return LSPImages.imageDescriptorOverlayFromSymbolTag(SymbolTag.Deprecated);
 	}
 
-	private static final List<SymbolTag> VISIBILITY_PRECEDENCE = List.of(
+	protected static final List<SymbolTag> VISIBILITY_PRECEDENCE = List.of(
 			SymbolTag.Public, SymbolTag.Protected, SymbolTag.Package,
 			SymbolTag.Internal, SymbolTag.File, SymbolTag.Private);
 
@@ -104,7 +111,7 @@ public class SymbolIconProvider {
 
 	// In order to keep the number of overlay icons rather small in the UI, we do not show the following symbol tags:
 	// SymbolTag.Nullable, SymbolTag.NonNull, SymbolTag.Declaration, SymbolTag.Definition
-	private static final List<SymbolTag> ADDITIONAL_TAGS_PRECEDENCE = List.of(
+	protected static final List<SymbolTag> ADDITIONAL_TAGS_PRECEDENCE = List.of(
 			SymbolTag.Static, SymbolTag.Final, SymbolTag.Abstract,
 			SymbolTag.Overrides, SymbolTag.Implements, SymbolTag.Virtual, SymbolTag.Sealed,
 			SymbolTag.Synchronized, SymbolTag.Transient, SymbolTag.Volatile,
@@ -249,6 +256,7 @@ public class SymbolIconProvider {
 			final @Nullable List<SymbolTag> symbolTags, int severity, Object symbol) {
 
 		if (symbolKind == null) {
+			// return empty image
 			return LSPImages.imageFromSymbolKind(symbolKind);
 		}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
@@ -256,8 +256,7 @@ public class SymbolIconProvider {
 			final @Nullable List<SymbolTag> symbolTags, int severity, Object symbol) {
 
 		if (symbolKind == null) {
-			// return empty image
-			return LSPImages.imageFromSymbolKind(symbolKind);
+			return LSPImages.getEmptyImage();
 		}
 
 		final List<SymbolTag> finalSymbolTags = symbolTags != null ? symbolTags : Collections.emptyList();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
@@ -50,22 +50,15 @@ public class SymbolIconProvider {
 	 * @return the symbol's name or <code>null</code>.
 	 */
 	protected @Nullable String getName(Object symbol) {
-		String name = null;
-		if (symbol instanceof SymbolInformation info) {
-			name = info.getName();
-		} else if (symbol instanceof WorkspaceSymbol wpSymbol) {
-			name = wpSymbol.getName();
-		} else if (symbol instanceof DocumentSymbol docSymbol) {
-			name = docSymbol.getName();
-		} else if (symbol instanceof DocumentSymbolWithURI symbolWithURI) {
-			name = symbolWithURI.symbol.getName();
-		} else if (symbol instanceof CallHierarchyItem callHierItem) {
-			name = callHierItem.getName();
-		} else if (symbol instanceof TypeHierarchyItem typeHierItem) {
-			name = typeHierItem.getName();
-		}
-
-		return name;
+		return switch (symbol) {
+			case SymbolInformation info -> info.getName();
+			case WorkspaceSymbol wpSymbol -> wpSymbol.getName();
+			case DocumentSymbol docSymbol -> docSymbol.getName();
+			case DocumentSymbolWithURI symbolWithURI -> symbolWithURI.symbol.getName();
+			case CallHierarchyItem callHierItem -> callHierItem.getName();
+			case TypeHierarchyItem typeHierItem -> typeHierItem.getName();
+			default -> null;
+		};
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/SymbolIconProvider.java
@@ -282,6 +282,8 @@ public class SymbolIconProvider {
 	 */
 	protected Overlays getOverlaysFor(final SymbolKind symbolKind,
 			final List<SymbolTag> symbolTags, int severity, Object symbol) {
+		// The symbol parameter is intentionally added to the method signature in order to give subclasses
+		// a way to adapt the overlay icons depending on a symbol's properties.
 
 		ImageDescriptor severityImageDescriptor = getOverlayForMarkerSeverity(severity);
 		ImageDescriptor deprecatedImageDescriptor = getUnderlayForDeprecation(SymbolsUtil.isDeprecated(symbolTags));


### PR DESCRIPTION
This PR makes overlay icon calculation customizable in client plug-ins (e.g. in CDT LSP) by introducing a new extension point for custom `SymbolIcenProvider` implementations. Custom `SymbolIcenProvider`s are registered for certain content types and are used in all views / dialogs like outline view, call hierarchy, and type hierachy.

An exemplary customization (introducing a custom overlay icon for destructors) is implemented in CDT LSP PR https://github.com/eclipse-cdt/cdt-lsp/pull/609, see corresponding issue https://github.com/eclipse-cdt/cdt-lsp/issues/608.