### PR TITLE
fix: Check content type before LSP enablement

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServersRegistry.java
@@ -473,7 +473,7 @@ public class LanguageServersRegistry {
 		final var res = new HashSet<LanguageServerDefinition>();
 		contentTypes = expandToSuperTypes(contentTypes);
 		for (ContentTypeToLanguageServerDefinition mapping : this.connections) {
-			if (mapping.isEnabled(uri) && contentTypes.contains(mapping.getKey())) {
+			if (contentTypes.contains(mapping.getKey()) && mapping.isEnabled(uri)) {
 				res.add(mapping.getValue());
 			}
 		}


### PR DESCRIPTION
This changes the order of checks when looking up available language servers.

Before, LSP4E evaluated `mapping.isEnabled(uri)` before checking whether the mapping's content type matched the file. For mappings with an `enabledWhen`, that can be expensive and may load the file as a document even when the mapping does not apply.

With this change, the content type is checked first, so `enabledWhen` is only evaluated for matching mappings.

Fixes #1551