### PR TITLE
fix: Send a single hover request every time the user hovers

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.16.11.qualifier
+Bundle-Version: 0.16.12.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.16.11-SNAPSHOT</version>
+	<version>0.16.12-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 Rogue Wave Software Inc. and others.
+ * Copyright (c) 2016, 2026 Rogue Wave Software Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -28,7 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.internal.text.html.BrowserInformationControl;
+import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
 import org.eclipse.lsp4e.LSPEclipseUtils;
@@ -98,7 +100,8 @@ public class HoverTest extends AbstractTestWithProject {
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 
-		String html = hover.getHoverInfoFuture(viewer, new Region(0, 10)).get(2, TimeUnit.SECONDS);
+		@Nullable IRegion hoverRegion = hover.getHoverRegion(viewer, 0);
+		String html = hover.getHoverInfoFuture(viewer, hoverRegion).get(2, TimeUnit.SECONDS);
 		assertNotNull(html);
 		assertTrue(html.contains("HoverContent"));
 	}
@@ -111,8 +114,8 @@ public class HoverTest extends AbstractTestWithProject {
 
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
-
-		assertEquals(null, hover.getHoverInfo(viewer, new Region(0, 10)));
+		@Nullable IRegion hoverRegion = hover.getHoverRegion(viewer, 0);
+		assertEquals(null, hover.getHoverInfo(viewer, hoverRegion));
 	}
 
 	@Test
@@ -122,7 +125,8 @@ public class HoverTest extends AbstractTestWithProject {
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 
-		assertEquals(null, hover.getHoverInfo(viewer, new Region(0, 10)));
+		@Nullable IRegion hoverRegion = hover.getHoverRegion(viewer, 0);
+		assertEquals(null, hover.getHoverInfo(viewer, hoverRegion));
 	}
 
 	@Test
@@ -134,7 +138,8 @@ public class HoverTest extends AbstractTestWithProject {
 		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 
-		assertEquals(null, hover.getHoverInfo(viewer, new Region(0, 10)));
+		@Nullable IRegion hoverRegion = hover.getHoverRegion(viewer, 0);
+		assertEquals(null, hover.getHoverInfo(viewer, hoverRegion));
 	}
 
 	@Test
@@ -146,7 +151,8 @@ public class HoverTest extends AbstractTestWithProject {
 		Path file = Files.createFile(tempDir.resolve("testHoverOnExternalfile.lspt"));
 		ITextViewer viewer = LSPEclipseUtils
 				.getTextViewer(IDE.openInternalEditorOnFileStore(UI.getActivePage(), EFS.getStore(file.toUri())));
-		String html = hover.getHoverInfoFuture(viewer, new Region(0, 0)).get(2, TimeUnit.SECONDS);
+		@Nullable IRegion hoverRegion = hover.getHoverRegion(viewer, 0);
+		String html = hover.getHoverInfoFuture(viewer, hoverRegion).get(2, TimeUnit.SECONDS);
 		assertTrue(html != null && html.contains("blah"));
 	}
 
@@ -159,7 +165,8 @@ public class HoverTest extends AbstractTestWithProject {
 		IFile file = TestUtils.createUniqueTestFileMultiLS(project, "HoverRange Other Text");
 		ITextViewer viewer = TestUtils.openTextViewer(file);
 
-		String hoverInfo = hover.getHoverInfoFuture(viewer, new Region(0, 10)).get(2, TimeUnit.SECONDS);
+		@Nullable IRegion hoverRegion = hover.getHoverRegion(viewer, 0);
+		String hoverInfo = hover.getHoverInfoFuture(viewer, hoverRegion).get(2, TimeUnit.SECONDS);
 		int index = hoverInfo.indexOf("HoverContent");
 		assertNotEquals(-1, index, "Hover content not found");
 		index += "HoverContent".length();
@@ -182,7 +189,8 @@ public class HoverTest extends AbstractTestWithProject {
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editorPart);
 		assertEquals(UI.getActivePart(), editorPart);
 
-		String hoverContent = hover.getHoverInfoFuture(viewer, new Region(0, 10)).get(2, TimeUnit.SECONDS);
+		@Nullable IRegion hoverRegion = hover.getHoverRegion(viewer, 0);
+		String hoverContent = hover.getHoverInfoFuture(viewer, hoverRegion).get(2, TimeUnit.SECONDS);
 
 		final var hoverManager = new LSPTextHover();
 
@@ -234,5 +242,56 @@ public class HoverTest extends AbstractTestWithProject {
 			}
 			shell.dispose();
 		}
