### PR TITLE
fix(tests): Construct valid command in MockTextDocumentService

### DIFF
--- a/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mock Language Server to test LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.tests.mock
-Bundle-Version: 0.17.3.qualifier
+Bundle-Version: 0.17.4.qualifier
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.lsp4j,

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -216,7 +216,7 @@ public class MockTextDocumentService implements TextDocumentService {
 		if (file.exists() && file.length() > 100) {
 			return CompletableFuture
 					.completedFuture(List.of(new CodeLens(new Range(new Position(1, 0), new Position(1, 1)),
-							new Command("Hi, I'm a CodeLens", null), null)));
+							new Command("Hi, I'm a CodeLens", "dummyCommand"), null)));
 		}
 		return CompletableFuture.completedFuture(Collections.emptyList());
 	}


### PR DESCRIPTION
When executing tests locally, one can observe this error, because the constructor of `Command` expects a non-null String
```
  06:46:47 SEVERE [org.eclipse.lsp4j.jsonrpc.RemoteEndpoint] Internal error: Property must not be null: command 
  java.lang.NullPointerException: Property must not be null: command
  	at org.eclipse.lsp4j.jsonrpc.util.Preconditions.checkNotNull(Preconditions.java:29)
  	at org.eclipse.lsp4j.Command.<init>(Command.java:56)
  	at org.eclipse.lsp4e.tests.mock.MockTextDocumentService.codeLens(MockTextDocumentService.java:219)
  	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
  	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
  	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.lambda$recursiveFindRpcMethods$0(GenericEndpoint.java:65)
  	at org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint.request(GenericEndpoint.java:128)
  	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleRequest(RemoteEndpoint.java:265)
  	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:195)
  	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:189)
  	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:97)
  	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:97)
  	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
  	at java.base/java.lang.Thread.run(Thread.java:1583)
```