### PR TITLE
fix: Only catch expected Exceptions in `LSPEclipseUtils.getFileName(URI)`

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.12.qualifier
+Bundle-Version: 0.19.13.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.12-SNAPSHOT</version>
+	<version>0.19.13-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -432,12 +433,15 @@ public final class LSPEclipseUtils {
 	}
 
 	public static @Nullable String getFileName(URI uri) {
+		final java.nio.file.Path path;
 		try {
-			return java.nio.file.Path.of(uri).getFileName().toString();
-		} catch (Exception e) {
+			path = java.nio.file.Path.of(uri);
+		} catch (IllegalArgumentException | FileSystemNotFoundException e) {
 			LanguageServerPlugin.logWarning("Failed to parse file name from URI " + uri, e); //$NON-NLS-1$
+			return null;
 		}
-		return null;
+		java.nio.file.Path fileName = path.getFileName();
+		return fileName == null ? null : fileName.toString();
 	}
 
 	public static int toEclipseMarkerSeverity(@Nullable DiagnosticSeverity lspSeverity) {


### PR DESCRIPTION
`LSPEclipseUtils.getFileName(URI)` catches `Exception`, which includes a NullPointerException when `Path.getFileName()` returns null:
```
   06:46:31 WARNING [org.eclipse.lsp4e] Status WARNING: org.eclipse.lsp4e code=0 Failed to parse file name from URI file:/// java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.toString()" because the return value of "java.nio.file.Path.getFileName()" is null 
  java.lang.NullPointerException: Cannot invoke "java.nio.file.Path.toString()" because the return value of "java.nio.file.Path.getFileName()" is null
  	at org.eclipse.lsp4e.LSPEclipseUtils.getFileName(LSPEclipseUtils.java:436)
  	at org.eclipse.lsp4e.test.edit.LSPEclipseUtilsTest.lambda$0(LSPEclipseUtilsTest.java:652)
  	at org.junit.jupiter.api.AssertDoesNotThrow.assertDoesNotThrow(AssertDoesNotThrow.java:76)
  	at org.junit.jupiter.api.AssertDoesNotThrow.assertDoesNotThrow(AssertDoesNotThrow.java:61)
  	at org.junit.jupiter.api.Assertions.assertDoesNotThrow(Assertions.java:3355)
  	at org.eclipse.lsp4e.test.edit.LSPEclipseUtilsTest.testReadingFileNameFromUri(LSPEclipseUtilsTest.java:652)
```
Catching NPEs is usually not good practice, so instead, we handle the null case explicitly. Also, we only catch expected exceptions