### PR TITLE
feat: remove "initializeResult unexpectedly null after initialization" exception

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -318,7 +318,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		return languageServerWrapper.getServerCapabilitiesAsync().thenCompose(capabilities -> {
 			FormattingOptions formatOptions = LSPFormatter.getFormatOptions();
 			final var docId = new TextDocumentIdentifier(fileUri.toString());
-			if (LSPFormatter.isDocumentRangeFormattingSupported(capabilities)
+			if (capabilities != null && LSPFormatter.isDocumentRangeFormattingSupported(capabilities)
 					&& !(LSPFormatter.isDocumentFormattingSupported(capabilities) && textSelection.getLength() == 0)) {
 				try {
 					DocumentRangeFormattingParams rangeParams = LSPFormatter.getRangeFormattingParams(document,

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -1079,17 +1079,14 @@ public class LanguageServerWrapper {
 		return res;
 	}
 
-	public CompletableFuture<InitializeResult> getInitializeResultAsync() {
-		return getInitializedServer().thenCompose(ls -> {
-			final var initializeResult = this.initializeResult;
-			if (initializeResult == null) {
-				// This can happen if the server shuts down immediately after initialization,
-				// but before this callback was invoked.
-				return CompletableFuture.failedFuture(
-						new IllegalStateException("initializeResult unexpectedly null after initialization")); //$NON-NLS-1$
-			}
-			return CompletableFuture.completedFuture(initializeResult);
-		});
+	/**
+	 * @return a {@link CompletableFuture} that provides the {@link InitializeResult}.
+	 * <p>
+	 * The {@link InitializeResult} will be {@code null} if the server shuts down
+	 * immediately after initialization or if it fails to start.
+	 */
+	public CompletableFuture<@Nullable InitializeResult> getInitializeResultAsync() {
+		return getInitializedServer().thenCompose(ls -> CompletableFuture.completedFuture(this.initializeResult));
 	}
 
 	/**
@@ -1116,17 +1113,14 @@ public class LanguageServerWrapper {
 		return this.serverCapabilities;
 	}
 
-	public CompletableFuture<ServerCapabilities> getServerCapabilitiesAsync() {
-		return getInitializedServer().thenCompose(ls -> {
-			final var serverCapabilities = this.serverCapabilities;
-			if (serverCapabilities == null) {
-				// This can happen if the server shuts down immediately after initialization,
-				// but before this callback was invoked.
-				return CompletableFuture.failedFuture(
-						new IllegalStateException("serverCapabilities unexpectedly null after initialization")); //$NON-NLS-1$
-			}
-			return CompletableFuture.completedFuture(serverCapabilities);
-		});
+	/**
+	 * @return a {@link CompletableFuture} that provides the {@link ServerCapabilities}.
+	 * <p>
+	 * The {@link ServerCapabilities} will be {@code null} if the server shuts down
+	 * immediately after initialization or if it fails to start.
+	 */
+	public CompletableFuture<@Nullable ServerCapabilities> getServerCapabilitiesAsync() {
+		return getInitializedServer().thenCompose(ls -> CompletableFuture.completedFuture(this.serverCapabilities));
 	}
 
 	public CompletableFuture<@Nullable ServerInfo> getServerInfoAsync() {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -206,9 +206,9 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 	 * @param serverCapabilities
 	 */
 	@SuppressWarnings("unchecked")
-	public E withCapability(final Function<ServerCapabilities, Either<Boolean, ?>> serverCapabilities) {
+	public E withCapability(final @Nullable Function<ServerCapabilities, Either<Boolean, ?>> serverCapabilities) {
 		Assert.isLegal(this.filter == NO_FILTER);
-		this.filter = f -> LSPEclipseUtils.hasCapability(serverCapabilities.apply(f));
+		this.filter = f -> serverCapabilities != null && LSPEclipseUtils.hasCapability(serverCapabilities.apply(f));
 		return (E) this;
 	}
 
@@ -280,7 +280,7 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 		 */
 		private CompletableFuture<@Nullable LanguageServerWrapper> filter(LanguageServerWrapper wrapper) {
 			return wrapper.getServerCapabilitiesAsync() //
-					.thenApply(sc -> getFilter().test(sc) ? wrapper : null);
+					.thenApply(sc -> sc != null && getFilter().test(sc) ? wrapper : null);
 		}
 
 		@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -94,6 +94,7 @@ public class LanguageServiceAccessor {
 			this.wrapper = wrapper;
 		}
 
+		@Deprecated
 		public IDocument getDocument() {
 			return this.document;
 		}
@@ -103,22 +104,27 @@ public class LanguageServiceAccessor {
 		 *
 		 * @return the file URI
 		 */
+		@Deprecated
 		public URI getFileUri() {
 			return this.fileUri;
 		}
 
+		@Deprecated
 		public LanguageServerWrapper getLanguageServerWrapper() {
 			return wrapper;
 		}
 
+		@Deprecated
 		public int getVersion() {
 			return wrapper.getTextDocumentVersion(fileUri);
 		}
 
+		@Deprecated
 		public @Nullable ServerCapabilities getCapabilites() {
 			return this.wrapper.getServerCapabilities();
 		}
 
+		@Deprecated
 		public boolean isActive() {
 			return this.wrapper.isActive();
 		}
@@ -220,7 +226,7 @@ public class LanguageServiceAccessor {
 			final @Nullable Predicate<ServerCapabilities> capabilitiesPredicate) {
 		return capabilitiesPredicate == null //
 				? CompletableFuture.completedFuture(true) //
-				: wrapper.getServerCapabilitiesAsync().thenApply(capabilitiesPredicate::test);
+				: wrapper.getServerCapabilitiesAsync().thenApply(sC -> sC != null && capabilitiesPredicate.test(sC));
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
@@ -52,6 +52,9 @@ public class LSPCodeMining extends LineHeaderCodeMining {
 	@Override
 	protected CompletableFuture<@Nullable Void> doResolve(ITextViewer viewer, IProgressMonitor monitor) {
 		return languageServerWrapper.getServerCapabilitiesAsync().thenCompose(capabilities -> {
+			if (capabilities == null) {
+				return CompletableFuture.completedFuture(null);
+			}
 			final Boolean resolveProvider = capabilities.getCodeLensProvider().getResolveProvider();
 			if (resolveProvider == null || !resolveProvider) {
 				return CompletableFuture.completedFuture(null);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -57,6 +57,10 @@ public class LSPFormatter {
 		// can fall through to the next server (e.g. Vue LS after TS LS on .vue files).
 		long modificationStamp = DocumentUtil.getDocumentModificationStamp(document);
 		return executor.computeFirst((w, ls) -> w.getServerCapabilitiesAsync().thenCompose(capabilities -> {
+			if (capabilities == null) {
+				return CompletableFuture.completedFuture(null);
+			}
+
 			if (isDocumentRangeFormattingSupported(capabilities) && (textSelection.getLength() > 0 || !isDocumentFormattingSupported(capabilities))) {
 				return (CompletableFuture<@Nullable List<? extends TextEdit>>) ls.getTextDocumentService()
 						.rangeFormatting(rangeParams);


### PR DESCRIPTION
this reduces the number of exceptions during LSP4E operations. As an
example of such an exception is:

!ENTRY org.eclipse.lsp4e 4 0 2026-04-20 09:22:31.360
!MESSAGE java.lang.IllegalStateException: serverCapabilities unexpectedly null after initialization
!STACK 0
java.util.concurrent.CompletionException: java.lang.IllegalStateException: serverCapabilities unexpectedly null after initialization
	at java.base/java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:368)
	at java.base/java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:1189)
	at java.base/java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2341)
	at org.eclipse.lsp4e.LanguageServerWrapper.getServerCapabilitiesAsync(LanguageServerWrapper.java:1120)
	at org.eclipse.lsp4e.LanguageServers$LanguageServerDocumentExecutor.filter(LanguageServers.java:282)
...
	at org.eclipse.lsp4e.LanguageServers$LanguageServerDocumentExecutor.getServers(LanguageServers.java:290)
	at org.eclipse.lsp4e.LanguageServers.executeOnServers(LanguageServers.java:441)
	at org.eclipse.lsp4e.LanguageServers.collectAll(LanguageServers.java:92)
	at org.eclipse.lsp4e.LanguageServers.collectAll(LanguageServers.java:75)
	at org.eclipse.lsp4e.operations.linkedediting.LSPLinkedEditingBase.collectLinkedEditingRanges(LSPLinkedEditingBase.java:72)
	at org.eclipse.lsp4e.operations.linkedediting.LSPLinkedEditingReconcilingStrategy.updateLinkedEditing(LSPLinkedEditingReconcilingStrategy.java:168)
	at org.eclipse.lsp4e.operations.linkedediting.LSPLinkedEditingReconcilingStrategy.updateLinkedEditing(LSPLinkedEditingReconcilingStrategy.java:156)
	at org.eclipse.lsp4e.operations.linkedediting.LSPLinkedEditingReconcilingStrategy.lambda$0(LSPLinkedEditingReconcilingStrategy.java:134)
	...