### PR TITLE
fix(tests): Activate part instead of calling setFocus

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatHandlerReadOnlyTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/format/FormatHandlerReadOnlyTest.java
@@ -40,13 +40,10 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.IHandlerService;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 public class FormatHandlerReadOnlyTest extends AbstractTestWithProject {
 
 	@Test
-	@DisabledOnOs(value = OS.LINUX, architectures = "aarch64", disabledReason = "Test fails consistently on Ubuntu 24.04 (ARM)")
 	public void testFormatOnReadOnlyFileAndMakeWritable() throws Exception {
 		// Mock formatting to prepend "//" at the start of each line
 		var edits = List.of( //

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/hover/HoverTest.java
@@ -187,7 +187,7 @@ public class HoverTest extends AbstractTestWithProject {
 
 		waitForAndAssertCondition(5_000, () -> LSPEclipseUtils.getTextViewer(editorPart) != null);
 		ITextViewer viewer = LSPEclipseUtils.getTextViewer(editorPart);
-		assertEquals(UI.getActivePart(), editorPart);
+		assertEquals(editorPart, UI.getActivePart());
 
 		@Nullable IRegion hoverRegion = hover.getHoverRegion(viewer, 0);
 		String hoverContent = hover.getHoverInfoFuture(viewer, hoverRegion).get(2, TimeUnit.SECONDS);
@@ -220,7 +220,7 @@ public class HoverTest extends AbstractTestWithProject {
 				@Override
 				public void completed(ProgressEvent event) {
 					browser.removeProgressListener(this);
-					assertEquals(UI.getActivePart(), editorPart);
+					assertEquals(editorPart, UI.getActivePart());
 					browser.execute("document.getElementsByTagName('a')[0].click()");
 					completed.set(true);
 				}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
@@ -80,10 +80,7 @@ public class TestUtils {
 		IWorkbenchPage page = workbenchWindow.getActivePage();
 		final var input = new FileEditorInput(file);
 
-		IEditorPart part = page.openEditor(input, "org.eclipse.ui.genericeditor.GenericEditor", false);
-		if (part != null) {
-			part.setFocus();
-		}
+		IEditorPart part = page.openEditor(input, "org.eclipse.ui.genericeditor.GenericEditor", true);
 		return part;
 	}
 
@@ -103,10 +100,7 @@ public class TestUtils {
 	public static IEditorPart openExternalFileInEditor(Path file) throws PartInitException {
 		IWorkbenchWindow workbenchWindow = UI.getActiveWindow();
 		IWorkbenchPage page = workbenchWindow.getActivePage();
-		IEditorPart part = IDE.openEditor(page, file.toUri(), "org.eclipse.ui.genericeditor.GenericEditor", false);
-		if (part != null) {
-			part.setFocus();
-		}
+		IEditorPart part = IDE.openEditor(page, file.toUri(), "org.eclipse.ui.genericeditor.GenericEditor", true);
 		return part;
 	}
 
@@ -115,8 +109,8 @@ public class TestUtils {
 		IWorkbenchPage page = workbenchWindow.getActivePage();
 		IFileStore fileStore = EFS.getLocalFileSystem().getStore(file.toUri());
 		IEditorPart part = IDE.openEditorOnFileStore(page, fileStore);
-		if (part != null) {
-			part.setFocus();
+		if (page != null && part != null) {
+			page.activate(part);
 		}
 		return part;
 	}


### PR DESCRIPTION
- `IWorkbenchPart.setFocus()` should not be called directly. Instead, the part should be activated.
- Swap arguments of assertEquals to correctly specify actual/expected
- This fixes the consistently failing tests on ubuntu-latest
 
Fixes #1485
