### PR TITLE
fix: support EFS in LSPEclipseUtils.getFileName

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LSPEclipseUtils.java
@@ -433,6 +433,20 @@ public final class LSPEclipseUtils {
 	}
 
 	public static @Nullable String getFileName(URI uri) {
+		IResource resource = findResourceFor(uri);
+		if (resource != null) {
+			return resource.getName();
+		}
+
+		try {
+			String name = EFS.getStore(uri).getName();
+			// The root of a file system has an empty name; treat that like an absent file name (handled below).
+			if (!name.isEmpty()) {
+				return name;
+			}
+		} catch (CoreException e) {
+			// Not backed by an Eclipse file system; fall through to NIO handling below.
+		}
 		final java.nio.file.Path path;
 		try {
 			path = java.nio.file.Path.of(uri);


### PR DESCRIPTION
as in other places of the codebase, for example LSPEclipseUtils.getDocument(URI)