### PR TITLE
refactor(tests): Use JUnit Jupiter mechanisms to handle general test setup and reporting

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.16.11.qualifier
+Bundle-Version: 0.16.12.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21
@@ -32,6 +32,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.filesystem,
  junit-jupiter-api;bundle-version="[6.0.1,7.0.0)",
  junit-jupiter-params;bundle-version="[6.0.1,7.0.0)",
+ junit-platform-commons;bundle-version="[6.0.3,7.0.0)",
+ junit-platform-launcher;bundle-version="[6.0.3,7.0.0)",
+ junit-platform-engine;bundle-version="[6.0.0,7.0.0)",
  org.hamcrest,
  org.opentest4j
 Automatic-Module-Name: org.eclipse.lsp4e.test

--- a/org.eclipse.lsp4e.test/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/org.eclipse.lsp4e.test/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.eclipse.lsp4e.test.utils.CloseIntroExtension

--- a/org.eclipse.lsp4e.test/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
+++ b/org.eclipse.lsp4e.test/META-INF/services/org.junit.platform.launcher.LauncherSessionListener
@@ -1,0 +1,1 @@
+org.eclipse.lsp4e.test.utils.LoggingLauncherSessionListener

--- a/org.eclipse.lsp4e.test/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/org.eclipse.lsp4e.test/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+org.eclipse.lsp4e.test.utils.LoggingTestExecutionListener

--- a/org.eclipse.lsp4e.test/junit-platform.properties
+++ b/org.eclipse.lsp4e.test/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled=true

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.16.11-SNAPSHOT</version>
+	<version>0.16.12-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->
@@ -42,7 +42,7 @@
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>true</useUIThread>
 					<forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
-					<argLine>-Dfile.encoding=${project.build.sourceEncoding} -Xms1g -Xmx1g -Djava.util.logging.config.file=${project.basedir}/src/jul.properties ${ui.test.vmargs} ${os-jvm-flags}</argLine>
+					<argLine>-Dfile.encoding=${project.build.sourceEncoding} -Xms1g -Xmx1g ${ui.test.vmargs} ${os-jvm-flags}</argLine>
 					<providerHint>junit6</providerHint>
 				</configuration>
 			</plugin>

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AbstractTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AbstractTest.java
@@ -11,50 +11,17 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.utils;
 
