### PR TITLE
Fix path parsing on Windows in SymbolIconProviderRegistry & add tests

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.16.10.qualifier
+Bundle-Version: 0.16.11.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.16.10-SNAPSHOT</version>
+	<version>0.16.11-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/edit/LSPEclipseUtilsTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.edit;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -81,6 +82,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class LSPEclipseUtilsTest extends AbstractTestWithProject {
@@ -636,6 +638,19 @@ public class LSPEclipseUtilsTest extends AbstractTestWithProject {
 	@MethodSource
 	void getHtmlDocString(Either<@Nullable String, MarkupContent> arg, String expected) throws Exception {
 		assertEquals(expected, LSPEclipseUtils.getHtmlDocString(arg));
+	}
+	
+	@ParameterizedTest
+	@CsvSource({
+		"file:///C:/Users/username/path/to/SomeDir/SomeType.hpp, SomeType.hpp",
+		"file:///home/username/path/to/SomeDir/SomeType.hpp, SomeType.hpp",
+		"file:///,"
+	})
+	void testReadingFileNameFromUri(String uriText, String expectedFileName) {
+		URI uri = URI.create(uriText);
+		
+		String actualFileName = assertDoesNotThrow(() -> LSPEclipseUtils.getFileName(uri));
+		assertEquals(expectedFileName, actualFileName);
 	}
 
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -1602,6 +1602,16 @@ public final class LSPEclipseUtils {
 		return null;
 	}
 
+	/**
+	 * Converts the given string to a {@link URI} if possible.
+	 * Ensures correct encoding in case of file URIs.
+	 *
+	 * @param uri a URI string
+	 * @return a URI instance for the given string
+	 * @throws IllegalArgumentException if the given string is not a valid URI (if it violates RFC 2396)
+	 * @throws NullPointerException if the given string is null
+	 * @see URI#create(String)
+	 */
 	public static URI toUri(String uri) {
 		URI initialUri = URI.create(uri);
 		return FILE_SCHEME.equals(initialUri.getScheme()) ? toUri(Path.fromPortableString(initialUri.getPath())) : initialUri;

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -431,6 +431,15 @@ public final class LSPEclipseUtils {
 		return toPath(toBuffer(document));
 	}
 
+	public static @Nullable String getFileName(URI uri) {
+		try {
+			return java.nio.file.Path.of(uri).getFileName().toString();
+		} catch (Exception e) {
+			LanguageServerPlugin.logWarning("Failed to parse file name from URI " + uri, e); //$NON-NLS-1$
+		}
+		return null;
+	}
+
 	public static int toEclipseMarkerSeverity(@Nullable DiagnosticSeverity lspSeverity) {
 		if (lspSeverity == null) {
 			// if severity is empty it is up to the client to interpret diagnostics

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
@@ -12,7 +12,6 @@
 package org.eclipse.lsp4e.operations.symbols.internal;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,6 +21,7 @@ import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
 import org.eclipse.lsp4e.ui.SymbolIconProvider;
@@ -106,11 +106,8 @@ public class SymbolIconProviderRegistry {
 			return defaultIconProvider;
 		}
 
-		String fileName = null;
-		try {
-			fileName = Path.of(uri.getPath()).getFileName().toString();
-		} catch (Exception e) {
-			LanguageServerPlugin.logWarning("Failed to parse file name from URI " + uri, e); //$NON-NLS-1$
+		String fileName = LSPEclipseUtils.getFileName(uri);
+		if (fileName == null) {
 			return defaultIconProvider;
 		}
 
@@ -146,8 +143,8 @@ public class SymbolIconProviderRegistry {
 		}
 
 		try {
-			return URI.create(uri);
-		} catch (IllegalArgumentException e) {
+			return LSPEclipseUtils.toUri(uri);
+		} catch (Exception e) {
 			LanguageServerPlugin.logWarning("Failed to parse URI " + uri, e); //$NON-NLS-1$
 			return null;
 		}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/symbols/internal/SymbolIconProviderRegistry.java
@@ -144,7 +144,7 @@ public class SymbolIconProviderRegistry {
 
 		try {
 			return LSPEclipseUtils.toUri(uri);
-		} catch (Exception e) {
+		} catch (IllegalArgumentException e) {
 			LanguageServerPlugin.logWarning("Failed to parse URI " + uri, e); //$NON-NLS-1$
 			return null;
 		}


### PR DESCRIPTION
On Windows a path parsing issue can occur while retrieving overlay icons for the outline view, type hierarchy, or call hierarchy. This PR provides a fix for [an issue reported in CDT LSP](https://github.com/eclipse-cdt/cdt-lsp/pull/609#issuecomment-4318375948) and adds a test for reproducing that issue.