### PR TITLE
fix(tests): Stop timer thread when shutting down dispatchers

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -349,6 +349,9 @@ public class LanguageServerWrapper {
 
 		// Similarly, the error stream should also close when the input/output streams close.
 		this.errorProcessor.shutdownNow();
+
+		// Make sure the timer thread shuts down.
+		this.timer.cancel();
 	}
 
 	/**


### PR DESCRIPTION
We call `LanguageServerWrapper.stopDispatcher()` after each test to clean up the spawned executors/threads. However, we did not include the Timer instance, which would cause many leaked Threads during test execution