-import java.io.PrintStream;
-
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * Test base class that configures a {@link AllCleanExtension} and a
- * {@link TestInfoExtension} and works around a surefire-plugin issue which
- * suppresses output to stderr
+ * Test base class that configures a {@link AllCleanExtension}.
  */
 public abstract class AbstractTest {
 
-	private static PrintStream originalSystemErr;
-
-	private static final boolean isExecutedBySurefirePlugin = System.getProperty("surefire.real.class.path") != null;
-
-	@BeforeAll
-	public static void setUpSystemErrRedirection() throws Exception {
-		if (isExecutedBySurefirePlugin) {
-			// redirect stderr to stdout during test execution as it is otherwise suppressed
-			// by the surefire-plugin
-			originalSystemErr = System.err;
-			System.setErr(System.out);
-		}
-	}
-
-	@AfterAll
-	public static void tearDownSystemErrRedirection() throws Exception {
-		if (isExecutedBySurefirePlugin) {
-			System.setErr(originalSystemErr);
-		}
-	}
-
 	@RegisterExtension
-	@Order(1)
 	public final AllCleanExtension allCleanRule = new AllCleanExtension(this::getServerCapabilities);
-	
-	@RegisterExtension
-	@Order(0)
-	public final TestInfoExtension testInfo = new TestInfoExtension();
 
 	/**
 	 * Override if required, used by {@link #allCleanRule}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AllCleanExtension.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/AllCleanExtension.java
@@ -23,8 +23,6 @@ import org.eclipse.lsp4e.tests.mock.MockConnectionProvider;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.intro.IIntroPart;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -43,10 +41,6 @@ public class AllCleanExtension implements BeforeEachCallback, AfterEachCallback 
 
 	@Override
 	public void beforeEach(ExtensionContext context) throws Exception {
-		IIntroPart intro = PlatformUI.getWorkbench().getIntroManager().getIntro();
-		if (intro != null) {
-			PlatformUI.getWorkbench().getIntroManager().closeIntro(intro);
-		}
 		clear();
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/CloseIntroExtension.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/CloseIntroExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Vegard IT GmbH and others.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -7,21 +7,26 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *  Sebastian Thomschke (Vegard IT GmbH) - initial implementation
+ *   See git history
  *******************************************************************************/
 package org.eclipse.lsp4e.test.utils;
 
-import java.lang.System.Logger.Level;
-
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.intro.IIntroPart;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class TestInfoExtension implements BeforeEachCallback {
+/**
+ * Makes sure the Eclipse Introduction is closed.
+ */
+public class CloseIntroExtension implements BeforeEachCallback {
 
 	@Override
-	public void beforeEach(ExtensionContext context) {
-		String testClass = context.getTestClass().map(Class::getName).orElse("UnknownTestClass");
-		System.getLogger(testClass).log(Level.INFO, "Testing [" + context.getDisplayName() + "]...");
+	public void beforeEach(ExtensionContext context) throws Exception {
+		IIntroPart intro = PlatformUI.getWorkbench().getIntroManager().getIntro();
+		if (intro != null) {
+			PlatformUI.getWorkbench().getIntroManager().closeIntro(intro);
+		}
 	}
-	
+
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/LoggingLauncherSessionListener.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/LoggingLauncherSessionListener.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.utils;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.util.logging.LogManager;
+
+import org.junit.platform.launcher.LauncherSession;
+import org.junit.platform.launcher.LauncherSessionListener;
+
+/**
+ * Set up logging. Redirect stderr to stdout if the tests are executed from
+ * surefire-plugin.
+ */
+public class LoggingLauncherSessionListener implements LauncherSessionListener {
+
+	private PrintStream originalSystemErr;
+
+	private Logger LOGGER = System.getLogger(LoggingLauncherSessionListener.class.getName());
+
+	private final boolean isExecutedBySurefirePlugin = System.getProperty("surefire.real.class.path") != null;
+
+	@Override
+	public void launcherSessionOpened(LauncherSession session) {
+		if (isExecutedBySurefirePlugin) {
+			originalSystemErr = System.err;
+			System.setErr(System.out);
+		}
+
+		// Explicitly load the JUL config
+		System.setProperty("java.util.logging.config.file", "src/jul.properties");
+		try {
+			LogManager.getLogManager().readConfiguration();
+		} catch (SecurityException | IOException e) {
+			LOGGER.log(Level.ERROR, "Failed to apply jul.properties", e);
+		}
+	}
+
+	@Override
+	public void launcherSessionClosed(LauncherSession session) {
+		if (isExecutedBySurefirePlugin) {
+			System.setErr(originalSystemErr);
+		}
+	}
+
+}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/LoggingTestExecutionListener.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/LoggingTestExecutionListener.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.utils;
+
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+/**
+ * Log test execution events.
+ * This somewhat duplicates the default reporting from surefire but has the advantage
+ * that you also get this output when running the tests through Eclipse.
+ */
+public class LoggingTestExecutionListener implements TestExecutionListener {
+
+	private Logger LOGGER = System.getLogger(LoggingTestExecutionListener.class.getSimpleName());
+
+	@Override
+	public void executionStarted(TestIdentifier testIdentifier) {
+		LOGGER.log(Level.INFO, "Starting {0}", testIdentifier.getDisplayName());
+	}
+
+	@Override
+	public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+		LOGGER.log(Level.INFO, "Finished {0}: {1}", testIdentifier.getDisplayName(), testExecutionResult.getStatus());
+	}
+
+	@Override
+	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+		LOGGER.log(Level.INFO, "Skipped {0}: {1}", testIdentifier.getDisplayName(), reason);
+	}
+
+}


### PR DESCRIPTION
- The `junit.jupiter.extensions.autodetection.enabled=true` configuration automatically loads all listeners/extensions defined in META-INF/services. For example, we previously used the `TestInfoExtension` to log when a test starts. However, for this to work, you either had to manually add the extension to your test class or extend AbstractTest. Otherwise there would have been no output.
- `CloseIntroExtension` is now a regular Extension which just makes sure the Intro is closed. This has the same advantage, that you don't have to use it explicitly or inherit from AbstractTest
- `LoggingTestExecutionListener` is now used to report when a test case or test container starts/finish. This implements `TestExecutionListener` which has the advantage that it is called for each test, even for skipped ones and that you also get access to the result of the test case execution, which is something you cannot do with something like beforeEach/afterEach.
- `LoggingLauncherSessionListener` is now used to redirect stderr and configure the java.util.logging. This implements `LauncherSessionListener` which is only called once per test session, instead of previously being done before each test case.