+	}
+
+	@Test
+	public void testHoverRegionRefreshesForSameOffsetAfterCompletedRequest() throws Exception {
+		// Test for https://github.com/eclipse-lsp4e/lsp4e/issues/1514
+		// Verifies that getHoverRegion refreshes for the same offset after a completed
+		// request, instead of reusing the previous completed hover range indefinitely.
+		final var firstHover = new Hover(List.of(Either.forLeft("FirstValue")),
+				new Range(new Position(0, 0), new Position(0, 5)));
+		final var secondHover = new Hover(List.of(Either.forLeft("SecondValue")),
+				new Range(new Position(0, 6), new Position(0, 10)));
+
+		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
+		ITextViewer viewer = TestUtils.openTextViewer(file);
+
+		MockLanguageServer.INSTANCE.setHover(firstHover);
+		assertEquals(new Region(0, 5), hover.getHoverRegion(viewer, 2));
+
+		MockLanguageServer.INSTANCE.setHover(secondHover);
+		assertEquals(new Region(6, 4), hover.getHoverRegion(viewer, 2));
+	}
+
+	@Test
+	public void testHoverInfoRefreshesForSameOffsetAfterCompletedRequest() throws Exception {
+		// Test for https://github.com/eclipse-lsp4e/lsp4e/issues/1514
+		// Verifies that a second hover at the same offset recomputes the hover region
+		// and refreshes the hover content after the previous request completed.
+		final var firstHover = new Hover(List.of(Either.forLeft("FirstValue")),
+				new Range(new Position(0, 0), new Position(0, 5)));
+		final var secondHover = new Hover(List.of(Either.forLeft("SecondValue")),
+				new Range(new Position(0, 6), new Position(0, 10)));
+
+		IFile file = TestUtils.createUniqueTestFile(project, "HoverRange Other Text");
+		ITextViewer viewer = TestUtils.openTextViewer(file);
+
+		MockLanguageServer.INSTANCE.setHover(firstHover);
+		Region firstRegion = (Region) hover.getHoverRegion(viewer, 2);
+		assertEquals(new Region(0, 5), firstRegion);
+
+		String firstHtml = hover.getHoverInfoFuture(viewer, firstRegion).get(2, TimeUnit.SECONDS);
+		assertNotNull(firstHtml);
+		assertTrue(firstHtml.contains("FirstValue"));
+
+		MockLanguageServer.INSTANCE.setHover(secondHover);
+		Region secondRegion = (Region) hover.getHoverRegion(viewer, 2);
+		assertEquals(new Region(6, 4), secondRegion);
+
+		String secondHtml = hover.getHoverInfoFuture(viewer, secondRegion).get(2, TimeUnit.SECONDS);
+		assertNotNull(secondHtml);
+		assertTrue(secondHtml.contains("SecondValue"));
+		assertTrue(!secondHtml.contains("FirstValue"));
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPHoverRegion.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPHoverRegion.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.lsp4e.operations.hover;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.jface.text.Region;
+import org.eclipse.lsp4j.Hover;
+
+/**
+ * A {@link Region} which contains the hover request which was sent when
+ * creating this region.
+ */
+public class LSPHoverRegion extends Region {
+
+	private final CompletableFuture<List<Hover>> request;
+
+	public LSPHoverRegion(int offset, int length, CompletableFuture<List<Hover>> request) {
+		super(offset, length);
+		this.request = request;
+	}
+
+	public CompletableFuture<List<Hover>> getRequest() {
+		return request;
+	}
+
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/LSPTextHover.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Red Hat Inc. and others.
+ * Copyright (c) 2016, 2023, 2026 Red Hat Inc. and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -15,8 +15,6 @@
  *  Sebastian Thomschke (Vegard IT GmbH) - Prevent UI freezes through non-blocking hover rendering
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.hover;
-
-import static org.eclipse.lsp4e.internal.NullSafetyHelper.castNonNull;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -67,53 +65,58 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension, ITextHover
 
 	private static final int GET_HOVER_REGION_TIMEOUT_MS = 100;
 
-	private @Nullable IRegion lastRegion;
-	private @Nullable ITextViewer lastViewer;
 	private @Nullable CompletableFuture<List<Hover>> request;
-	private @Nullable CompletableFuture<@Nullable String> hoverInfoFuture;
 
 	@Override
 	public @Nullable String getHoverInfo(ITextViewer textViewer, IRegion hoverRegion) {
 		// Non-blocking: only return immediately available content.
-		final var hoverInfoRequest_ = this.hoverInfoFuture = getHoverInfoFuture(textViewer, hoverRegion);
-		if (hoverInfoRequest_.isDone()) {
-			try {
-				return hoverInfoRequest_.getNow(null);
-			} catch (final Exception ex) {
-				if (CancellationUtil.isRequestCancelledException(ex)) {
-					// Hover was cancelled; ignore as this is an expected fast-mouse-move scenario.
-					return null;
-				}
-				LanguageServerPlugin.logError(ex);
-			}
+		final var hoverInfoFuture = getHoverInfoFuture(textViewer, hoverRegion);
+		if (hoverInfoFuture.isDone()) {
+			return getResult(hoverInfoFuture);
 		}
 		return null;
 	}
 
 	@Override
 	public @Nullable Object getHoverInfo2(ITextViewer textViewer, IRegion hoverRegion) {
-		final var hoverInfoRequest_ = this.hoverInfoFuture = getHoverInfoFuture(textViewer, hoverRegion);
+		final var hoverInfoFuture = getHoverInfoFuture(textViewer, hoverRegion);
+		if (hoverInfoFuture.isDone()) {
+			// Result is already available, no need to load async.
+			return getResult(hoverInfoFuture);
+		}
 		final String placeholder = "<html><body>Loading…</body></html>"; //$NON-NLS-1$
-		return new AsyncHtmlHoverInput(hoverInfoRequest_, placeholder);
+		return new AsyncHtmlHoverInput(hoverInfoFuture, placeholder);
+	}
+
+	private @Nullable String getResult(CompletableFuture<@Nullable String> hoverInfoFuture) {
+		try {
+			return hoverInfoFuture.getNow(null);
+		} catch (final Exception ex) {
+			if (!CancellationUtil.isRequestCancelledException(ex)) {
+				// Hover computation failed but not due to a cancellation
+				LanguageServerPlugin.logError(ex);
+			}
+			return null;
+		}
 	}
 
 	public CompletableFuture<@Nullable String> getHoverInfoFuture(ITextViewer textViewer, IRegion hoverRegion) {
-		if (this.request == null || !textViewer.equals(this.lastViewer) || !hoverRegion.equals(this.lastRegion)) {
-			initiateHoverRequest(textViewer, hoverRegion.getOffset());
+		if (hoverRegion instanceof LSPHoverRegion region) {
+			return region.getRequest().thenApply(hoversList -> {
+				String result = hoversList.stream() //
+						.filter(Objects::nonNull) //
+						.map(LSPTextHover::getHoverString) //
+						.filter(Objects::nonNull) //
+						.collect(Collectors.joining("\n\n")) //$NON-NLS-1$
+						.trim();
+				if (!result.isEmpty()) {
+					return MarkdownUtil.renderToHtml(result);
+				} else {
+					return null;
+				}
+			});
 		}
-		return castNonNull(request).thenApply(hoversList -> {
-			String result = hoversList.stream() //
-					.filter(Objects::nonNull) //
-					.map(LSPTextHover::getHoverString) //
-					.filter(Objects::nonNull) //
-					.collect(Collectors.joining("\n\n")) //$NON-NLS-1$
-					.trim();
-			if (!result.isEmpty()) {
-				return MarkdownUtil.renderToHtml(result);
-			} else {
-				return null;
-			}
-		});
+		return CompletableFuture.completedFuture(null);
 	}
 
 	protected static @Nullable String getHoverString(Hover hover) {
@@ -133,7 +136,10 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension, ITextHover
 					// strings with language tags, e.g. without it things after <?php tag aren't
 					// displayed
 					if (markedString.getLanguage() != null && !markedString.getLanguage().isEmpty()) {
-						return String.format("```%s%n%s%n```", markedString.getLanguage(), markedString.getValue()); //$NON-NLS-1$
+						return String.format("""
+								```%s
+								%s
+								```""", markedString.getLanguage(), markedString.getValue()); //$NON-NLS-1$
 					} else {
 						return markedString.getValue();
 					}
@@ -148,20 +154,19 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension, ITextHover
 
 	@Override
 	public @Nullable IRegion getHoverRegion(ITextViewer textViewer, int offset) {
-		final var lastRegion = this.lastRegion;
-		if (this.request == null || lastRegion == null || !textViewer.equals(this.lastViewer)
-				|| offset < lastRegion.getOffset() || offset > lastRegion.getOffset() + lastRegion.getLength()) {
-			initiateHoverRequest(textViewer, offset);
-		}
-
 		final IDocument document = textViewer.getDocument();
 		if (document == null) {
 			return null;
 		}
 
+		var locRequest = initiateHoverRequest(textViewer, offset);
+		if (locRequest == null) {
+			return null;
+		}
+
 		try {
 			// Wait shortly for hover region result, fallback to heuristics if LS is laggy
-			Range range = castNonNull(this.request).get(GET_HOVER_REGION_TIMEOUT_MS, TimeUnit.MILLISECONDS).stream() //
+			Range range = locRequest.get(GET_HOVER_REGION_TIMEOUT_MS, TimeUnit.MILLISECONDS).stream() //
 					.filter(Objects::nonNull) //
 					.map(Hover::getRange) //
 					.filter(Objects::nonNull) //
@@ -171,7 +176,7 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension, ITextHover
 					LSPEclipseUtils.toOffset(range.getStart(), document));
 			int regionEndOffset = Math.min(document.getLength(),
 					LSPEclipseUtils.toOffset(range.getEnd(), document));
-			return this.lastRegion = new Region(regionStartOffset, regionEndOffset - regionStartOffset);
+			return new LSPHoverRegion(regionStartOffset, regionEndOffset - regionStartOffset, locRequest);
 		} catch (ExecutionException | BadLocationException e) {
 			if (!CancellationUtil.isRequestCancelledException(e)) {
 				LanguageServerPlugin.logError("Cannot get hover region for offset " + offset, e); //$NON-NLS-1$
@@ -182,7 +187,8 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension, ITextHover
 			// Fallback to heuristic region without blocking.
 		}
 
-		return this.lastRegion = computeHeuristicRegion(document, offset);
+		Region heuristicRegion = computeHeuristicRegion(document, offset);
+		return new LSPHoverRegion(heuristicRegion.getOffset(), heuristicRegion.getLength(), locRequest);
 	}
 
 	private static Region computeHeuristicRegion(final IDocument document, final int offset) {
@@ -202,10 +208,6 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension, ITextHover
 			request.cancel(true);
 			request = null;
 		}
-		if (hoverInfoFuture != null) {
-			hoverInfoFuture.cancel(true);
-			hoverInfoFuture = null;
-		}
 	}
 
 	/**
@@ -215,23 +217,24 @@ public class LSPTextHover implements ITextHover, ITextHoverExtension, ITextHover
 	 *            the text viewer.
 	 * @param offset
 	 *            the hovered offset.
+	 * @return the created request.
 	 */
-	private void initiateHoverRequest(ITextViewer viewer, int offset) {
+	private @Nullable CompletableFuture<List<Hover>> initiateHoverRequest(ITextViewer viewer, int offset) {
 		cancel();
 		final IDocument document = viewer.getDocument();
 		if (document == null) {
-			return;
+			return null;
 		}
-		this.lastViewer = viewer;
 		try {
 			HoverParams params = LSPEclipseUtils.toHoverParams(offset, document);
-
+			// Store request so we can cancel it when a new request is created.
 			this.request = LanguageServers.forDocument(document) //
 					.withCapability(ServerCapabilities::getHoverProvider) //
 					.collectAll(server -> server.getTextDocumentService().hover(params));
 		} catch (BadLocationException e) {
 			LanguageServerPlugin.logError(e);
 		}
+		return request;
 	}
 
 	@Override


### PR DESCRIPTION
I looked at the Eclipse Platform code and the protocol for `getHoverRegion` and `getHoverInfo2` seems to be:
```java
IRegion region = hover.getHoverRegion(viewer, offset);
// [... setup some stuff with region ...]
hover.getHoverInfo2(viewer, region);
```
Most importantly, the region returned from `getHoverRegion` is also the one passed back to `getHoverInfo2`. We can use this to return a custom Region object which holds the request sent to the LS. This way, `getHoverInfo2` can simply use that stored request instead of having to do its own bookkeeping to know if the last stored request is the correct one to use.
This also makes sure that exactly one request is sent per getHoverRegion/getHoverInfo2 cycle.

I also added another fast-path to avoid async loading, if the result is already present.

Fixes #1514