### PR TITLE
fix: prevent an exception during LanguageServerPlugin#stop

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.10.qualifier
+Bundle-Version: 0.19.11.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.10-SNAPSHOT</version>
+	<version>0.19.11-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/LSPImages.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.FileLocator;
@@ -66,7 +67,7 @@ public final class LSPImages {
 	private static final String ACTION = ICONS_PATH + "elcl16/"; // basic colors - size 16x16 //$NON-NLS-1$
 	private static final String OVERLAY = ICONS_PATH + "ovr16/"; // basic colors - size 7x8 and 14x16 //$NON-NLS-1$
 
-	private static final Image EMPTY_IMAGE = new Image(UI.getDisplay(), 16, 16);
+	private static @Nullable Image emptyImage;
 
 	public static final String IMG_MODULE = "IMG_MODULE"; //$NON-NLS-1$
 	public static final String IMG_NAMESPACE = "IMG_NAMESPACE"; //$NON-NLS-1$
@@ -240,12 +241,16 @@ public final class LSPImages {
 			@Nullable ImageDescriptor underlayDescriptor) {}
 
 	/**
-	 * Returns an empty fallback image f(16x16 pixels).
+	 * Returns an empty fallback image (16x16 pixels).
 	 *
 	 * @return an empty 16x16 icon
 	 */
 	public static Image getEmptyImage() {
-		return EMPTY_IMAGE;
+		Image img = emptyImage;
+		if (img == null) {
+			img = emptyImage = new Image(UI.getDisplay(), 16, 16);
+		}
+		return img;
 	}
 
 	/**
@@ -543,12 +548,14 @@ public final class LSPImages {
 	}
 
 	public static final void dispose() {
-		Stream.concat(
+		Stream.concat(Stream.concat(
 				colorToImageCache.values().stream(),
-				overlayImagesCache.values().stream())
+				overlayImagesCache.values().stream()
+				), Optional.ofNullable(emptyImage).stream())
 			.filter(Objects::nonNull)
 			.forEach(Image::dispose);
 		overlayImagesCache.clear();
 		colorToImageCache.clear();
+		emptyImage = null;
 	}
 }


### PR DESCRIPTION
org.osgi.framework.BundleException: Exception in
org.eclipse.lsp4e.LanguageServerPlugin.stop() of bundle org.eclipse.lsp4e.
	at org.eclipse.osgi.internal.framework.BundleContextImpl.stop(BundleContextImpl.java:928)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.stopWorker0(EquinoxBundle.java:1096)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.stopWorker(EquinoxBundle.java:399)
	at org.eclipse.osgi.container.Module.doStop(Module.java:699)
	at org.eclipse.osgi.container.Module.stop(Module.java:557)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.decStartLevel(ModuleContainer.java:2153)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:2022)
	at org.eclipse.osgi.container.SystemModule.stopWorker(SystemModule.java:281)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule.stopWorker(EquinoxBundle.java:225)
	at org.eclipse.osgi.container.Module.doStop(Module.java:699)
	at org.eclipse.osgi.container.Module.stop(Module.java:557)
	at org.eclipse.osgi.container.SystemModule.stop(SystemModule.java:212)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule$1.run(EquinoxBundle.java:244)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ExceptionInInitializerError
	at org.eclipse.lsp4e.LanguageServerPlugin.stop(LanguageServerPlugin.java:72)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:908)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:1)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.stop(BundleContextImpl.java:900)
	... 13 more
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Set.add(Object)" because "this.resourcesWithZoomSupport" is null
	at org.eclipse.swt.graphics.Device.registerResourceWithZoomSupport(Device.java:966)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:247)
	at org.eclipse.lsp4e.ui.LSPImages.<clinit>(LSPImages.java:69)
	... 18 more
Root exception:
java.lang.ExceptionInInitializerError
	at org.eclipse.lsp4e.LanguageServerPlugin.stop(LanguageServerPlugin.java:72)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:908)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:1)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.stop(BundleContextImpl.java:900)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.stopWorker0(EquinoxBundle.java:1096)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.stopWorker(EquinoxBundle.java:399)
	at org.eclipse.osgi.container.Module.doStop(Module.java:699)
	at org.eclipse.osgi.container.Module.stop(Module.java:557)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.decStartLevel(ModuleContainer.java:2153)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:2022)
	at org.eclipse.osgi.container.SystemModule.stopWorker(SystemModule.java:281)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule.stopWorker(EquinoxBundle.java:225)
	at org.eclipse.osgi.container.Module.doStop(Module.java:699)
	at org.eclipse.osgi.container.Module.stop(Module.java:557)
	at org.eclipse.osgi.container.SystemModule.stop(SystemModule.java:212)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$SystemBundle$EquinoxSystemModule$1.run(EquinoxBundle.java:244)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Set.add(Object)" because "this.resourcesWithZoomSupport" is null
	at org.eclipse.swt.graphics.Device.registerResourceWithZoomSupport(Device.java:966)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:247)
	at org.eclipse.lsp4e.ui.LSPImages.<clinit>(LSPImages.java:69)
	... 18 more